### PR TITLE
Use a single type arena for all of `wasm-compose`

### DIFF
--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -27,10 +27,10 @@ serde_yaml = "0.9.22"
 smallvec = "1.10.0"
 wasm-encoder = { workspace = true, features = ['std', 'wasmparser', 'component-model'] }
 wasmparser = { workspace = true, features = ['std', 'validate', 'component-model', 'features'] }
-wat = { workspace = true }
+wat = { workspace = true, features = ['component-model'] }
 
 [dev-dependencies]
 glob = "0.3.0"
 pretty_assertions = "1.2.1"
-wasmprinter = { workspace = true }
+wasmprinter = { workspace = true, features = ['component-model'] }
 wit-component = { workspace = true }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -391,6 +391,14 @@ impl Validator {
     /// [`CoreTypeId`][crate::types::CoreTypeId]) for the same types that are
     /// defined multiple times across different modules and components.
     ///
+    /// # Panics
+    ///
+    /// This function will panic if the validator was mid-way through
+    /// validating a binary. Validation must complete entirely or not have
+    /// started at all for this method to be called.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// fn foo() -> anyhow::Result<()> {
     /// use wasmparser::Validator;
@@ -458,7 +466,7 @@ impl Validator {
         } = self;
 
         assert!(
-            matches!(state, State::End),
+            matches!(state, State::End) || matches!(state, State::Unparsed(None)),
             "cannot reset a validator that did not successfully complete validation"
         );
         assert!(module.is_none());
@@ -1601,5 +1609,10 @@ mod tests {
         assert!(std::ptr::eq(&types[t_id], &types[a2_id],));
 
         Ok(())
+    }
+
+    #[test]
+    fn reset_fresh_validator() {
+        Validator::new().reset();
     }
 }


### PR DESCRIPTION
This commit updates parsing of components in `wasm-compose` to use the same `Validator` for all components to ensure that type information is deduplicated. This will also become an API contract required in the upcoming component-model/GC work so this is future-proofing against that change as well.