### PR TITLE
dump: fix some missing section colors

### DIFF
--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -163,13 +163,13 @@ impl<'a> Dump<'a> {
                 })?,
                 Payload::StartSection { func, range } => {
                     write!(self.state, "start section")?;
-                    self.print(range.start)?;
+                    self.color_print(range.start)?;
                     write!(self.state, "start function {func}")?;
                     self.print(range.end)?;
                 }
                 Payload::DataCountSection { count, range } => {
                     write!(self.state, "data count section")?;
-                    self.print(range.start)?;
+                    self.color_print(range.start)?;
                     write!(self.state, "data count {count}")?;
                     self.print(range.end)?;
                 }


### PR DESCRIPTION
I noticed that the data count and start sections were not dumped with header colors like the rest of the sections. I suspect this is because the `Dump::section` helper does that automatically but these sections are parsed a bit differently. This adds colors to those sections.