### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -1189,7 +1189,7 @@ pub use _for_each_operator_impl as for_each_operator;
 ///     }
 /// }
 /// # // to get this example to compile another macro is used here to define
-/// # // visit methods for all mvp oeprators.
+/// # // visit methods for all mvp operators.
 /// # macro_rules! visit_mvp {
 /// #     ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident ($($ann:tt)*))*) => {
 /// #         $(

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -440,7 +440,7 @@ impl Validator {
             // they are using the same validation context, even after resetting.
             id: _,
 
-            // Don't mess with `types`, we specifically want to reuse canonicalizations.
+            // Don't mess with `types`, we specifically want to reuse canonicalization.
             types: _,
 
             // Also leave features as they are. While this is perhaps not

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -2820,7 +2820,7 @@ impl ComponentState {
         //    component X" since in such a situation the type of all
         //    instantiations would be the same, which they aren't.
         //
-        //    This sort of subtelty comes up quite frequently for resources.
+        //    This sort of subtlety comes up quite frequently for resources.
         //    This file contains references to `imported_resources` and
         //    `defined_resources` for example which refer to the formal
         //    nature of components and their abstract variables. Specifically

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -46,7 +46,7 @@ pub trait TypeIdentifier: core::fmt::Debug + Copy + Eq + Sized + 'static {
 
 /// A trait shared by all types within a `Types`.
 ///
-/// This is the data that can be retreived by indexing with the associated
+/// This is the data that can be retrieved by indexing with the associated
 /// [`TypeIdentifier`].
 pub trait TypeData: core::fmt::Debug {
     /// The identifier for this type data.


### PR DESCRIPTION


This PR fixes several typos in documentation and comments:
- `oeprators` → `operators` in `lib.rs`
- `canonicalizations` → `canonicalization` in `validator.rs`
- `subtelty` → `subtlety` in `validator/component.rs`
- `retreived` → `retrieved` in `validator/types.rs`
