### PR TITLE
wasm-smith: add support for `--exports` and `--available-imports` option

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -55,7 +55,7 @@ macro_rules! define_config {
             /// module. The implementation (e.g. function bodies, global
             /// initializers) of each export in the generated module will be
             /// random and unrelated to the implementation in the provided
-            /// module. Only globals and functions are supported.
+            /// module.
             ///
             ///
             /// Defaults to `None` which means arbitrary exports will be
@@ -73,12 +73,13 @@ macro_rules! define_config {
             ///
             /// # Module Limits
             ///
-            /// All types, functions, globals, and exports that are needed to
-            /// provide the required exports will be generated, even if it
-            /// causes the resulting module to exceed the limits defined in
-            /// [`Self::max_type_size`], [`Self::max_types`],
-            /// [`Self::max_funcs`], [`Self::max_globals`], or
-            /// [`Self::max_exports`].
+            /// All types, functions, globals, memories, tables, tags, and exports
+            /// that are needed to provide the required exports will be generated,
+            /// even if it causes the resulting module to exceed the limits defined
+            /// in [`Self::max_type_size`], [`Self::max_types`],
+            /// [`Self::max_funcs`], [`Self::max_globals`],
+            /// [`Self::max_memories`], [`Self::max_tables`],
+            /// [`Self::max_tags`], or [`Self::max_exports`].
             ///
             /// # Example
             ///
@@ -90,6 +91,9 @@ macro_rules! define_config {
             ///     (module
             ///         (func (export "foo") (param i32) (result i64) unreachable)
             ///         (global (export "bar") f32 f32.const 0)
+            ///         (memory (export "baz") 1 10)
+            ///         (table (export "qux") 5 10 (ref null extern))
+            ///         (tag (export "quux") (param f32))
             ///     )
             /// "#));
             /// ```
@@ -141,7 +145,7 @@ macro_rules! define_config {
             /// module. The implementation (e.g. function bodies, global
             /// initializers) of each export in the generated module will be
             /// random and unrelated to the implementation in the provided
-            /// module. Only globals and functions are supported.
+            /// module.
             ///
             /// Defaults to `None` which means arbitrary exports will be
             /// generated.
@@ -158,12 +162,13 @@ macro_rules! define_config {
             ///
             /// # Module Limits
             ///
-            /// All types, functions, globals, and exports that are needed to
-            /// provide the required exports will be generated, even if it
-            /// causes the resulting module to exceed the limits defined in
-            /// [`Self::max_type_size`], [`Self::max_types`],
-            /// [`Self::max_funcs`], [`Self::max_globals`], or
-            /// [`Self::max_exports`].
+            /// All types, functions, globals, memories, tables, tags, and exports
+            /// that are needed to provide the required exports will be generated,
+            /// even if it causes the resulting module to exceed the limits defined
+            /// in [`Self::max_type_size`], [`Self::max_types`],
+            /// [`Self::max_funcs`], [`Self::max_globals`],
+            /// [`Self::max_memories`], [`Self::max_tables`],
+            /// [`Self::max_tags`], or [`Self::max_exports`].
             ///
             #[cfg_attr(feature = "clap", clap(long))]
             exports: Option<std::path::PathBuf>,

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -3171,6 +3171,7 @@ impl FromStr for InstructionKind {
 
 // Conversions from `wasmparser` to `wasm-smith`. Currently, only type conversions
 // have been implemented.
+#[cfg(feature = "wasmparser")]
 impl From<wasmparser::FuncType> for FuncType {
     fn from(value: wasmparser::FuncType) -> Self {
         FuncType {
@@ -3190,6 +3191,7 @@ impl From<wasmparser::FuncType> for FuncType {
     }
 }
 
+#[cfg(feature = "wasmparser")]
 impl From<wasmparser::CompositeType> for CompositeType {
     fn from(value: wasmparser::CompositeType) -> Self {
         let inner_type = match value.inner {
@@ -3214,6 +3216,7 @@ impl From<wasmparser::CompositeType> for CompositeType {
     }
 }
 
+#[cfg(feature = "wasmparser")]
 impl From<wasmparser::SubType> for SubType {
     fn from(value: wasmparser::SubType) -> Self {
         let supertype_idx = value

--- a/crates/wasm-smith/tests/available_imports.rs
+++ b/crates/wasm-smith/tests/available_imports.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "wasmparser")]
 
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::Unstructured;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use std::collections::HashMap;
 use wasm_smith::{Config, Module};
@@ -38,8 +38,16 @@ fn smoke_test_imports_config() {
                 if let wasmparser::Payload::TypeSection(rdr) = payload {
                     // Gather the signature types to later check function types
                     // against.
-                    for ty in rdr.into_iter_err_on_gc_types() {
-                        sig_types.push(ty.unwrap());
+                    for recgrp in rdr {
+                        let recgrp = recgrp.unwrap();
+                        for subtype in recgrp.into_types() {
+                            match subtype.composite_type.inner {
+                                wasmparser::CompositeInnerType::Func(func_type) => {
+                                    sig_types.push(Some(func_type))
+                                }
+                                _ => sig_types.push(None),
+                            }
+                        }
                     }
                 } else if let wasmparser::Payload::ImportSection(rdr) = payload {
                     // Read out imports, checking that they all are within the
@@ -64,16 +72,22 @@ fn smoke_test_imports_config() {
                                 *seen = true
                             }
                             (Some((seen, I::Func(p, r))), TypeRef::Func(sig_idx))
-                                if sig_types[*sig_idx as usize].params() == *p
-                                    && sig_types[*sig_idx as usize].results() == *r =>
+                                if sig_types[*sig_idx as usize].clone().unwrap().params() == *p
+                                    && sig_types[*sig_idx as usize].clone().unwrap().results()
+                                        == *r =>
                             {
                                 *seen = true
                             }
                             (
                                 Some((seen, I::Tag(p))),
                                 TypeRef::Tag(wasmparser::TagType { func_type_idx, .. }),
-                            ) if sig_types[*func_type_idx as usize].params() == *p
-                                && sig_types[*func_type_idx as usize].results().is_empty() =>
+                            ) if sig_types[*func_type_idx as usize].clone().unwrap().params()
+                                == *p
+                                && sig_types[*func_type_idx as usize]
+                                    .clone()
+                                    .unwrap()
+                                    .results()
+                                    .is_empty() =>
                             {
                                 *seen = true
                             }
@@ -108,8 +122,8 @@ fn smoke_test_imports_config() {
 
 #[derive(Debug)]
 enum AvailableImportKind {
-    Func(&'static [ValType], &'static [ValType]),
-    Tag(&'static [ValType]),
+    Func(Vec<ValType>, Vec<ValType>),
+    Tag(Vec<ValType>),
     Global(ValType),
     Table(ValType),
     Memory,
@@ -121,28 +135,43 @@ fn import_config(
     Config,
     Vec<(&'static str, &'static str, AvailableImportKind)>,
 ) {
-    let mut config = Config::arbitrary(u).expect("arbitrary swarm");
-    config.gc_enabled = false;
+    let mut config = Config::default();
     config.exceptions_enabled = u.arbitrary().expect("exceptions enabled for swarm");
     let available = {
-        use {AvailableImportKind::*, ValType::*};
+        use {
+            wasmparser::{PackedIndex, RefType},
+            AvailableImportKind::*,
+            ValType::*,
+        };
         vec![
-            ("env", "pi", Func(&[I32], &[])),
-            ("env", "pi2", Func(&[I32], &[])),
-            ("env", "pipi2", Func(&[I32, I32], &[])),
-            ("env", "po", Func(&[], &[I32])),
-            ("env", "pipo", Func(&[I32], &[I32])),
-            ("env", "popo", Func(&[], &[I32, I32])),
+            ("env", "pi", Func(vec![I32], vec![])),
+            ("env", "pi2", Func(vec![I32], vec![])),
+            ("env", "pipi2", Func(vec![I32, I32], vec![])),
+            ("env", "po", Func(vec![], vec![I32])),
+            ("env", "pipo", Func(vec![I32], vec![I32])),
+            ("env", "popo", Func(vec![], vec![I32, I32])),
             ("env", "mem", Memory),
             ("env", "tbl", Table(ValType::FUNCREF)),
             ("vars", "g", Global(I64)),
-            ("tags", "tag1", Tag(&[I32])),
+            ("tags", "tag1", Tag(vec![I32])),
+            (
+                "tags",
+                "tag2",
+                Tag(vec![Ref(RefType::concrete(
+                    true,
+                    PackedIndex::from_module_index(0).unwrap(),
+                ))]),
+            ),
         ]
     };
     config.available_imports = Some(
         wat::parse_str(
             r#"
             (module
+                (rec
+                    (type $s0 (array (ref $s1)))
+                    (type $s1 (array (ref $s0)))
+                )
                 (import "env" "pi" (func (param i32)))
                 (import "env" "pi2" (func (param i32)))
                 (import "env" "pipi2" (func (param i32 i32)))
@@ -153,6 +182,7 @@ fn import_config(
                 (import "env" "tbl" (table 1 16 funcref))
                 (import "vars" "g" (global i64))
                 (import "tags" "tag1" (tag (param i32)))
+                (import "tags" "tag2" (tag (param (ref null $s0))))
             )
             "#,
         )

--- a/crates/wasm-smith/tests/exports.rs
+++ b/crates/wasm-smith/tests/exports.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "wasmparser")]
 
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::Unstructured;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use wasm_smith::{Config, Module};
 use wasmparser::{
-    types::EntityType, CompositeType, FuncType, GlobalType, Parser, Validator, WasmFeatures,
+    types::EntityType, CompositeType, FuncType, GlobalType, MemoryType, Parser, TableType,
+    Validator, WasmFeatures,
 };
 
 mod common;
@@ -14,6 +15,9 @@ use common::validate;
 enum ExportType {
     Func(FuncType),
     Global(GlobalType),
+    Memory(MemoryType),
+    Table(TableType),
+    Tag(FuncType),
 }
 
 #[test]
@@ -65,14 +69,26 @@ fn smoke_test_export_with_imports() {
         (module
             (import "" "foo" (func (param i32)))
             (import "" "bar" (global (mut f32)))
+            (import "" "mem" (memory 5))
+            (import "" "baz" (table 1 10 funcref))
+            (import "" "qux" (tag (param i32 f64)))
             (func (param i64) unreachable)
             (global i32 (i32.const 0))
+            (memory 10)
+            (table 10 (ref null any))
+            (tag (param f32 v128))
             (export "a" (func 0))
             (export "b" (global 0))
-            (export "c" (func 1))
-            (export "d" (global 1))
+            (export "c" (memory 0))
+            (export "d" (table 0))
+            (export "e" (tag 0))
+            (export "f" (func 1))
+            (export "g" (global 1))
+            (export "h" (memory 1))
+            (export "i" (table 1))
+            (export "j" (tag 1))
         )
-            "#;
+        "#;
     smoke_test_exports(test, 21)
 }
 
@@ -92,12 +108,25 @@ fn smoke_test_with_mutable_global_exports() {
     smoke_test_exports(test, 22)
 }
 
-fn get_func_and_global_exports(features: WasmFeatures, module: &[u8]) -> Vec<(String, ExportType)> {
+#[test]
+fn smoke_test_all_exports() {
+    let test = r#"
+        (module
+            (func (export "foo") (param i32) (result i64) unreachable)
+            (global (export "bar") f32 f32.const 0)
+            (memory (export "baz") 1 10)
+            (table (export "qux") 5 10 (ref null extern))
+            (tag (export "quux") (param f32))
+        )
+        "#;
+    smoke_test_exports(test, 23);
+}
+
+fn get_exports(features: WasmFeatures, module: &[u8]) -> Vec<(String, ExportType)> {
     let mut validator = Validator::new_with_features(features);
     let types = validate(&mut validator, module);
     let types = types.as_ref();
     let mut exports = vec![];
-
     for payload in Parser::new(0).parse_all(module) {
         let payload = payload.unwrap();
         if let wasmparser::Payload::ExportSection(rdr) = payload {
@@ -119,10 +148,27 @@ fn get_func_and_global_exports(features: WasmFeatures, module: &[u8]) -> Vec<(St
                             .push((export.name.to_string(), ExportType::Func(func_type.clone())));
                     }
                     EntityType::Global(global_type) => {
-                        exports.push((export.name.to_string(), ExportType::Global(global_type)))
+                        exports.push((export.name.to_string(), ExportType::Global(global_type)));
                     }
-                    other => {
-                        panic!("Unexpected entity type {other:?}")
+                    EntityType::Memory(memory_type) => {
+                        exports.push((export.name.to_string(), ExportType::Memory(memory_type)));
+                    }
+                    EntityType::Table(table_type) => {
+                        exports.push((export.name.to_string(), ExportType::Table(table_type)));
+                    }
+                    EntityType::Tag(core_id) => {
+                        let sub_type = types.get(core_id).expect("Failed to lookup core id");
+                        assert!(sub_type.is_final);
+                        assert!(sub_type.supertype_idx.is_none());
+                        let CompositeType {
+                            inner: wasmparser::CompositeInnerType::Func(func_type),
+                            ..
+                        } = &sub_type.composite_type
+                        else {
+                            panic!("Expected Func CompositeType, but found {sub_type:?}");
+                        };
+                        assert!(func_type.results().is_empty());
+                        exports.push((export.name.to_string(), ExportType::Tag(func_type.clone())));
                     }
                 }
             }
@@ -135,20 +181,22 @@ fn smoke_test_exports(exports_test_case: &str, seed: u64) {
     let mut rng = SmallRng::seed_from_u64(seed);
     let mut buf = vec![0; 512];
     let wasm = wat::parse_str(exports_test_case).unwrap();
-    let expected_exports = get_func_and_global_exports(WasmFeatures::default(), &wasm);
+    let expected_exports = get_exports(WasmFeatures::default(), &wasm);
 
     for _ in 0..1024 {
         rng.fill_bytes(&mut buf);
         let mut u = Unstructured::new(&buf);
 
-        let mut config = Config::arbitrary(&mut u).expect("arbitrary config");
+        // Enable all standardized proposals.
+        let mut config = Config::default();
+        config.max_memories = u.int_in_range(2..=5).unwrap();
         config.exports = Some(wasm.clone());
 
         let features = config.features();
         let module = Module::new(config, &mut u).unwrap();
         let wasm_bytes = module.to_bytes();
 
-        let generated_exports = get_func_and_global_exports(features, &wasm_bytes);
+        let generated_exports = get_exports(features, &wasm_bytes);
         assert_eq!(expected_exports, generated_exports);
     }
 }

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -570,9 +570,7 @@ impl<'a> TypesRef<'a> {
                 ExternalKind::Global => {
                     EntityType::Global(*module.globals.get(export.index as usize)?)
                 }
-                ExternalKind::Tag => EntityType::Tag(
-                    module.types[*module.functions.get(export.index as usize)? as usize],
-                ),
+                ExternalKind::Tag => EntityType::Tag(*module.tags.get(export.index as usize)?),
             }),
             #[cfg(feature = "component-model")]
             TypesRefKind::Component(_) => None,


### PR DESCRIPTION
This PR fixes issue https://github.com/bytecodealliance/wasm-tools/issues/2110 (sorry for the lateness):

1. It allows wasm-smith to generate the corresponding tag, table, and memory exports as specified by the `--exports` option. Note that I have also modified the function signatures of **arbitrary_const_expr** and **globals_for_const_expr** and added a new parameter called *allow_defined_globals*. This is because the **required_exports** is called after **arbitrary_globals** in the **build** function, which results in wasm-smith potentially *picking up defined globals for table initialization expressions* and that is not allowed in the current Wasm standard;
2. It allows Wasm modules with GC types to appear in the `--available-imports` option. To achieve this, the current solution is to copy all the recursive groups in the provided module into the module being constructed. And the necessary trait implementation is also added (i.e., `From` trait);

Please feel free to share any suggestions/concerns you might have :).