### PR TITLE
Update spec test suite

### DIFF
--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -499,6 +499,14 @@ impl ModuleState {
                 $self.validate_gc("ref.i31")?;
                 $self.validator().visit_ref_i31()
             }};
+            (@visit $self:ident visit_extern_convert_any) => {{
+                $self.validate_gc("extern.convert_any")?;
+                $self.validator().visit_extern_convert_any()
+            }};
+            (@visit $self:ident visit_any_convert_extern) => {{
+                $self.validate_gc("any.convert_extern")?;
+                $self.validator().visit_any_convert_extern()
+            }};
             (@visit $self:ident visit_ref_i31_shared) => {{
                 $self.validate_shared_everything_threads("ref.i31_shared")?;
                 $self.validator().visit_ref_i31_shared()

--- a/tests/snapshots/testsuite/proposals/wasm-3.0/extern.wast.json
+++ b/tests/snapshots/testsuite/proposals/wasm-3.0/extern.wast.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "action",
-      "line": 34,
+      "line": 37,
       "action": {
         "type": "invoke",
         "field": "init",
@@ -23,7 +23,7 @@
     },
     {
       "type": "assert_return",
-      "line": 36,
+      "line": 39,
       "action": {
         "type": "invoke",
         "field": "internalize",
@@ -43,7 +43,7 @@
     },
     {
       "type": "assert_return",
-      "line": 37,
+      "line": 40,
       "action": {
         "type": "invoke",
         "field": "internalize",
@@ -63,7 +63,7 @@
     },
     {
       "type": "assert_return",
-      "line": 39,
+      "line": 42,
       "action": {
         "type": "invoke",
         "field": "externalize",
@@ -83,7 +83,7 @@
     },
     {
       "type": "assert_return",
-      "line": 40,
+      "line": 43,
       "action": {
         "type": "invoke",
         "field": "externalize",
@@ -103,66 +103,6 @@
     },
     {
       "type": "assert_return",
-      "line": 42,
-      "action": {
-        "type": "invoke",
-        "field": "externalize-i",
-        "args": [
-          {
-            "type": "i32",
-            "value": "0"
-          }
-        ]
-      },
-      "expected": [
-        {
-          "type": "externref",
-          "value": "null"
-        }
-      ]
-    },
-    {
-      "type": "assert_return",
-      "line": 43,
-      "action": {
-        "type": "invoke",
-        "field": "externalize-i",
-        "args": [
-          {
-            "type": "i32",
-            "value": "1"
-          }
-        ]
-      },
-      "expected": [
-        {
-          "type": "externref",
-          "value": "null"
-        }
-      ]
-    },
-    {
-      "type": "assert_return",
-      "line": 44,
-      "action": {
-        "type": "invoke",
-        "field": "externalize-i",
-        "args": [
-          {
-            "type": "i32",
-            "value": "2"
-          }
-        ]
-      },
-      "expected": [
-        {
-          "type": "externref",
-          "value": "null"
-        }
-      ]
-    },
-    {
-      "type": "assert_return",
       "line": 45,
       "action": {
         "type": "invoke",
@@ -170,7 +110,7 @@
         "args": [
           {
             "type": "i32",
-            "value": "3"
+            "value": "0"
           }
         ]
       },
@@ -190,7 +130,7 @@
         "args": [
           {
             "type": "i32",
-            "value": "4"
+            "value": "1"
           }
         ]
       },
@@ -210,7 +150,27 @@
         "args": [
           {
             "type": "i32",
-            "value": "5"
+            "value": "2"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "externref",
+          "value": "null"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 48,
+      "action": {
+        "type": "invoke",
+        "field": "externalize-i",
+        "args": [
+          {
+            "type": "i32",
+            "value": "3"
           }
         ]
       },
@@ -224,6 +184,46 @@
     {
       "type": "assert_return",
       "line": 49,
+      "action": {
+        "type": "invoke",
+        "field": "externalize-i",
+        "args": [
+          {
+            "type": "i32",
+            "value": "4"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "externref",
+          "value": "null"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 50,
+      "action": {
+        "type": "invoke",
+        "field": "externalize-i",
+        "args": [
+          {
+            "type": "i32",
+            "value": "5"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "externref",
+          "value": "null"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 52,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",
@@ -243,7 +243,7 @@
     },
     {
       "type": "assert_return",
-      "line": 50,
+      "line": 53,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",
@@ -262,7 +262,7 @@
     },
     {
       "type": "assert_return",
-      "line": 51,
+      "line": 54,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",
@@ -281,7 +281,7 @@
     },
     {
       "type": "assert_return",
-      "line": 52,
+      "line": 55,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",
@@ -300,7 +300,7 @@
     },
     {
       "type": "assert_return",
-      "line": 53,
+      "line": 56,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",
@@ -320,7 +320,7 @@
     },
     {
       "type": "assert_return",
-      "line": 54,
+      "line": 57,
       "action": {
         "type": "invoke",
         "field": "externalize-ii",

--- a/tests/snapshots/testsuite/proposals/wasm-3.0/extern.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/wasm-3.0/extern.wast/0.print
@@ -8,6 +8,8 @@
   (type (;6;) (func (param i32) (result externref)))
   (type (;7;) (func (param i32) (result anyref)))
   (table (;0;) 10 anyref)
+  (global (;0;) externref ref.null any extern.convert_any)
+  (global (;1;) anyref ref.null extern any.convert_extern)
   (export "init" (func 1))
   (export "internalize" (func 2))
   (export "externalize" (func 3))


### PR DESCRIPTION
Add `extern.convert_any` and `any.convert_extern` to allowed constant expression instructions.