### PR TITLE
Fix `ReorderCustomSectionMutator` in `wasm-mutate`

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -304,10 +304,16 @@ impl<'a> ModuleInfo<'a> {
         assert!(dest_idx < self.raw_sections.len());
         assert_ne!(src_idx, dest_idx);
         let mut sections = self.raw_sections.clone();
-        sections.swap(src_idx, dest_idx);
+        let to_move = sections.remove(src_idx);
         let mut module = wasm_encoder::Module::new();
-        for section in sections {
-            module.section(&section);
+        for (i, section) in sections.iter().enumerate() {
+            if i == dest_idx {
+                module.section(&to_move);
+            }
+            module.section(section);
+        }
+        if sections.len() == dest_idx {
+            module.section(&to_move);
         }
         module
     }

--- a/crates/wasm-mutate/src/mutators/custom.rs
+++ b/crates/wasm-mutate/src/mutators/custom.rs
@@ -253,4 +253,25 @@ mod tests {
             "#,
         )
     }
+
+    #[test]
+    fn test_reorder_custom_section2() {
+        crate::mutators::match_mutation(
+            r#"
+            (module
+                (func (export "x"))
+                (@custom "name2" "data")
+                (@custom "name3" "data")
+            )
+            "#,
+            ReorderCustomSectionMutator,
+            r#"
+            (module
+                (@custom "name3" "data")
+                (func (export "x"))
+                (@custom "name2" "data")
+            )
+            "#,
+        )
+    }
 }


### PR DESCRIPTION
This commit fixes an issue with the reordering sections helper which used `<[_]>::swap` which isn't appropriate in this context because that reorders the destination section instead of just moving the section in question, possibly producing an invalid module.