### PR TITLE
wast: detect an invalid type reference case

### DIFF
--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -748,7 +748,18 @@ impl<'a> TypeReference<'a> for FunctionType<'a> {
         };
         let (params, results) = match cx.type_info.get(n as usize) {
             Some(TypeInfo::Func { params, results }) => (params, results),
-            _ => return Ok(()),
+            Some(_) => {
+                return Err(Error::new(
+                    idx.span(),
+                    format!("invalid type: not a function type"),
+                ))
+            }
+            _ => {
+                return Err(Error::new(
+                    idx.span(),
+                    format!("unknown type: type index out of bounds"),
+                ))
+            }
         };
 
         // Here we need to check that the inline type listed (ourselves) matches


### PR DESCRIPTION
The spec testsuite has a module like this (https://github.com/WebAssembly/spec/blob/9f5356d46/test/core/func.wast#L447-L457) with a malformed type use:

```wasm
(func $f (result f64) (f64.const 0))  ;; adds implicit type definition
(func $g (param i32))                 ;; reuses explicit type definition
(func $h (result f64) (f64.const 1))  ;; reuses implicit type definition
(type $t (func (param i32)))

(func (type 2) (param i32))           ;; does not exist
```

This is a text-format error (`type 2` and `param i32` disagree, because `type 2` doesn't exist) that right now is only being caught by the validator. This PR makes `wast` catch the error.