### PR TITLE
feat(wasm-encoder, wasmparser): replace `f32` / `f64` with `Ieee32` / `Ieee64`

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -294,6 +294,76 @@ impl Encode for Function {
     }
 }
 
+/// An IEEE binary32 immediate floating point value, represented as a u32
+/// containing the bit pattern.
+///
+/// All bit patterns are allowed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Ieee32(pub(crate) u32);
+
+impl Ieee32 {
+    /// Gets the underlying bits of the 32-bit float.
+    pub fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<f32> for Ieee32 {
+    fn from(value: f32) -> Self {
+        Ieee32 {
+            0: u32::from_le_bytes(value.to_le_bytes()),
+        }
+    }
+}
+
+impl From<Ieee32> for f32 {
+    fn from(bits: Ieee32) -> f32 {
+        f32::from_bits(bits.bits())
+    }
+}
+
+impl Encode for Ieee32 {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        let bits = self.bits();
+        sink.extend(bits.to_le_bytes())
+    }
+}
+
+/// An IEEE binary64 immediate floating point value, represented as a u64
+/// containing the bit pattern.
+///
+/// All bit patterns are allowed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Ieee64(pub(crate) u64);
+
+impl Ieee64 {
+    /// Gets the underlying bits of the 64-bit float.
+    pub fn bits(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<f64> for Ieee64 {
+    fn from(value: f64) -> Self {
+        Ieee64 {
+            0: u64::from_le_bytes(value.to_le_bytes()),
+        }
+    }
+}
+
+impl From<Ieee64> for f64 {
+    fn from(bits: Ieee64) -> f64 {
+        f64::from_bits(bits.bits())
+    }
+}
+
+impl Encode for Ieee64 {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        let bits = self.bits();
+        sink.extend(bits.to_le_bytes())
+    }
+}
+
 /// The immediate for a memory instruction.
 #[derive(Clone, Copy, Debug)]
 pub struct MemArg {
@@ -471,8 +541,8 @@ pub enum Instruction<'a> {
     // Numeric instructions.
     I32Const(i32),
     I64Const(i64),
-    F32Const(f32),
-    F64Const(f64),
+    F32Const(Ieee32),
+    F64Const(Ieee64),
     I32Eqz,
     I32Eq,
     I32Ne,
@@ -2202,12 +2272,12 @@ impl ConstExpr {
     }
 
     /// Create a constant expression containing a single `f32.const` instruction.
-    pub fn f32_const(value: f32) -> Self {
+    pub fn f32_const(value: Ieee32) -> Self {
         Self::new(|insn| insn.f32_const(value))
     }
 
     /// Create a constant expression containing a single `f64.const` instruction.
-    pub fn f64_const(value: f64) -> Self {
+    pub fn f64_const(value: Ieee64) -> Self {
         Self::new(|insn| insn.f64_const(value))
     }
 
@@ -2242,12 +2312,12 @@ impl ConstExpr {
     }
 
     /// Add a `f32.const` instruction to this constant expression.
-    pub fn with_f32_const(self, value: f32) -> Self {
+    pub fn with_f32_const(self, value: Ieee32) -> Self {
         self.with(|insn| insn.f32_const(value))
     }
 
     /// Add a `f64.const` instruction to this constant expression.
-    pub fn with_f64_const(self, value: f64) -> Self {
+    pub fn with_f64_const(self, value: Ieee64) -> Self {
         self.with(|insn| insn.f64_const(value))
     }
 

--- a/crates/wasm-encoder/src/core/dump.rs
+++ b/crates/wasm-encoder/src/core/dump.rs
@@ -1,4 +1,4 @@
-use crate::{CustomSection, Encode, Section};
+use crate::{CustomSection, Encode, Ieee32, Ieee64, Section};
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec;
@@ -305,9 +305,9 @@ pub enum CoreDumpValue {
     /// An i64 value
     I64(i64),
     /// An f32 value
-    F32(f32),
+    F32(Ieee32),
     /// An f64 value
-    F64(f64),
+    F64(Ieee64),
 }
 
 impl Encode for CoreDumpValue {

--- a/crates/wasm-encoder/src/core/instructions.rs
+++ b/crates/wasm-encoder/src/core/instructions.rs
@@ -1,8 +1,8 @@
 #[allow(unused_imports)]
 use crate::Instruction;
 use crate::{
-    encode_vec, BlockType, Catch, Encode, Handle, HeapType, Lane, MemArg, Ordering, RefType,
-    ValType,
+    encode_vec, BlockType, Catch, Encode, Handle, HeapType, Ieee32, Ieee64, Lane, MemArg, Ordering,
+    RefType, ValType,
 };
 use alloc::vec::Vec;
 
@@ -505,17 +505,17 @@ impl<'a> InstructionSink<'a> {
     }
 
     /// Encode [`Instruction::F32Const`].
-    pub fn f32_const(&mut self, x: f32) -> &mut Self {
+    pub fn f32_const(&mut self, x: Ieee32) -> &mut Self {
         self.sink.push(0x43);
-        let x = x.to_bits();
+        let x = x.bits();
         self.sink.extend(x.to_le_bytes().iter().copied());
         self
     }
 
     /// Encode [`Instruction::F64Const`].
-    pub fn f64_const(&mut self, x: f64) -> &mut Self {
+    pub fn f64_const(&mut self, x: Ieee64) -> &mut Self {
         self.sink.push(0x44);
-        let x = x.to_bits();
+        let x = x.bits();
         self.sink.extend(x.to_le_bytes().iter().copied());
         self
     }

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -162,20 +162,6 @@ impl Encode for i64 {
     }
 }
 
-impl Encode for f32 {
-    fn encode(&self, sink: &mut Vec<u8>) {
-        let bits = self.to_bits();
-        sink.extend(bits.to_le_bytes())
-    }
-}
-
-impl Encode for f64 {
-    fn encode(&self, sink: &mut Vec<u8>) {
-        let bits = self.to_bits();
-        sink.extend(bits.to_le_bytes())
-    }
-}
-
 fn encode_vec<T, V>(elements: V, sink: &mut Vec<u8>)
 where
     T: Encode,

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -173,6 +173,14 @@ pub trait Reencode {
         utils::memory_type(self, memory_ty)
     }
 
+    fn ieee32_arg(&mut self, arg: wasmparser::Ieee32) -> crate::Ieee32 {
+        utils::ieee32_arg(self, arg)
+    }
+
+    fn ieee64_arg(&mut self, arg: wasmparser::Ieee64) -> crate::Ieee64 {
+        utils::ieee64_arg(self, arg)
+    }
+
     fn mem_arg(&mut self, arg: wasmparser::MemArg) -> crate::MemArg {
         utils::mem_arg(self, arg)
     }
@@ -883,6 +891,20 @@ pub mod utils {
 
     pub fn memory_index<T: ?Sized + Reencode>(_reencoder: &mut T, memory: u32) -> u32 {
         memory
+    }
+
+    pub fn ieee32_arg<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
+        arg: wasmparser::Ieee32,
+    ) -> crate::Ieee32 {
+        crate::Ieee32(arg.bits())
+    }
+
+    pub fn ieee64_arg<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
+        arg: wasmparser::Ieee64,
+    ) -> crate::Ieee64 {
+        crate::Ieee64(arg.bits())
     }
 
     pub fn mem_arg<T: ?Sized + Reencode>(
@@ -1649,8 +1671,8 @@ pub mod utils {
             (build TypedSelectMulti $arg:ident) => (Instruction::TypedSelectMulti(Cow::from($arg)));
             (build I32Const $arg:ident) => (Instruction::I32Const($arg));
             (build I64Const $arg:ident) => (Instruction::I64Const($arg));
-            (build F32Const $arg:ident) => (Instruction::F32Const(f32::from_bits($arg.bits())));
-            (build F64Const $arg:ident) => (Instruction::F64Const(f64::from_bits($arg.bits())));
+            (build F32Const $arg:ident) => (Instruction::F32Const($arg.into()));
+            (build F64Const $arg:ident) => (Instruction::F64Const($arg.into()));
             (build V128Const $arg:ident) => (Instruction::V128Const($arg.i128()));
             (build TryTable $table:ident) => (Instruction::TryTable(reencoder.block_type($table.ty)?, {
                 $table.catches.into_iter().map(|c| reencoder.catch(c)).collect::<Vec<_>>().into()
@@ -1805,6 +1827,18 @@ pub mod utils {
             ret.append(map_index(naming.index), &name_map(naming.names, |i| i)?);
         }
         Ok(ret)
+    }
+}
+
+impl From<wasmparser::Ieee32> for crate::Ieee32 {
+    fn from(arg: wasmparser::Ieee32) -> Self {
+        RoundtripReencoder.ieee32_arg(arg)
+    }
+}
+
+impl From<wasmparser::Ieee64> for crate::Ieee64 {
+    fn from(arg: wasmparser::Ieee64) -> Self {
+        RoundtripReencoder.ieee64_arg(arg)
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/add_function.rs
+++ b/crates/wasm-mutate/src/mutators/add_function.rs
@@ -53,10 +53,10 @@ impl Mutator for AddFunctionMutator {
                     func.instructions().i64_const(0);
                 }
                 PrimitiveTypeInfo::F32 => {
-                    func.instructions().f32_const(0.0);
+                    func.instructions().f32_const(0.0.into());
                 }
                 PrimitiveTypeInfo::F64 => {
-                    func.instructions().f64_const(0.0);
+                    func.instructions().f64_const(0.0.into());
                 }
                 PrimitiveTypeInfo::V128 => {
                     func.instructions().v128_const(0);

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -117,8 +117,8 @@ impl<'cfg, 'wasm> Reencode for InitTranslator<'cfg, 'wasm> {
             T::I32 if should_zero => CE::i32_const(0),
             T::I64 if should_zero => CE::i64_const(0),
             T::V128 if should_zero => CE::v128_const(0),
-            T::F32 if should_zero => CE::f32_const(0.0),
-            T::F64 if should_zero => CE::f64_const(0.0),
+            T::F32 if should_zero => CE::f32_const(0.0.into()),
+            T::F64 if should_zero => CE::f64_const(0.0.into()),
             T::I32 => CE::i32_const(if let O::I32Const { value } = op {
                 let range = if value < 0 { value..0 } else { 0..value };
                 self.config.rng().gen_range(range)
@@ -137,14 +137,14 @@ impl<'cfg, 'wasm> Reencode for InitTranslator<'cfg, 'wasm> {
                 self.config.rng().r#gen()
             }),
             T::F32 => CE::f32_const(if let O::F32Const { value } = op {
-                f32::from_bits(value.bits()) / 2.0
+                (f32::from_bits(value.bits()) / 2.0).into()
             } else {
-                f32::from_bits(self.config.rng().r#gen())
+                f32::from_bits(self.config.rng().r#gen()).into()
             }),
             T::F64 => CE::f64_const(if let O::F64Const { value } = op {
-                f64::from_bits(value.bits()) / 2.0
+                (f64::from_bits(value.bits()) / 2.0).into()
             } else {
-                f64::from_bits(self.config.rng().r#gen())
+                f64::from_bits(self.config.rng().r#gen()).into()
             }),
             T::FuncRef => CE::ref_null(wasm_encoder::HeapType::FUNC),
             T::ExternRef => CE::ref_null(wasm_encoder::HeapType::EXTERN),

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -316,10 +316,10 @@ impl PeepholeMutator {
                                             (ConstExpr::i64_const(0), ValType::I64)
                                         }
                                         PrimitiveTypeInfo::F32 => {
-                                            (ConstExpr::f32_const(0.0), ValType::F32)
+                                            (ConstExpr::f32_const(0.0.into()), ValType::F32)
                                         }
                                         PrimitiveTypeInfo::F64 => {
-                                            (ConstExpr::f64_const(0.0), ValType::F64)
+                                            (ConstExpr::f64_const(0.0.into()), ValType::F64)
                                         }
                                         PrimitiveTypeInfo::V128 => {
                                             (ConstExpr::v128_const(0), ValType::V128)

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -116,8 +116,8 @@ pub fn expr2wasm(
                     Lang::I64Load32S(memarg, _) => insn.i64_load32_s(memarg.into()),
                     Lang::RandI32 => insn.i32_const(config.rng().r#gen()),
                     Lang::RandI64 => insn.i64_const(config.rng().r#gen()),
-                    Lang::RandF32 => insn.f32_const(f32::from_bits(config.rng().r#gen())),
-                    Lang::RandF64 => insn.f64_const(f64::from_bits(config.rng().r#gen())),
+                    Lang::RandF32 => insn.f32_const(f32::from_bits(config.rng().r#gen()).into()),
+                    Lang::RandF64 => insn.f64_const(f64::from_bits(config.rng().r#gen()).into()),
                     Lang::Undef => {
                         // Do nothing
                         insn
@@ -164,8 +164,8 @@ pub fn expr2wasm(
                     }
                     Lang::I32(v) => insn.i32_const(*v),
                     Lang::I64(v) => insn.i64_const(*v),
-                    Lang::F32(v) => insn.f32_const(v.to_f32()),
-                    Lang::F64(v) => insn.f64_const(v.to_f64()),
+                    Lang::F32(v) => insn.f32_const(v.to_f32().into()),
+                    Lang::F64(v) => insn.f64_const(v.to_f64().into()),
                     Lang::V128(v) => insn.v128_const(*v),
                     Lang::I32Add(_) => insn.i32_add(),
                     Lang::I64Add(_) => insn.i64_add(),

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -52,10 +52,10 @@ impl Mutator for SnipMutator {
                                 f.instructions().i64_const(0);
                             }
                             PrimitiveTypeInfo::F32 => {
-                                f.instructions().f32_const(0.0);
+                                f.instructions().f32_const(0.0.into());
                             }
                             PrimitiveTypeInfo::F64 => {
-                                f.instructions().f64_const(0.0);
+                                f.instructions().f64_const(0.0.into());
                             }
                             PrimitiveTypeInfo::V128 => {
                                 f.instructions().v128_const(0);

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1745,8 +1745,12 @@ impl Module {
                     choices.push(Box::new(arbitrary_extended_const));
                 }
             }
-            ValType::F32 => choices.push(Box::new(|u, _| Ok(ConstExpr::f32_const(u.arbitrary()?)))),
-            ValType::F64 => choices.push(Box::new(|u, _| Ok(ConstExpr::f64_const(u.arbitrary()?)))),
+            ValType::F32 => choices.push(Box::new(|u, _| {
+                Ok(ConstExpr::f32_const(u.arbitrary::<f32>()?.into()))
+            })),
+            ValType::F64 => choices.push(Box::new(|u, _| {
+                Ok(ConstExpr::f64_const(u.arbitrary::<f64>()?.into()))
+            })),
             ValType::V128 => {
                 choices.push(Box::new(|u, _| Ok(ConstExpr::v128_const(u.arbitrary()?))))
             }
@@ -2612,14 +2616,14 @@ impl Module {
                 u.arbitrary()?
             })),
             ValType::F32 => Ok(Instruction::F32Const(if u.arbitrary()? {
-                f32::from_bits(*u.choose(&self.interesting_values32)?)
+                f32::from_bits(*u.choose(&self.interesting_values32)?).into()
             } else {
-                u.arbitrary()?
+                u.arbitrary::<f32>()?.into()
             })),
             ValType::F64 => Ok(Instruction::F64Const(if u.arbitrary()? {
-                f64::from_bits(*u.choose(&self.interesting_values64)?)
+                f64::from_bits(*u.choose(&self.interesting_values64)?).into()
             } else {
-                u.arbitrary()?
+                u.arbitrary::<f64>()?.into()
             })),
             ValType::V128 => Ok(Instruction::V128Const(if u.arbitrary()? {
                 let upper = (*u.choose(&self.interesting_values64)? as i128) << 64;

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -1379,8 +1379,8 @@ impl CodeBuilder<'_> {
         const CANON_64BIT_NAN: u64 =
             0b0111111111111000000000000000000000000000000000000000000000000000;
         ins.push(match ty {
-            Float::F32 => Instruction::F32Const(f32::from_bits(CANON_32BIT_NAN)),
-            Float::F64 => Instruction::F64Const(f64::from_bits(CANON_64BIT_NAN)),
+            Float::F32 => Instruction::F32Const(f32::from_bits(CANON_32BIT_NAN).into()),
+            Float::F64 => Instruction::F64Const(f64::from_bits(CANON_64BIT_NAN).into()),
             Float::F32x4 => {
                 let nan = CANON_32BIT_NAN as i128;
                 let nan = nan | (nan << 32) | (nan << 64) | (nan << 96);

--- a/crates/wasm-smith/src/core/code_builder/no_traps.rs
+++ b/crates/wasm-smith/src/core/code_builder/no_traps.rs
@@ -402,8 +402,8 @@ fn dummy_value_inst<'a>(ty: ValType) -> Instruction<'a> {
     match ty {
         ValType::I32 => Instruction::I32Const(0),
         ValType::I64 => Instruction::I64Const(0),
-        ValType::F32 => Instruction::F32Const(0.0),
-        ValType::F64 => Instruction::F64Const(0.0),
+        ValType::F32 => Instruction::F32Const(0.0.into()),
+        ValType::F64 => Instruction::F64Const(0.0.into()),
         ValType::V128 => Instruction::V128Const(0),
         ValType::Ref(ty) => {
             assert!(ty.nullable);
@@ -466,14 +466,14 @@ fn min_input_const_for_trunc<'a>(inst: &Instruction) -> Instruction<'a> {
     // This is the minimum float value that is representable as as i32
     let min_f32_as_i32 = -2_147_483_500f32;
     match inst {
-        Instruction::I32TruncF32S => Instruction::F32Const(min_f32_as_i32),
-        Instruction::I32TruncF32U => Instruction::F32Const(0.0),
-        Instruction::I64TruncF32S => Instruction::F32Const(min_f32),
-        Instruction::I64TruncF32U => Instruction::F32Const(0.0),
-        Instruction::I32TruncF64S => Instruction::F64Const(i32::MIN as f64),
-        Instruction::I32TruncF64U => Instruction::F64Const(0.0),
-        Instruction::I64TruncF64S => Instruction::F64Const(min_f64),
-        Instruction::I64TruncF64U => Instruction::F64Const(0.0),
+        Instruction::I32TruncF32S => Instruction::F32Const(min_f32_as_i32.into()),
+        Instruction::I32TruncF32U => Instruction::F32Const(0.0.into()),
+        Instruction::I64TruncF32S => Instruction::F32Const(min_f32.into()),
+        Instruction::I64TruncF32U => Instruction::F32Const(0.0.into()),
+        Instruction::I32TruncF64S => Instruction::F64Const((i32::MIN as f64).into()),
+        Instruction::I32TruncF64U => Instruction::F64Const(0.0.into()),
+        Instruction::I64TruncF64S => Instruction::F64Const(min_f64.into()),
+        Instruction::I64TruncF64U => Instruction::F64Const(0.0.into()),
         _ => panic!("not a trunc instruction"),
     }
 }
@@ -487,16 +487,16 @@ fn max_input_const_for_trunc<'a>(inst: &Instruction) -> Instruction<'a> {
     let max_f32_as_i32 = 2_147_483_500f32;
     match inst {
         Instruction::I32TruncF32S | Instruction::I32TruncF32U => {
-            Instruction::F32Const(max_f32_as_i32)
+            Instruction::F32Const(max_f32_as_i32.into())
         }
         Instruction::I64TruncF32S | Instruction::I64TruncF32U => {
-            Instruction::F32Const(max_f32_as_i64)
+            Instruction::F32Const(max_f32_as_i64.into())
         }
         Instruction::I32TruncF64S | Instruction::I32TruncF64U => {
-            Instruction::F64Const(i32::MAX as f64)
+            Instruction::F64Const((i32::MAX as f64).into())
         }
         Instruction::I64TruncF64S | Instruction::I64TruncF64U => {
-            Instruction::F64Const(max_f64_as_i64)
+            Instruction::F64Const(max_f64_as_i64.into())
         }
         _ => panic!("not a trunc instruction"),
     }
@@ -624,16 +624,16 @@ fn flt_gt_inst<'a>(ty: ValType) -> Instruction<'a> {
 
 fn flt_inf_const_inst<'a>(ty: ValType) -> Instruction<'a> {
     match ty {
-        ValType::F32 => Instruction::F32Const(f32::INFINITY),
-        ValType::F64 => Instruction::F64Const(f64::INFINITY),
+        ValType::F32 => Instruction::F32Const(f32::INFINITY.into()),
+        ValType::F64 => Instruction::F64Const(f64::INFINITY.into()),
         _ => panic!("not a float type"),
     }
 }
 
 fn flt_neg_inf_const_inst<'a>(ty: ValType) -> Instruction<'a> {
     match ty {
-        ValType::F32 => Instruction::F32Const(f32::NEG_INFINITY),
-        ValType::F64 => Instruction::F64Const(f64::NEG_INFINITY),
+        ValType::F32 => Instruction::F32Const(f32::NEG_INFINITY.into()),
+        ValType::F64 => Instruction::F64Const(f64::NEG_INFINITY.into()),
         _ => panic!("not a float type"),
     }
 }

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, Ieee32, Ieee64};
 use crate::{BinaryReader, FromReader, Result};
 
 /// The data portion of a custom section representing a core dump. Per the
@@ -254,9 +254,9 @@ pub enum CoreDumpValue {
     /// An i64 value
     I64(i64),
     /// An f32 value
-    F32(f32),
+    F32(Ieee32),
     /// An f64 value
-    F64(f64),
+    F64(Ieee64),
 }
 
 impl<'a> FromReader<'a> for CoreDumpValue {
@@ -266,12 +266,8 @@ impl<'a> FromReader<'a> for CoreDumpValue {
             0x01 => Ok(CoreDumpValue::Missing),
             0x7F => Ok(CoreDumpValue::I32(reader.read_var_i32()?)),
             0x7E => Ok(CoreDumpValue::I64(reader.read_var_i64()?)),
-            0x7D => Ok(CoreDumpValue::F32(f32::from_bits(
-                reader.read_f32()?.bits(),
-            ))),
-            0x7C => Ok(CoreDumpValue::F64(f64::from_bits(
-                reader.read_f64()?.bits(),
-            ))),
+            0x7D => Ok(CoreDumpValue::F32(reader.read_f32()?)),
+            0x7C => Ok(CoreDumpValue::F64(reader.read_f64()?)),
             _ => bail!(pos, "invalid CoreDumpValue type"),
         }
     }


### PR DESCRIPTION
Resolves #2155
