### PR TITLE
Fix typos: Correct "compnents" to "components" and "independenent" to "independent"

### DIFF
--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -2,7 +2,7 @@ use crate::{BinaryReader, BinaryReaderError, NameMap, Result, Subsection, Subsec
 use core::ops::Range;
 
 /// Type used to iterate and parse the contents of the `component-name` custom
-/// section in compnents, similar to the `name` section of core modules.
+/// section in components, similar to the `name` section of core modules.
 pub type ComponentNameSectionReader<'a> = Subsections<'a, ComponentName<'a>>;
 
 /// Represents a name read from the names custom section.

--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -128,7 +128,7 @@ back_to_enum! {
         MemoryAddrRelSleb = 11,
 
         /// A function address (table index) relative to the __table_base wasm
-        /// global. Used in position indepenent code (-fPIC) where absolute
+        /// global. Used in position independent code (-fPIC) where absolute
         /// function addresses are not known at link time.
         TableIndexRelSleb = 12,
 


### PR DESCRIPTION

**Description:**
This PR fixes two minor typos in the codebase:

1. In `crates/wasmparser/src/readers/component/names.rs`:
   - Corrects "compnents" to "components" in the section comment

2. In `crates/wasmparser/src/readers/core/reloc.rs`: 
   - Fixes "independenent" to "independent" in the documentation comment

These changes improve code documentation clarity and consistency.
