### PR TITLE
wasmparser(CM+GC): Allow declaring a core function type when lowering

### DIFF
--- a/crates/wasm-encoder/src/component/canonicals.rs
+++ b/crates/wasm-encoder/src/component/canonicals.rs
@@ -27,6 +27,8 @@ pub enum CanonicalOption {
     /// The function to use if the async lifting of a function should receive task/stream/future progress events
     /// using a callback.
     Callback(u32),
+    /// The core function type to lower a component function into.
+    CoreType(u32),
 }
 
 impl Encode for CanonicalOption {
@@ -52,6 +54,10 @@ impl Encode for CanonicalOption {
             }
             Self::Callback(idx) => {
                 sink.push(0x07);
+                idx.encode(sink);
+            }
+            Self::CoreType(idx) => {
+                sink.push(0x08);
                 idx.encode(sink);
             }
         }

--- a/crates/wasm-encoder/src/reencode/component.rs
+++ b/crates/wasm-encoder/src/reencode/component.rs
@@ -1367,6 +1367,9 @@ pub mod component_utils {
             wasmparser::CanonicalOption::Callback(u) => {
                 crate::component::CanonicalOption::Callback(reencoder.function_index(u))
             }
+            wasmparser::CanonicalOption::CoreType(u) => {
+                crate::component::CanonicalOption::CoreType(reencoder.type_index(u))
+            }
         }
     }
 

--- a/crates/wasmparser/src/readers/component/canonicals.rs
+++ b/crates/wasmparser/src/readers/component/canonicals.rs
@@ -28,6 +28,8 @@ pub enum CanonicalOption {
     /// The function to use if the async lifting of a function should receive task/stream/future progress events
     /// using a callback.
     Callback(u32),
+    /// The core function type to lower this component function to.
+    CoreType(u32),
 }
 
 /// Represents a canonical function in a WebAssembly component.
@@ -401,6 +403,7 @@ impl<'a> FromReader<'a> for CanonicalOption {
             0x05 => CanonicalOption::PostReturn(reader.read_var_u32()?),
             0x06 => CanonicalOption::Async,
             0x07 => CanonicalOption::Callback(reader.read_var_u32()?),
+            0x08 => CanonicalOption::CoreType(reader.read_var_u32()?),
             x => return reader.invalid_leading_byte(x, "canonical option"),
         })
     }

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -345,7 +345,7 @@ impl CanonicalOptions {
         if self.core_type.is_some() {
             bail!(
                 offset,
-                "canonical option `core type` is not allowed in `canon lift`"
+                "canonical option `core-type` is not allowed in `canon lift`"
             )
         }
 

--- a/crates/wasmprinter/src/component.rs
+++ b/crates/wasmprinter/src/component.rs
@@ -830,6 +830,11 @@ impl Printer<'_, '_> {
                     self.print_idx(&state.core.func_names, *idx)?;
                     self.end_group()?;
                 }
+                CanonicalOption::CoreType(idx) => {
+                    self.start_group("core type ")?;
+                    self.print_idx(&state.core.type_names, *idx)?;
+                    self.end_group()?;
+                }
             }
         }
         Ok(())

--- a/crates/wasmprinter/src/component.rs
+++ b/crates/wasmprinter/src/component.rs
@@ -831,7 +831,7 @@ impl Printer<'_, '_> {
                     self.end_group()?;
                 }
                 CanonicalOption::CoreType(idx) => {
-                    self.start_group("core type ")?;
+                    self.start_group("core-type ")?;
                     self.print_idx(&state.core.type_names, *idx)?;
                     self.end_group()?;
                 }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -975,6 +975,7 @@ impl From<&CanonOpt<'_>> for wasm_encoder::CanonicalOption {
             CanonOpt::PostReturn(f) => Self::PostReturn(f.idx.into()),
             CanonOpt::Async => Self::Async,
             CanonOpt::Callback(f) => Self::Callback(f.idx.into()),
+            CanonOpt::CoreType(t) => Self::CoreType(t.idx.into()),
         }
     }
 }

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -994,9 +994,8 @@ impl<'a> Parse<'a> for CanonOpt<'a> {
                     Ok(CanonOpt::Callback(
                         parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
                     ))
-                } else if l.peek::<kw::core>()? {
-                    parser.parse::<kw::core>()?;
-                    parser.parse::<kw::r#type>()?;
+                } else if l.peek::<kw::core_type>()? {
+                    parser.parse::<kw::core_type>()?;
                     Ok(CanonOpt::CoreType(
                         parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
                     ))
@@ -1022,7 +1021,7 @@ impl Peek for CanonOpt<'_> {
                         || kw::realloc::peek(next)?
                         || kw::post_return::peek(next)?
                         || kw::callback::peek(next)?
-                        || kw::core::peek(next)?
+                        || kw::core_type::peek(next)?
                 }
                 None => false,
             })

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -949,6 +949,14 @@ pub enum CanonOpt<'a> {
     Async,
     /// Use the specified function to deliver async events to stackless coroutines.
     Callback(CoreItemRef<'a, kw::func>),
+    /// Lower this component function into the specified core function type.
+    CoreType(CoreItemRef<'a, kw::r#type>),
+}
+
+impl Default for kw::r#type {
+    fn default() -> Self {
+        Self(Span::from_offset(0))
+    }
 }
 
 impl<'a> Parse<'a> for CanonOpt<'a> {
@@ -986,6 +994,12 @@ impl<'a> Parse<'a> for CanonOpt<'a> {
                     Ok(CanonOpt::Callback(
                         parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
                     ))
+                } else if l.peek::<kw::core>()? {
+                    parser.parse::<kw::core>()?;
+                    parser.parse::<kw::r#type>()?;
+                    Ok(CanonOpt::CoreType(
+                        parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
+                    ))
                 } else {
                     Err(l.error())
                 }
@@ -1008,6 +1022,7 @@ impl Peek for CanonOpt<'_> {
                         || kw::realloc::peek(next)?
                         || kw::post_return::peek(next)?
                         || kw::callback::peek(next)?
+                        || kw::core::peek(next)?
                 }
                 None => false,
             })

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -486,6 +486,7 @@ impl<'a> Resolver<'a> {
                 CanonOpt::Realloc(r) | CanonOpt::PostReturn(r) | CanonOpt::Callback(r) => {
                     self.core_item_ref(r)?
                 }
+                CanonOpt::CoreType(t) => self.core_item_ref(t)?,
             }
         }
 

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -544,6 +544,7 @@ pub mod kw {
     custom_keyword!(post_return = "post-return");
     custom_keyword!(with);
     custom_keyword!(core);
+    custom_keyword!(core_type = "core-type");
     custom_keyword!(true_ = "true");
     custom_keyword!(false_ = "false");
     custom_keyword!(language);

--- a/tests/cli/component-model-gc/core-type.wat
+++ b/tests/cli/component-model-gc/core-type.wat
@@ -3,7 +3,7 @@
 (component
   (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
   (core type $ty (func (param i32 i32) (result i32)))
-  (core func (canon lower (func $f) (core type $ty)))
+  (core func (canon lower (func $f) (core-type $ty)))
 )
 
 (assert_invalid
@@ -16,17 +16,17 @@
 
     (core type $ty (func (result i32)))
     (func (export "f") (result u32)
-      (canon lift (core func $i "f") (core type $ty))
+      (canon lift (core func $i "f") (core-type $ty))
     )
   )
-  "canonical option `core type` is not allowed in `canon lift`"
+  "canonical option `core-type` is not allowed in `canon lift`"
 )
 
 (assert_invalid
   (component
     (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
     (core type $ty (func (param i64 i32) (result i32)))
-    (core func (canon lower (func $f) (core type $ty)))
+    (core func (canon lower (func $f) (core-type $ty)))
   )
   "declared core type has `[I64, I32]` parameter types, but actual lowering has `[I32, I32]` parameter types"
 )
@@ -35,7 +35,7 @@
   (component
     (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
     (core type $ty (func (param i32 i32) (result i64)))
-    (core func (canon lower (func $f) (core type $ty)))
+    (core func (canon lower (func $f) (core-type $ty)))
   )
   "declared core type has `[I64]` result types, but actual lowering has `[I32]` result types"
 )

--- a/tests/cli/component-model-gc/core-type.wat
+++ b/tests/cli/component-model-gc/core-type.wat
@@ -1,0 +1,41 @@
+;; RUN: wast --assert default --snapshot tests/snapshots % -f gc,cm-gc
+
+(component
+  (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
+  (core type $ty (func (param i32 i32) (result i32)))
+  (core func (canon lower (func $f) (core type $ty)))
+)
+
+(assert_invalid
+  (component
+    (core module $m
+      (memory (export "memory") 1)
+      (func (export "f") (result i32) unreachable)
+    )
+    (core instance $i (instantiate $m))
+
+    (core type $ty (func (result i32)))
+    (func (export "f") (result u32)
+      (canon lift (core func $i "f") (core type $ty))
+    )
+  )
+  "canonical option `core type` is not allowed in `canon lift`"
+)
+
+(assert_invalid
+  (component
+    (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
+    (core type $ty (func (param i64 i32) (result i32)))
+    (core func (canon lower (func $f) (core type $ty)))
+  )
+  "declared core type has `[I64, I32]` parameter types, but actual lowering has `[I32, I32]` parameter types"
+)
+
+(assert_invalid
+  (component
+    (import "f" (func $f (param "x" u32) (param "y" u32) (result u32)))
+    (core type $ty (func (param i32 i32) (result i64)))
+    (core func (canon lower (func $f) (core type $ty)))
+  )
+  "declared core type has `[I64]` result types, but actual lowering has `[I32]` result types"
+)

--- a/tests/snapshots/cli/component-model-gc/core-type.wat.json
+++ b/tests/snapshots/cli/component-model-gc/core-type.wat.json
@@ -1,0 +1,32 @@
+{
+  "source_filename": "tests/cli/component-model-gc/core-type.wat",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "core-type.0.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "core-type.1.wasm",
+      "module_type": "binary",
+      "text": "canonical option `core type` is not allowed in `canon lift`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 26,
+      "filename": "core-type.2.wasm",
+      "module_type": "binary",
+      "text": "declared core type has `[I64, I32]` parameter types, but actual lowering has `[I32, I32]` parameter types"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 35,
+      "filename": "core-type.3.wasm",
+      "module_type": "binary",
+      "text": "declared core type has `[I64]` result types, but actual lowering has `[I32]` result types"
+    }
+  ]
+}

--- a/tests/snapshots/cli/component-model-gc/core-type.wat.json
+++ b/tests/snapshots/cli/component-model-gc/core-type.wat.json
@@ -12,7 +12,7 @@
       "line": 10,
       "filename": "core-type.1.wasm",
       "module_type": "binary",
-      "text": "canonical option `core type` is not allowed in `canon lift`"
+      "text": "canonical option `core-type` is not allowed in `canon lift`"
     },
     {
       "type": "assert_invalid",

--- a/tests/snapshots/cli/component-model-gc/core-type.wat/0.print
+++ b/tests/snapshots/cli/component-model-gc/core-type.wat/0.print
@@ -2,5 +2,5 @@
   (type (;0;) (func (param "x" u32) (param "y" u32) (result u32)))
   (import "f" (func $f (;0;) (type 0)))
   (core type $ty (;0;) (func (param i32 i32) (result i32)))
-  (core func (;0;) (canon lower (func $f) (core type $ty)))
+  (core func (;0;) (canon lower (func $f) (core-type $ty)))
 )

--- a/tests/snapshots/cli/component-model-gc/core-type.wat/0.print
+++ b/tests/snapshots/cli/component-model-gc/core-type.wat/0.print
@@ -1,0 +1,6 @@
+(component
+  (type (;0;) (func (param "x" u32) (param "y" u32) (result u32)))
+  (import "f" (func $f (;0;) (type 0)))
+  (core type $ty (;0;) (func (param i32 i32) (result i32)))
+  (core func (;0;) (canon lower (func $f) (core type $ty)))
+)


### PR DESCRIPTION
When lowering a component function into a core function, allow the declaration of which core function type the lowered function (or lowered CM intrinsic) should have. Right now, this is effectively just double checking that the declared type matches the actual lowered type. After future PRs, this will allow declaring a Wasm GC-using function type, and lowering will adjust accordingly. This also lets the Wasm declare which of the "equivalent" function types it wants to lower to in the case that there are multiple rec groups containing the "same" function type, or in the face of function type subtyping. Again, subsequent PRs will start adding support for rec groups and subtyping and such to CM core types.