### PR TITLE
For `assert_invalid`, assert modules all parse

### DIFF
--- a/ci/generate-spec-tests.rs
+++ b/ci/generate-spec-tests.rs
@@ -44,7 +44,8 @@ fn copy_test(src: &Path, dst: &Path) {
     contents.push_str(";;      --assert default \\\n");
 
     // Allow certain assert_malformed tests to be interpreted as assert_invalid
-    if src.iter().any(|p| p == "binary.wast") || src.iter().any(|p| p == "global.wast") {
+    if src.ends_with("binary.wast") || src.ends_with("global.wast") || src.ends_with("select.wast")
+    {
         contents.push_str(";;      --assert permissive \\\n");
     }
 

--- a/src/bin/wasm-tools/wast.rs
+++ b/src/bin/wasm-tools/wast.rs
@@ -214,8 +214,8 @@ impl Opts {
                 if let Err(e) = parse_binary_wasm(parser, &bytes) {
                     self.assert_error_matches(test, &format!("{e:?}"), message)?;
 
-                    // make sure validator also rejects module (not necessarily
-                    // with same error)
+                    // Make sure validator also rejects the module (not necessarily
+                    // with same error).
                     if self.test_wasm_valid(test, &bytes).is_ok() {
                         bail!("validator thought malformed example was valid")
                     }

--- a/tests/cli/spec/proposals/function-references/select.wast
+++ b/tests/cli/spec/proposals/function-references/select.wast
@@ -1,5 +1,6 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm2,function-references,tail-call \

--- a/tests/cli/spec/proposals/gc/select.wast
+++ b/tests/cli/spec/proposals/gc/select.wast
@@ -1,5 +1,6 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm2,function-references,gc,tail-call \

--- a/tests/cli/spec/proposals/wasm-3.0/select.wast
+++ b/tests/cli/spec/proposals/wasm-3.0/select.wast
@@ -1,5 +1,6 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm3 \

--- a/tests/cli/spec/select.wast
+++ b/tests/cli/spec/select.wast
@@ -1,5 +1,6 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm2 \


### PR DESCRIPTION
Sort of the inverse of `assert_malformed`, but assert that invalid modules all parse successfully and just fail validation.