### PR TITLE
Improve time complexity of handling large WIT types

### DIFF
--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -1144,9 +1144,6 @@ impl ComponentDefinedType {
             ),
             Self::List(_) => lowered_types.push(ValType::I32) && lowered_types.push(ValType::I32),
             Self::FixedSizeList(ty, length) => {
-                if *length as usize > lowered_types.max {
-                    return false;
-                }
                 (0..*length).all(|_n| ty.push_wasm_types(types, lowered_types))
             }
             Self::Tuple(t) => t

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1339,7 +1339,10 @@ impl<'a> Resolver<'a> {
                 if !matches!(&ty.stability, Stability::Unknown) {
                     Some(&ty.stability)
                 } else {
-                    find_in_kind(types, &ty.kind)
+                    // Note that this type isn't searched recursively since the
+                    // creation of `id` should already have searched its
+                    // recursive edges, so there's no need to search again.
+                    None
                 }
             } else {
                 None

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -10,7 +10,7 @@ use wasm_encoder::reencode::{Error, Reencode, ReencodeComponent, RoundtripReenco
 use wasm_encoder::ModuleType;
 use wasm_tools::Output;
 use wasmparser::types::{CoreTypeId, EntityType, Types};
-use wasmparser::{Payload, ValidPayload};
+use wasmparser::{Payload, ValidPayload, WasmFeatures};
 use wat::Detect;
 use wit_component::{
     embed_component_metadata, metadata, ComponentEncoder, DecodedWasm, Linker, StringEncoding,
@@ -831,7 +831,7 @@ impl WitOpts {
         let decoded_package = decoded.package();
         let bytes = wit_component::encode(decoded.resolve(), decoded_package)?;
         if !self.skip_validation {
-            wasmparser::Validator::new().validate_all(&bytes)?;
+            wasmparser::Validator::new_with_features(WasmFeatures::all()).validate_all(&bytes)?;
         }
         self.output.output_wasm(&self.general, &bytes, self.wat)?;
         Ok(())

--- a/tests/cli/wit-deep-list.wit
+++ b/tests/cli/wit-deep-list.wit
@@ -1,0 +1,18 @@
+// RUN[parse]: component wit % -t | validate -f cm-fixed-size-list
+// RUN[abi]: component embed --dummy % | component new | validate -f cm-fixed-size-list
+
+package a:b;
+
+world lists {
+  type t = list<t2, 16>;
+  type t2 = list<t3, 16>;
+  type t3 = list<t4, 16>;
+  type t4 = list<t5, 16>;
+  type t5 = list<t6, 16>;
+  type t6 = list<t7, 16>;
+  type t7 = list<t8, 16>;
+  type t8 = list<u8, 16>;
+
+  import x: func(t: t);
+}
+

--- a/tests/cli/wit-deep-record.wit
+++ b/tests/cli/wit-deep-record.wit
@@ -1,0 +1,42 @@
+// FAIL[parse]: component wit % -t
+// FAIL[abi]: component embed --dummy % | component new
+
+package a:b;
+
+world records {
+  record t1 {
+    f1: t2, f2: t2, f3: t2, f4: t2, f5: t2, f6: t2, f7: t2, f8: t2,
+    f9: t2, f10: t2, f11: t2, f12: t2, f13: t2, f14: t2, f15: t2, f16: t2,
+  }
+  record t2 {
+    f1: t3, f2: t3, f3: t3, f4: t3, f5: t3, f6: t3, f7: t3, f8: t3,
+    f9: t3, f10: t3, f11: t3, f12: t3, f13: t3, f14: t3, f15: t3, f16: t3,
+  }
+  record t3 {
+    f1: t4, f2: t4, f3: t4, f4: t4, f5: t4, f6: t4, f7: t4, f8: t4,
+    f9: t4, f10: t4, f11: t4, f12: t4, f13: t4, f14: t4, f15: t4, f16: t4,
+  }
+  record t4 {
+    f1: t5, f2: t5, f3: t5, f4: t5, f5: t5, f6: t5, f7: t5, f8: t5,
+    f9: t5, f10: t5, f11: t5, f12: t5, f13: t5, f14: t5, f15: t5, f16: t5,
+  }
+  record t5 {
+    f1: t6, f2: t6, f3: t6, f4: t6, f5: t6, f6: t6, f7: t6, f8: t6,
+    f9: t6, f10: t6, f11: t6, f12: t6, f13: t6, f14: t6, f15: t6, f16: t6,
+  }
+  record t6 {
+    f1: t7, f2: t7, f3: t7, f4: t7, f5: t7, f6: t7, f7: t7, f8: t7,
+    f9: t7, f10: t7, f11: t7, f12: t7, f13: t7, f14: t7, f15: t7, f16: t7,
+  }
+  record t7 {
+    f1: t8, f2: t8, f3: t8, f4: t8, f5: t8, f6: t8, f7: t8, f8: t8,
+    f9: t8, f10: t8, f11: t8, f12: t8, f13: t8, f14: t8, f15: t8, f16: t8,
+  }
+  record t8 {
+    f1: u8, f2: u8, f3: u8, f4: u8, f5: u8, f6: u8, f7: u8, f8: u8,
+    f9: u8, f10: u8, f11: u8, f12: u8, f13: u8, f14: u8, f15: u8, f16: u8,
+  }
+
+  import x: func(t: t1);
+}
+

--- a/tests/cli/wit-deep-record.wit.abi.stderr
+++ b/tests/cli/wit-deep-record.wit.abi.stderr
@@ -1,0 +1,4 @@
+error: decoding custom section component-type
+
+Caused by:
+    0: effective type size exceeds the limit of 1000000 (at offset 0x27)

--- a/tests/cli/wit-deep-record.wit.parse.stderr
+++ b/tests/cli/wit-deep-record.wit.parse.stderr
@@ -1,0 +1,1 @@
+error: effective type size exceeds the limit of 1000000 (at offset 0xc)

--- a/tests/cli/wit-deep-tuple.wit
+++ b/tests/cli/wit-deep-tuple.wit
@@ -1,0 +1,17 @@
+// FAIL[parse]: component wit % -t
+// FAIL[abi]: component embed --dummy % | component new
+
+package a:b;
+
+world tuples {
+  type t = tuple<t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,t2,>;
+  type t2 = tuple<t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,t3,>;
+  type t3 = tuple<t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,t4,>;
+  type t4 = tuple<t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,t5,>;
+  type t5 = tuple<t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,t6,>;
+  type t6 = tuple<t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,t7,>;
+  type t7 = tuple<t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,t8,>;
+  type t8 = tuple<u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,u8,>;
+
+  import x: func(t: t);
+}

--- a/tests/cli/wit-deep-tuple.wit.abi.stderr
+++ b/tests/cli/wit-deep-tuple.wit.abi.stderr
@@ -1,0 +1,4 @@
+error: decoding custom section component-type
+
+Caused by:
+    0: effective type size exceeds the limit of 1000000 (at offset 0x27)

--- a/tests/cli/wit-deep-tuple.wit.parse.stderr
+++ b/tests/cli/wit-deep-tuple.wit.parse.stderr
@@ -1,0 +1,1 @@
+error: effective type size exceeds the limit of 1000000 (at offset 0xc)

--- a/tests/cli/wit-deep-variant.wit
+++ b/tests/cli/wit-deep-variant.wit
@@ -1,0 +1,47 @@
+// FAIL[parse]: component wit % -t
+
+// TODO: this should use "FAIL" and should actually be a test, but this
+// currently takes too long to run and the long runtime is in and of itself a
+// bug.
+// fail[abi]: component embed --dummy % | component new
+
+package a:b;
+
+world variants {
+  variant t1 {
+    f1(t2), f2(t2), f3(t2), f4(t2), f5(t2), f6(t2), f7(t2), f8(t2),
+    f9(t2), f10(t2), f11(t2), f12(t2), f13(t2), f14(t2), f15(t2), f16(t2),
+  }
+  variant t2 {
+    f1(t3), f2(t3), f3(t3), f4(t3), f5(t3), f6(t3), f7(t3), f8(t3),
+    f9(t3), f10(t3), f11(t3), f12(t3), f13(t3), f14(t3), f15(t3), f16(t3),
+  }
+  variant t3 {
+    f1(t4), f2(t4), f3(t4), f4(t4), f5(t4), f6(t4), f7(t4), f8(t4),
+    f9(t4), f10(t4), f11(t4), f12(t4), f13(t4), f14(t4), f15(t4), f16(t4),
+  }
+  variant t4 {
+    f1(t5), f2(t5), f3(t5), f4(t5), f5(t5), f6(t5), f7(t5), f8(t5),
+    f9(t5), f10(t5), f11(t5), f12(t5), f13(t5), f14(t5), f15(t5), f16(t5),
+  }
+  variant t5 {
+    f1(t6), f2(t6), f3(t6), f4(t6), f5(t6), f6(t6), f7(t6), f8(t6),
+    f9(t6), f10(t6), f11(t6), f12(t6), f13(t6), f14(t6), f15(t6), f16(t6),
+  }
+  variant t6 {
+    f1(t7), f2(t7), f3(t7), f4(t7), f5(t7), f6(t7), f7(t7), f8(t7),
+    f9(t7), f10(t7), f11(t7), f12(t7), f13(t7), f14(t7), f15(t7), f16(t7),
+  }
+  variant t7 {
+    f1(t8), f2(t8), f3(t8), f4(t8), f5(t8), f6(t8), f7(t8), f8(t8),
+    f9(t8), f10(t8), f11(t8), f12(t8), f13(t8), f14(t8), f15(t8), f16(t8),
+  }
+  variant t8 {
+    f1(u8), f2(u8), f3(u8), f4(u8), f5(u8), f6(u8), f7(u8), f8(u8),
+    f9(u8), f10(u8), f11(u8), f12(u8), f13(u8), f14(u8), f15(u8), f16(u8),
+  }
+
+  import x: func(t: t1);
+}
+
+

--- a/tests/cli/wit-deep-variant.wit.parse.stderr
+++ b/tests/cli/wit-deep-variant.wit.parse.stderr
@@ -1,0 +1,1 @@
+error: effective type size exceeds the limit of 1000000 (at offset 0xc)


### PR DESCRIPTION
Update a few places in tooling which iterate over the structure of a WIT type to contain early-returns or similar to ensure that processing these large types doesn't take an exponential amount of time.

Closes #2164