### PR TITLE
Require `[..]l.l` is not present with `l`

### DIFF
--- a/tests/cli/component-model-async/names.wast
+++ b/tests/cli/component-model-async/names.wast
@@ -72,3 +72,17 @@
     (import "[async static]r.f" (func))
     (import "[static]r.f" (func)))
   "conflicts with previous name")
+
+(assert_invalid
+  (component
+    (import "a" (type $a (sub resource)))
+    (import "[async method]a.a" (func (param "self" (borrow $a))))
+  )
+  "import name `[async method]a.a` conflicts with previous name `a`")
+
+(assert_invalid
+  (component
+    (import "a" (type $a (sub resource)))
+    (import "[async static]a.a" (func))
+  )
+  "import name `[async static]a.a` conflicts with previous name `a`")

--- a/tests/cli/component-model/naming.wast
+++ b/tests/cli/component-model/naming.wast
@@ -109,3 +109,22 @@
   (instance (import "a:b/c"))
   (instance (import "a1:b1/c"))
 )
+
+(component
+  (import "a" (type $a (sub resource)))
+  (import "[constructor]a" (func (result (own $a))))
+)
+
+(assert_invalid
+  (component
+    (import "a" (type $a (sub resource)))
+    (import "[method]a.a" (func (param "self" (borrow $a))))
+  )
+  "import name `[method]a.a` conflicts with previous name `a`")
+
+(assert_invalid
+  (component
+    (import "a" (type $a (sub resource)))
+    (import "[static]a.a" (func))
+  )
+  "import name `[static]a.a` conflicts with previous name `a`")

--- a/tests/snapshots/cli/component-model-async/names.wast.json
+++ b/tests/snapshots/cli/component-model-async/names.wast.json
@@ -69,6 +69,20 @@
       "filename": "names.9.wasm",
       "module_type": "binary",
       "text": "conflicts with previous name"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 77,
+      "filename": "names.10.wasm",
+      "module_type": "binary",
+      "text": "import name `[async method]a.a` conflicts with previous name `a`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 84,
+      "filename": "names.11.wasm",
+      "module_type": "binary",
+      "text": "import name `[async static]a.a` conflicts with previous name `a`"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model/naming.wast.json
+++ b/tests/snapshots/cli/component-model/naming.wast.json
@@ -110,6 +110,26 @@
       "line": 108,
       "filename": "naming.15.wasm",
       "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 113,
+      "filename": "naming.16.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 119,
+      "filename": "naming.17.wasm",
+      "module_type": "binary",
+      "text": "import name `[method]a.a` conflicts with previous name `a`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 126,
+      "filename": "naming.18.wasm",
+      "module_type": "binary",
+      "text": "import name `[static]a.a` conflicts with previous name `a`"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model/naming.wast/16.print
+++ b/tests/snapshots/cli/component-model/naming.wast/16.print
@@ -1,0 +1,6 @@
+(component
+  (import "a" (type $a (;0;) (sub resource)))
+  (type (;1;) (own $a))
+  (type (;2;) (func (result 1)))
+  (import "[constructor]a" (func (;0;) (type 2)))
+)


### PR DESCRIPTION
This updates validation of component model names to account for WebAssembly/component-model#494. This technically affects all existing users as well but it's hoped that it won't actually hit any cases of this in the wild.