### PR TITLE
[test] Reclassify some tests between "invalid" and "malformed"

### DIFF
--- a/tests/cli/branch-hinting/branch-hinting-simple.wast
+++ b/tests/cli/branch-hinting/branch-hinting-simple.wast
@@ -60,13 +60,13 @@
   )
 )
 
-(assert_invalid
+(assert_malformed
   (module quote "(@metadata.code.branch_hint)")
   "expected valid module field")
-(assert_invalid
+(assert_malformed
   (module quote "(func (@metadata.code.branch_hint))")
   "expected a string")
-(assert_invalid
+(assert_malformed
   (module quote "(func (@metadata.code.branch_hint \"a\"))")
   "invalid value for branch hint")
 

--- a/tests/cli/code-after-end.wast
+++ b/tests/cli/code-after-end.wast
@@ -1,36 +1,36 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
-  (module
-    (func end))
+(assert_malformed
+  (module quote
+    "(func end)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end block))
+(assert_malformed
+  (module quote
+    "(func end block)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end i32.add))
+(assert_malformed
+  (module quote
+    "(func end i32.add)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end unreachable))
+(assert_malformed
+  (module quote
+    "(func end unreachable)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end br 0))
+(assert_malformed
+  (module quote
+    "(func end br 0)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end return))
+(assert_malformed
+  (module quote
+    "(func end return)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end return_call 0))
+(assert_malformed
+  (module quote
+    "(func end return_call 0)")
   "operators remaining after end of function")

--- a/tests/cli/code-after-end.wast
+++ b/tests/cli/code-after-end.wast
@@ -5,9 +5,21 @@
     "(func end)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\05\01\03\00\0b\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end block)")
+  "operators remaining after end of function")
+
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\07\01\05\00\0b\02\40\0b")
   "operators remaining after end of function")
 
 (assert_malformed
@@ -15,9 +27,21 @@
     "(func end i32.add)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\06\01\04\00\0b\6a\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end unreachable)")
+  "operators remaining after end of function")
+
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\06\01\04\00\0b\00\0b")
   "operators remaining after end of function")
 
 (assert_malformed
@@ -25,12 +49,30 @@
     "(func end br 0)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\07\01\05\00\0b\0c\00\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end return)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\06\01\04\00\0b\0f\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end return_call 0)")
+  "operators remaining after end of function")
+
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\07\01\05\00\0b\12\00\0b")
   "operators remaining after end of function")

--- a/tests/cli/component-model/adapt.wast
+++ b/tests/cli/component-model/adapt.wast
@@ -246,7 +246,7 @@
   )
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(core module $m (func (export \"\")))"
     "(core instance $i (instantiate $m))"
@@ -279,7 +279,7 @@
   )
   "not a function type")
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(import \"a\" (func $f))"
     "(func (export \"foo\") (canon lift (core func $f)))"

--- a/tests/cli/component-model/definedtypes.wast
+++ b/tests/cli/component-model/definedtypes.wast
@@ -44,21 +44,21 @@
   (type $A22d (result $A9 (error $A10a)))
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type $t (variant (case $x \"x\" string (refines $x))))"
   )
   "variant case cannot refine itself"
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type $t (variant (case \"x\" (refines $y)) (case $y \"y\" string)))"
   )
   "unknown variant case"
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type $t string)"
     "(type $v (variant (case \"x\" $t (refines $z))))"
@@ -83,7 +83,7 @@
   "variant case can only refine a previously defined case"
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type $t string)"
     "(type $v (variant (case $x \"x\" $t) (case $x \"y\" $t)))"

--- a/tests/cli/component-model/export-introduces-alias.wast
+++ b/tests/cli/component-model/export-introduces-alias.wast
@@ -28,7 +28,7 @@
   ))
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type (instance"
       "(type $t u8)"

--- a/tests/cli/component-model/func.wast
+++ b/tests/cli/component-model/func.wast
@@ -123,7 +123,7 @@
   "canonical option `realloc` is required"
 )
 
-(assert_invalid
+(assert_malformed
   (component binary
     "\00asm" "\0d\00\01\00"   ;; component header
     "\07\05"          ;; component type section, 5 bytes
@@ -134,7 +134,7 @@
   )
   "invalid leading byte (0x1) for number of results")
 
-(assert_invalid
+(assert_malformed
   (component binary
     "\00asm" "\0d\00\01\00"   ;; component header
     "\07\05"          ;; component type section, 5 bytes

--- a/tests/cli/component-model/import.wast
+++ b/tests/cli/component-model/import.wast
@@ -69,19 +69,19 @@
   )
   "duplicate import name `:a`")
 
-(assert_malformed
-  (component quote
-    "(import \"a\" (func))"
-    "(import \"a\" (func))"
+(assert_invalid
+  (component
+    (import "a" (func))
+    (import "a" (func))
   )
   "import name `a` conflicts with previous name `a`")
 
-(assert_malformed
-  (component quote
-    "(type (component"
-      "(import \"a\" (func))"
-      "(import \"a\" (func))"
-    "))"
+(assert_invalid
+  (component
+    (type (component
+      (import "a" (func))
+      (import "a" (func))
+    ))
   )
   "import name `a` conflicts with previous name `a`")
 

--- a/tests/cli/component-model/instance-type.wast
+++ b/tests/cli/component-model/instance-type.wast
@@ -200,7 +200,7 @@
     )))
   "core type index 0 is not a module type")
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(type $t (func))"
     "(type (instance (export \"a\" (core module (type $t)))))"

--- a/tests/cli/component-model/start.wast
+++ b/tests/cli/component-model/start.wast
@@ -46,15 +46,15 @@
   (export "b" (value $a))
 )
 
-(assert_invalid
-  (component
-    (import "a" (func $f))
-    (start $f)
-    (start $f)
+(assert_malformed
+  (component quote
+    "(import \"a\" (func $f)) "
+    "(start $f) "
+    "(start $f) "
   )
-  "cannot have more than one start")
+  "multiple start sections found")
 
-(assert_invalid
+(assert_malformed
   (component binary
     "\00asm" "\0d\00\01\00"   ;; component header
 
@@ -76,7 +76,7 @@
   )
   "start function results size is out of bounds")
 
-(assert_invalid
+(assert_malformed
   (component binary
     "\00asm" "\0d\00\01\00"   ;; component header
 

--- a/tests/cli/component-model/types.wast
+++ b/tests/cli/component-model/types.wast
@@ -120,7 +120,7 @@
   )
   "import name `a` conflicts with previous name `A`")
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(component $c (core type $t (module (alias outer $c $t (type)))))"
   )
@@ -141,7 +141,7 @@
   ))
 )
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(component $c (type $t (component (alias outer $c $t (type)))))"
   )
@@ -193,7 +193,7 @@
   )
   "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`")
 
-(assert_invalid
+(assert_malformed
   (component quote
     "(component $c (type $t (instance (alias outer $c $t (type)))))"
   )

--- a/tests/cli/component-model/wrong-order.wast
+++ b/tests/cli/component-model/wrong-order.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm\01\00\00\00"
 

--- a/tests/cli/data-count-big.wast
+++ b/tests/cli/data-count-big.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm\01\00\00\00"
 

--- a/tests/cli/folding/branch-hinting-simple.wast
+++ b/tests/cli/folding/branch-hinting-simple.wast
@@ -60,13 +60,13 @@
   )
 )
 
-(assert_invalid
+(assert_malformed
   (module quote "(@metadata.code.branch_hint)")
   "expected valid module field")
-(assert_invalid
+(assert_malformed
   (module quote "(func (@metadata.code.branch_hint))")
   "expected a string")
-(assert_invalid
+(assert_malformed
   (module quote "(func (@metadata.code.branch_hint \"a\"))")
   "invalid value for branch hint")
 

--- a/tests/cli/gc/gc-subtypes-invalid.wast
+++ b/tests/cli/gc/gc-subtypes-invalid.wast
@@ -138,9 +138,9 @@
   )
   "type index out of bounds"
 )
-(assert_invalid
-  (module
-    (type (struct (field $vt (mut i32)) (field $vt (mut i64))))
+(assert_malformed
+  (module quote
+    "(type (struct (field $vt (mut i32)) (field $vt (mut i64))))"
   )
   "duplicate identifier"
 )

--- a/tests/cli/gc/invalid.wast
+++ b/tests/cli/gc/invalid.wast
@@ -135,7 +135,7 @@
   )
   "array.new_data can only create arrays with numeric and vector elements")
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"     ;; module header
 

--- a/tests/cli/if-else-parsing.wast
+++ b/tests/cli/if-else-parsing.wast
@@ -15,29 +15,29 @@
     (if (i32.const 1) (i32.eqz) (then nop))
   )
 )
-(assert_invalid
+(assert_malformed
   (module quote
     "(func (if))"
   )
   "no `then`")
 
-(assert_invalid
+(assert_malformed
   (module quote
     "(func (if (else)))"
   )
   "no `then`")
 
-(assert_invalid
+(assert_malformed
   (module quote
     "(func (if nop (else)))"
   )
   "expected `(`")
-(assert_invalid
+(assert_malformed
   (module quote
     "(func (if (nop) (else)))"
   )
   "no `then`")
-(assert_invalid
+(assert_malformed
   (module quote
     "(func (if (nop) nop (then)))"
   )

--- a/tests/cli/invalid/bad_br_table.wast
+++ b/tests/cli/invalid/bad_br_table.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/crash-0000.wast
+++ b/tests/cli/invalid/crash-0000.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast
+++ b/tests/cli/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast
+++ b/tests/cli/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
 
     "\00\61\73\6d" ;; header

--- a/tests/cli/invalid/empty-br-table.wast
+++ b/tests/cli/invalid/empty-br-table.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/func.wast
+++ b/tests/cli/invalid/func.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00" ;; magic header
 
@@ -21,7 +21,7 @@
   )
   "operators remaining after end of function")
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00" ;; magic header
 
@@ -42,7 +42,7 @@
   )
   "operators remaining after end of function")
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00" ;; magic header
 
@@ -63,27 +63,27 @@
   )
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end unreachable))
+(assert_malformed
+  (module quote
+    "(func end unreachable)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end return))
+(assert_malformed
+  (module quote
+    "(func end return)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end br 0))
+(assert_malformed
+  (module quote
+    "(func end br 0)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end br 100000))
+(assert_malformed
+  (module quote
+    "(func end br 100000)")
   "operators remaining after end of function")
 
-(assert_invalid
-  (module
-    (func end br_table 0))
+(assert_malformed
+  (module quote
+    "(func end br_table 0)")
   "operators remaining after end of function")

--- a/tests/cli/invalid/func.wast
+++ b/tests/cli/invalid/func.wast
@@ -68,9 +68,21 @@
     "(func end unreachable)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\06\01\04\00\0b\00\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end return)")
+  "operators remaining after end of function")
+
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\06\01\04\00\0b\0f\0b")
   "operators remaining after end of function")
 
 (assert_malformed
@@ -78,12 +90,30 @@
     "(func end br 0)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\07\01\05\00\0b\0c\00\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end br 100000)")
   "operators remaining after end of function")
 
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\09\01\07\00\0b\0c\a0\8d\06\0b")
+  "operators remaining after end of function")
+
 (assert_malformed
   (module quote
     "(func end br_table 0)")
+  "operators remaining after end of function")
+
+;; binary version of previous test
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00\01\04\01\60\00\00\03\02\01\00\0a\08\01\06\00\0b\0e\00\00\0b")
   "operators remaining after end of function")

--- a/tests/cli/invalid/invalid-ty2.wast
+++ b/tests/cli/invalid/invalid-ty2.wast
@@ -1,7 +1,13 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
+(assert_malformed
+  (module quote
+    "(func block (type 2))"
+  )
+  "type index out of bounds")
+
 (assert_invalid
   (module
-    (func block (type 2))
+    (func block (type 2) end)
   )
   "type index out of bounds")

--- a/tests/cli/invalid/issue139.wast
+++ b/tests/cli/invalid/issue139.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/issue192.wast
+++ b/tests/cli/invalid/issue192.wast
@@ -1,64 +1,64 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
-  (module
-    (type (;0;) (func (param i32)))
-    (type (;1;) (func (param i32) (result i32)))
-    (type (;2;) (func (param i32 i32)))
-    (type (;3;) (func))
-    (func (;0;) (type 3))
-    (func (;1;) (type 0) (param i32))
-    (func (;2;) (type 1) (param i32) (result i32)
-      i32.const 1
-    )
-    (func (;3;) (type 1) (param i32) (result i32)
-      i32.const 2
-    )
-    (func (;4;) (type 2) (param i32 i32)
-      local.get 0
-      unreachable
-      unreachable
-      unreachable
-      unreachable
-      unreachable
-      unreachable
-      unreachable
-      block (param i32)  ;; label = @1
-        unreachable
-        drop
-
-    )
-    (func (;5;) (type 3)
-      (local i32)
-      unreachable
-      unreachable
-      i32.mul
-      i32.popcnt
-      i32.div_u
-      i32.sub
-      i32.popcnt
-      i32.div_u
-      i32.sub
-      local.tee 0
-      global.set 0
-      local.get 0
-      i32.const 8
-      i32.add
-      i32.const 1024
-      call 4
-      local.get 0
-      i32.const 8
-      i32.add
-      i32.const 25166864
-      unreachable
-      call 2097156
-      call_indirect (type 0)
-      i32.const 16
-      i32.add
-      global.set 0
-    )
-    (func (;6;) (type 3)
-      i64.clz
-    )
+(assert_malformed
+  (module quote
+"    (type (;0;) (func (param i32)))"
+"    (type (;1;) (func (param i32) (result i32)))"
+"    (type (;2;) (func (param i32 i32)))"
+"    (type (;3;) (func))"
+"    (func (;0;) (type 3))"
+"    (func (;1;) (type 0) (param i32))"
+"    (func (;2;) (type 1) (param i32) (result i32)"
+"      i32.const 1"
+"    )"
+"    (func (;3;) (type 1) (param i32) (result i32)"
+"      i32.const 2"
+"    )"
+"    (func (;4;) (type 2) (param i32 i32)"
+"      local.get 0"
+"      unreachable"
+"      unreachable"
+"      unreachable"
+"      unreachable"
+"      unreachable"
+"      unreachable"
+"      unreachable"
+"      block (param i32)"
+"        unreachable"
+"        drop"
+""
+"    )"
+"    (func (;5;) (type 3)"
+"      (local i32)"
+"      unreachable"
+"      unreachable"
+"      i32.mul"
+"      i32.popcnt"
+"      i32.div_u"
+"      i32.sub"
+"      i32.popcnt"
+"      i32.div_u"
+"      i32.sub"
+"      local.tee 0"
+"      global.set 0"
+"      local.get 0"
+"      i32.const 8"
+"      i32.add"
+"      i32.const 1024"
+"      call 4"
+"      local.get 0"
+"      i32.const 8"
+"      i32.add"
+"      i32.const 25166864"
+"      unreachable"
+"      call 2097156"
+"      call_indirect (type 0)"
+"      i32.const 16"
+"      i32.add"
+"      global.set 0"
+"    )"
+"    (func (;6;) (type 3)"
+"      i64.clz"
+"    )"
   )
   "control frames remain at end of function")

--- a/tests/cli/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast
+++ b/tests/cli/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d" ;; header
     "\01\00\00\00" ;; version

--- a/tests/cli/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast
+++ b/tests/cli/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00\61\73\6d"    ;; header
     "\01\00\00\00"    ;; version

--- a/tests/cli/missing-features/component-not-enabled.wast
+++ b/tests/cli/missing-features/component-not-enabled.wast
@@ -3,6 +3,6 @@
 (assert_invalid
   (module binary
     "\00asm"
-    "\0a\00\01\00"
+    "\0d\00\01\00"
     )
-  "unknown binary version and encoding combination: 0xa and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation")
+  "unknown binary version and encoding combination: 0xd and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation")

--- a/tests/cli/missing-features/custom-page-sizes.wast
+++ b/tests/cli/missing-features/custom-page-sizes.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots % -f mvp
 
-(assert_invalid
+(assert_malformed
   (module
     (memory 0 (pagesize 1))
   )

--- a/tests/cli/missing-features/missing-exceptions.wast
+++ b/tests/cli/missing-features/missing-exceptions.wast
@@ -1,13 +1,13 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots % -f wasm1
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
     "\0d\01\00"
     )
   "exceptions proposal not enabled")
 
-(assert_invalid
+(assert_malformed
   (module
     (import "" "" (tag))
     )

--- a/tests/cli/missing-features/shared-everything-threads-globals.wast
+++ b/tests/cli/missing-features/shared-everything-threads-globals.wast
@@ -1,14 +1,14 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots % -f mvp
 
-(assert_invalid
-  (module
-    (global (shared i32) (i32.const 0))
+(assert_malformed
+  (module quote
+    "(global (shared i32) (i32.const 0))"
   )
   "shared globals require the shared-everything-threads proposal")
 
-(assert_invalid
-  (module
-    (global (import "spectest" "global_i64") (shared mut i64))
+(assert_malformed
+  (module quote
+    "(global (import \"spectest\" \"global_i64\") (shared mut i64))"
   )
   "shared globals require the shared-everything-threads proposal")
 

--- a/tests/cli/missing-features/shared-everything-threads-tables.wast
+++ b/tests/cli/missing-features/shared-everything-threads-tables.wast
@@ -1,7 +1,7 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots % -f mvp
 
-(assert_invalid
-  (module
-    (table shared 1 funcref)
+(assert_malformed
+  (module quote
+    "(table shared 1 funcref)"
   )
   "shared tables require the shared-everything-threads proposal")

--- a/tests/cli/producers.wast
+++ b/tests/cli/producers.wast
@@ -24,7 +24,7 @@
   (@producers (sdk "foo" "bar"))
 )
 
-(assert_invalid
+(assert_malformed
   (module quote "(@producers (foo))")
   "unexpected token")
 

--- a/tests/cli/table-funcref.wast
+++ b/tests/cli/table-funcref.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_malformed
+(assert_invalid
   (module
     (type (func (result i32)))
     (func $main (result i32)

--- a/tests/cli/tail-call-after-end.wast
+++ b/tests/cli/tail-call-after-end.wast
@@ -1,6 +1,6 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots %
 
-(assert_invalid
+(assert_malformed
   (module
     (func
       end

--- a/tests/snapshots/cli/branch-hinting/branch-hinting-simple.wast.json
+++ b/tests/snapshots/cli/branch-hinting/branch-hinting-simple.wast.json
@@ -20,21 +20,21 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 64,
       "filename": "branch-hinting-simple.3.wat",
       "module_type": "text",
       "text": "expected valid module field"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 67,
       "filename": "branch-hinting-simple.4.wat",
       "module_type": "text",
       "text": "expected a string"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 70,
       "filename": "branch-hinting-simple.5.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/code-after-end.wast.json
+++ b/tests/snapshots/cli/code-after-end.wast.json
@@ -2,52 +2,52 @@
   "source_filename": "tests/cli/code-after-end.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
-      "filename": "code-after-end.0.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.0.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 9,
-      "filename": "code-after-end.1.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.1.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 14,
-      "filename": "code-after-end.2.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.2.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 19,
-      "filename": "code-after-end.3.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.3.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 24,
-      "filename": "code-after-end.4.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.4.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 29,
-      "filename": "code-after-end.5.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.5.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 34,
-      "filename": "code-after-end.6.wasm",
-      "module_type": "binary",
+      "filename": "code-after-end.6.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     }
   ]

--- a/tests/snapshots/cli/code-after-end.wast.json
+++ b/tests/snapshots/cli/code-after-end.wast.json
@@ -10,44 +10,93 @@
     },
     {
       "type": "assert_malformed",
-      "line": 9,
-      "filename": "code-after-end.1.wat",
-      "module_type": "text",
+      "line": 10,
+      "filename": "code-after-end.1.wasm",
+      "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 14,
+      "line": 15,
       "filename": "code-after-end.2.wat",
       "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 19,
-      "filename": "code-after-end.3.wat",
-      "module_type": "text",
+      "line": 21,
+      "filename": "code-after-end.3.wasm",
+      "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 24,
+      "line": 26,
       "filename": "code-after-end.4.wat",
       "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 29,
-      "filename": "code-after-end.5.wat",
+      "line": 32,
+      "filename": "code-after-end.5.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 37,
+      "filename": "code-after-end.6.wat",
       "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 34,
-      "filename": "code-after-end.6.wat",
+      "line": 43,
+      "filename": "code-after-end.7.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 48,
+      "filename": "code-after-end.8.wat",
       "module_type": "text",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 54,
+      "filename": "code-after-end.9.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 59,
+      "filename": "code-after-end.10.wat",
+      "module_type": "text",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 65,
+      "filename": "code-after-end.11.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 70,
+      "filename": "code-after-end.12.wat",
+      "module_type": "text",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 76,
+      "filename": "code-after-end.13.wasm",
+      "module_type": "binary",
       "text": "operators remaining after end of function"
     }
   ]

--- a/tests/snapshots/cli/component-model/adapt.wast.json
+++ b/tests/snapshots/cli/component-model/adapt.wast.json
@@ -98,7 +98,7 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 250,
       "filename": "adapt.14.wat",
       "module_type": "text",
@@ -126,7 +126,7 @@
       "text": "not a function type"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 283,
       "filename": "adapt.18.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/component-model/definedtypes.wast.json
+++ b/tests/snapshots/cli/component-model/definedtypes.wast.json
@@ -9,21 +9,21 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 48,
       "filename": "definedtypes.1.wat",
       "module_type": "text",
       "text": "variant case cannot refine itself"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 55,
       "filename": "definedtypes.2.wat",
       "module_type": "text",
       "text": "unknown variant case"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 62,
       "filename": "definedtypes.3.wat",
       "module_type": "text",
@@ -44,7 +44,7 @@
       "text": "variant case can only refine a previously defined case"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 87,
       "filename": "definedtypes.6.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/component-model/export-introduces-alias.wast.json
+++ b/tests/snapshots/cli/component-model/export-introduces-alias.wast.json
@@ -20,7 +20,7 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 32,
       "filename": "export-introduces-alias.3.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/component-model/func.wast.json
+++ b/tests/snapshots/cli/component-model/func.wast.json
@@ -67,14 +67,14 @@
       "text": "canonical option `realloc` is required"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 127,
       "filename": "func.10.wasm",
       "module_type": "binary",
       "text": "invalid leading byte (0x1) for number of results"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 138,
       "filename": "func.11.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/component-model/import.wast.json
+++ b/tests/snapshots/cli/component-model/import.wast.json
@@ -57,17 +57,17 @@
       "text": "duplicate import name `:a`"
     },
     {
-      "type": "assert_malformed",
+      "type": "assert_invalid",
       "line": 73,
-      "filename": "import.8.wat",
-      "module_type": "text",
+      "filename": "import.8.wasm",
+      "module_type": "binary",
       "text": "import name `a` conflicts with previous name `a`"
     },
     {
-      "type": "assert_malformed",
+      "type": "assert_invalid",
       "line": 80,
-      "filename": "import.9.wat",
-      "module_type": "text",
+      "filename": "import.9.wasm",
+      "module_type": "binary",
       "text": "import name `a` conflicts with previous name `a`"
     },
     {

--- a/tests/snapshots/cli/component-model/instance-type.wast.json
+++ b/tests/snapshots/cli/component-model/instance-type.wast.json
@@ -53,7 +53,7 @@
       "text": "core type index 0 is not a module type"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 204,
       "filename": "instance-type.8.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/component-model/start.wast.json
+++ b/tests/snapshots/cli/component-model/start.wast.json
@@ -42,21 +42,21 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 50,
-      "filename": "start.6.wasm",
-      "module_type": "binary",
-      "text": "cannot have more than one start"
+      "filename": "start.6.wat",
+      "module_type": "text",
+      "text": "multiple start sections found"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 58,
       "filename": "start.7.wasm",
       "module_type": "binary",
       "text": "start function results size is out of bounds"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 80,
       "filename": "start.8.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/component-model/types.wast.json
+++ b/tests/snapshots/cli/component-model/types.wast.json
@@ -107,7 +107,7 @@
       "text": "import name `a` conflicts with previous name `A`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 124,
       "filename": "types.15.wat",
       "module_type": "text",
@@ -128,7 +128,7 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 145,
       "filename": "types.18.wat",
       "module_type": "text",
@@ -170,7 +170,7 @@
       "text": "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 197,
       "filename": "types.24.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/component-model/wrong-order.wast.json
+++ b/tests/snapshots/cli/component-model/wrong-order.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/component-model/wrong-order.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "wrong-order.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/data-count-big.wast.json
+++ b/tests/snapshots/cli/data-count-big.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/data-count-big.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "data-count-big.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/folding/branch-hinting-simple.wast.json
+++ b/tests/snapshots/cli/folding/branch-hinting-simple.wast.json
@@ -20,21 +20,21 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 64,
       "filename": "branch-hinting-simple.3.wat",
       "module_type": "text",
       "text": "expected valid module field"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 67,
       "filename": "branch-hinting-simple.4.wat",
       "module_type": "text",
       "text": "expected a string"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 70,
       "filename": "branch-hinting-simple.5.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/gc/invalid.wast.json
+++ b/tests/snapshots/cli/gc/invalid.wast.json
@@ -107,7 +107,7 @@
       "text": "array.new_data can only create arrays with numeric and vector elements"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 139,
       "filename": "invalid.15.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/if-else-parsing.wast.json
+++ b/tests/snapshots/cli/if-else-parsing.wast.json
@@ -8,35 +8,35 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 19,
       "filename": "if-else-parsing.1.wat",
       "module_type": "text",
       "text": "no `then`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 25,
       "filename": "if-else-parsing.2.wat",
       "module_type": "text",
       "text": "no `then`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 31,
       "filename": "if-else-parsing.3.wat",
       "module_type": "text",
       "text": "expected `(`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 36,
       "filename": "if-else-parsing.4.wat",
       "module_type": "text",
       "text": "no `then`"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 41,
       "filename": "if-else-parsing.5.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/invalid/bad_br_table.wast.json
+++ b/tests/snapshots/cli/invalid/bad_br_table.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/bad_br_table.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "bad_br_table.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/crash-0000.wast.json
+++ b/tests/snapshots/cli/invalid/crash-0000.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/crash-0000.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "crash-0000.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast.json
+++ b/tests/snapshots/cli/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "crash-1eefc5597ae263919265239b0dba6a033eb80384.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast.json
+++ b/tests/snapshots/cli/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "crash-9001106adb60c9b427167d0606700fd16d5b3a82.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/empty-br-table.wast.json
+++ b/tests/snapshots/cli/invalid/empty-br-table.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/empty-br-table.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "empty-br-table.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/func.wast.json
+++ b/tests/snapshots/cli/invalid/func.wast.json
@@ -31,30 +31,65 @@
     },
     {
       "type": "assert_malformed",
-      "line": 72,
-      "filename": "func.4.wat",
-      "module_type": "text",
+      "line": 73,
+      "filename": "func.4.wasm",
+      "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 77,
+      "line": 78,
       "filename": "func.5.wat",
       "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 82,
-      "filename": "func.6.wat",
+      "line": 84,
+      "filename": "func.6.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 89,
+      "filename": "func.7.wat",
       "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
       "type": "assert_malformed",
-      "line": 87,
-      "filename": "func.7.wat",
+      "line": 95,
+      "filename": "func.8.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 100,
+      "filename": "func.9.wat",
       "module_type": "text",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 106,
+      "filename": "func.10.wasm",
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 111,
+      "filename": "func.11.wat",
+      "module_type": "text",
+      "text": "operators remaining after end of function"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 117,
+      "filename": "func.12.wasm",
+      "module_type": "binary",
       "text": "operators remaining after end of function"
     }
   ]

--- a/tests/snapshots/cli/invalid/func.wast.json
+++ b/tests/snapshots/cli/invalid/func.wast.json
@@ -2,59 +2,59 @@
   "source_filename": "tests/cli/invalid/func.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "func.0.wasm",
       "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 25,
       "filename": "func.1.wasm",
       "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 46,
       "filename": "func.2.wasm",
       "module_type": "binary",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 67,
-      "filename": "func.3.wasm",
-      "module_type": "binary",
+      "filename": "func.3.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 72,
-      "filename": "func.4.wasm",
-      "module_type": "binary",
+      "filename": "func.4.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 77,
-      "filename": "func.5.wasm",
-      "module_type": "binary",
+      "filename": "func.5.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 82,
-      "filename": "func.6.wasm",
-      "module_type": "binary",
+      "filename": "func.6.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 87,
-      "filename": "func.7.wasm",
-      "module_type": "binary",
+      "filename": "func.7.wat",
+      "module_type": "text",
       "text": "operators remaining after end of function"
     }
   ]

--- a/tests/snapshots/cli/invalid/invalid-ty2.wast.json
+++ b/tests/snapshots/cli/invalid/invalid-ty2.wast.json
@@ -2,9 +2,16 @@
   "source_filename": "tests/cli/invalid/invalid-ty2.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
-      "filename": "invalid-ty2.0.wasm",
+      "filename": "invalid-ty2.0.wat",
+      "module_type": "text",
+      "text": "type index out of bounds"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "invalid-ty2.1.wasm",
       "module_type": "binary",
       "text": "type index out of bounds"
     }

--- a/tests/snapshots/cli/invalid/issue139.wast.json
+++ b/tests/snapshots/cli/invalid/issue139.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/issue139.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "issue139.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/issue192.wast.json
+++ b/tests/snapshots/cli/invalid/issue192.wast.json
@@ -2,10 +2,10 @@
   "source_filename": "tests/cli/invalid/issue192.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
-      "filename": "issue192.0.wasm",
-      "module_type": "binary",
+      "filename": "issue192.0.wat",
+      "module_type": "text",
       "text": "control frames remain at end of function"
     }
   ]

--- a/tests/snapshots/cli/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast.json
+++ b/tests/snapshots/cli/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast.json
+++ b/tests/snapshots/cli/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/missing-features/component-not-enabled.wast.json
+++ b/tests/snapshots/cli/missing-features/component-not-enabled.wast.json
@@ -6,7 +6,7 @@
       "line": 4,
       "filename": "component-not-enabled.0.wasm",
       "module_type": "binary",
-      "text": "unknown binary version and encoding combination: 0xa and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation"
+      "text": "unknown binary version and encoding combination: 0xd and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation"
     }
   ]
 }

--- a/tests/snapshots/cli/missing-features/custom-page-sizes.wast.json
+++ b/tests/snapshots/cli/missing-features/custom-page-sizes.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/missing-features/custom-page-sizes.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "custom-page-sizes.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/missing-features/missing-exceptions.wast.json
+++ b/tests/snapshots/cli/missing-features/missing-exceptions.wast.json
@@ -2,14 +2,14 @@
   "source_filename": "tests/cli/missing-features/missing-exceptions.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "missing-exceptions.0.wasm",
       "module_type": "binary",
       "text": "exceptions proposal not enabled"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 11,
       "filename": "missing-exceptions.1.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/missing-features/shared-everything-threads-globals.wast.json
+++ b/tests/snapshots/cli/missing-features/shared-everything-threads-globals.wast.json
@@ -2,17 +2,17 @@
   "source_filename": "tests/cli/missing-features/shared-everything-threads-globals.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
-      "filename": "shared-everything-threads-globals.0.wasm",
-      "module_type": "binary",
+      "filename": "shared-everything-threads-globals.0.wat",
+      "module_type": "text",
       "text": "shared globals require the shared-everything-threads proposal"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 10,
-      "filename": "shared-everything-threads-globals.1.wasm",
-      "module_type": "binary",
+      "filename": "shared-everything-threads-globals.1.wat",
+      "module_type": "text",
       "text": "shared globals require the shared-everything-threads proposal"
     },
     {

--- a/tests/snapshots/cli/missing-features/shared-everything-threads-tables.wast.json
+++ b/tests/snapshots/cli/missing-features/shared-everything-threads-tables.wast.json
@@ -2,10 +2,10 @@
   "source_filename": "tests/cli/missing-features/shared-everything-threads-tables.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
-      "filename": "shared-everything-threads-tables.0.wasm",
-      "module_type": "binary",
+      "filename": "shared-everything-threads-tables.0.wat",
+      "module_type": "text",
       "text": "shared tables require the shared-everything-threads proposal"
     }
   ]

--- a/tests/snapshots/cli/producers.wast.json
+++ b/tests/snapshots/cli/producers.wast.json
@@ -26,7 +26,7 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 28,
       "filename": "producers.4.wat",
       "module_type": "text",

--- a/tests/snapshots/cli/table-funcref.wast.json
+++ b/tests/snapshots/cli/table-funcref.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/table-funcref.wast",
   "commands": [
     {
-      "type": "assert_malformed",
+      "type": "assert_invalid",
       "line": 4,
       "filename": "table-funcref.0.wasm",
       "module_type": "binary",

--- a/tests/snapshots/cli/tail-call-after-end.wast.json
+++ b/tests/snapshots/cli/tail-call-after-end.wast.json
@@ -2,7 +2,7 @@
   "source_filename": "tests/cli/tail-call-after-end.wast",
   "commands": [
     {
-      "type": "assert_invalid",
+      "type": "assert_malformed",
       "line": 4,
       "filename": "tail-call-after-end.0.wasm",
       "module_type": "binary",


### PR DESCRIPTION
This PR is preparation for an invalid/malformed separation in the wast subcommand and for wasm-tools to be able to roundtrip any non-malformed module or component (the overall patchset is at https://github.com/keithw/wasm-tools/tree/malformed-invalid-separation).

It reclassifies some of the local tests between "malformed" (a violation of the [binary-format](https://webassembly.github.io/spec/core/binary/index.html) or [text-format](https://webassembly.github.io/spec/core/text/index.html) syntaxes) vs. ["invalid"](https://webassembly.github.io/spec/core/valid/index.html). I think these tests now match the spec more closely, although I haven't checked them all in the reference interpreter because the error messages aren't exactly the same and the reference interpreter doesn't make it easy to ignore them.

This doesn't have any effect yet because `wasm-tools wast` currently handles `assert_malformed` and `assert_invalid` the same way, but it will make a difference once they are separated.
