### PR TITLE
Add a `serde` crate feature to `wasm-smith`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,6 +275,7 @@ jobs:
       - run: cargo check --no-default-features -p wasm-smith --features component-model
       - run: cargo check --no-default-features -p wasm-smith --features wasmparser
       - run: cargo check --no-default-features -p wasm-smith --features wasmparser,component-model
+      - run: cargo check --no-default-features -p wasm-smith --features serde
       - run: cargo check --no-default-features -p wasm-metadata
       - run: cargo check --no-default-features -p wasm-metadata --features serde
       - run: cargo check --no-default-features -p wasm-metadata --features oci

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -44,6 +44,7 @@ wat = { workspace = true }
 libfuzzer-sys = { workspace = true }
 
 [features]
-_internal_cli = ["clap", "flagset/serde", "serde", "serde_derive", "wasmparser", "wat"]
+_internal_cli = ["clap", "serde", "dep:wasmparser", "dep:wat"]
 wasmparser = ['dep:wasmparser', 'wasm-encoder/wasmparser']
 component-model = ['wasm-encoder/component-model']
+serde = ['dep:serde', 'dep:serde_derive', 'flagset/serde', 'dep:wat']

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -188,6 +188,7 @@ macro_rules! define_config {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl TryFrom<InternalOptionalConfig> for Config {
             type Error = anyhow::Error;
             fn try_from(config: InternalOptionalConfig) -> anyhow::Result<Config> {

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -1,6 +1,7 @@
 //! Configuring the shape of generated Wasm modules.
 
 use crate::InstructionKinds;
+use anyhow::bail;
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 macro_rules! define_config {
@@ -113,10 +114,11 @@ macro_rules! define_config {
             }
         }
 
-        #[cfg(feature = "_internal_cli")]
         #[doc(hidden)]
-        #[derive(Clone, Debug, Default, clap::Parser, serde_derive::Deserialize)]
-        #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+        #[derive(Clone, Debug, Default)]
+        #[cfg_attr(feature = "clap", derive(clap::Parser))]
+        #[cfg_attr(feature = "serde", derive(serde_derive::Deserialize, serde_derive::Serialize))]
+        #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case", deny_unknown_fields))]
         pub struct InternalOptionalConfig {
             /// The imports that may be used when generating the module.
             ///
@@ -173,7 +175,6 @@ macro_rules! define_config {
             )*
         }
 
-        #[cfg(feature = "_internal_cli")]
         impl InternalOptionalConfig {
             pub fn or(self, other: Self) -> Self {
                 Self {
@@ -187,7 +188,6 @@ macro_rules! define_config {
             }
         }
 
-        #[cfg(feature = "_internal_cli")]
         impl TryFrom<InternalOptionalConfig> for Config {
             type Error = anyhow::Error;
             fn try_from(config: InternalOptionalConfig) -> anyhow::Result<Config> {
@@ -211,6 +211,23 @@ macro_rules! define_config {
                     $(
                         $field: config.$field.unwrap_or(default.$field),
                     )*
+                })
+            }
+        }
+
+        impl TryFrom<&Config> for InternalOptionalConfig {
+            type Error = anyhow::Error;
+            fn try_from(config: &Config) -> anyhow::Result<InternalOptionalConfig> {
+                if config.available_imports.is_some() {
+                    bail!("cannot serialize configuration with `available_imports`");
+                }
+                if config.exports.is_some() {
+                    bail!("cannot serialize configuration with `exports`");
+                }
+                Ok(InternalOptionalConfig {
+                    available_imports: None,
+                    exports: None,
+                    $( $field: Some(config.$field.clone()), )*
                 })
             }
         }
@@ -654,7 +671,10 @@ define_config! {
 ///
 /// The default is `(90, 9, 1)`.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde_derive", derive(serde_derive::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
 pub struct MemoryOffsetChoices(pub u32, pub u32, pub u32);
 
 impl Default for MemoryOffsetChoices {
@@ -663,7 +683,6 @@ impl Default for MemoryOffsetChoices {
     }
 }
 
-#[cfg(feature = "_internal_cli")]
 impl std::str::FromStr for MemoryOffsetChoices {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -863,5 +882,35 @@ impl Config {
         features.set(WasmFeatures::WIDE_ARITHMETIC, self.wide_arithmetic_enabled);
 
         features
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        match Config::try_from(InternalOptionalConfig::deserialize(deserializer)?) {
+            Ok(config) => Ok(config),
+            Err(e) => Err(D::Error::custom(e)),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Config {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+
+        match InternalOptionalConfig::try_from(self) {
+            Ok(result) => result.serialize(serializer),
+            Err(e) => Err(S::Error::custom(e)),
+        }
     }
 }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -3000,7 +3000,10 @@ impl EntityType {
 /// assert!(kinds.contains(InstructionKind::Memory));
 /// ```
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde_derive", derive(serde_derive::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
 pub struct InstructionKinds(pub(crate) FlagSet<InstructionKind>);
 
 impl InstructionKinds {

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -68,7 +68,7 @@ pub use config::{Config, MemoryOffsetChoices};
 use std::{collections::HashSet, fmt::Write, str};
 use wasm_encoder::MemoryType;
 
-#[cfg(feature = "_internal_cli")]
+#[doc(hidden)]
 pub use config::InternalOptionalConfig;
 
 pub(crate) fn page_size(mem: &MemoryType) -> u32 {


### PR DESCRIPTION
Use this to enable `Deserialize` and `Serialize` directly on the `Config` type. This was something I found useful for "record the dna/config" in Wasmtime fuzzing to reproduce a module generation in just wasm-tools alone.