### PR TITLE
wasmparser(CM+GC): Use matching when checking actual lowered signatures

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -13,10 +13,10 @@ use super::{
     core::{InternRecGroup, Module},
     types::{CoreTypeId, EntityType, TypeAlloc, TypeInfo, TypeList},
 };
-use crate::{collections::index_map::Entry, Matches};
 use crate::limits::*;
 use crate::prelude::*;
 use crate::validator::names::{ComponentName, ComponentNameKind, KebabStr, KebabString};
+use crate::{collections::index_map::Entry, Matches};
 use crate::{
     BinaryReaderError, CanonicalFunction, CanonicalOption, ComponentExportName,
     ComponentExternalKind, ComponentOuterAliasKind, ComponentTypeRef, CompositeInnerType,

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -13,7 +13,7 @@ use super::{
     core::{InternRecGroup, Module},
     types::{CoreTypeId, EntityType, TypeAlloc, TypeInfo, TypeList},
 };
-use crate::collections::index_map::Entry;
+use crate::{collections::index_map::Entry, Matches};
 use crate::limits::*;
 use crate::prelude::*;
 use crate::validator::names::{ComponentName, ComponentNameKind, KebabStr, KebabString};
@@ -359,25 +359,16 @@ impl CanonicalOptions {
         offset: usize,
     ) -> Result<CoreTypeId> {
         if let Some(declared_id) = self.core_type {
-            let declared = types[declared_id].unwrap_func();
+            let expected = types[declared_id].unwrap_func();
 
-            if actual.params() != declared.params() {
+            if !Matches::matches(types, &actual, expected) {
                 bail!(
                     offset,
-                    "declared core type has `{:?}` parameter types, but actual lowering has \
-                     `{:?}` parameter types",
-                    declared.params(),
-                    actual.params(),
-                );
-            }
-
-            if actual.results() != declared.results() {
-                bail!(
-                    offset,
-                    "declared core type has `{:?}` result types, but actual lowering has \
-                     `{:?}` result types",
-                    declared.results(),
-                    actual.results(),
+                    "type mismatch when checking `core-type` canonical option\n\
+                     expected: {}\n\
+                     actual:   {}",
+                    expected,
+                    actual,
                 );
             }
 

--- a/tests/cli/component-model-gc/core-type.wat
+++ b/tests/cli/component-model-gc/core-type.wat
@@ -28,7 +28,7 @@
     (core type $ty (func (param i64 i32) (result i32)))
     (core func (canon lower (func $f) (core-type $ty)))
   )
-  "declared core type has `[I64, I32]` parameter types, but actual lowering has `[I32, I32]` parameter types"
+  "type mismatch when checking `core-type` canonical option"
 )
 
 (assert_invalid
@@ -37,7 +37,7 @@
     (core type $ty (func (param i32 i32) (result i64)))
     (core func (canon lower (func $f) (core-type $ty)))
   )
-  "declared core type has `[I64]` result types, but actual lowering has `[I32]` result types"
+  "type mismatch when checking `core-type` canonical option"
 )
 
 (component

--- a/tests/snapshots/cli/component-model-gc/core-type.wat.json
+++ b/tests/snapshots/cli/component-model-gc/core-type.wat.json
@@ -19,14 +19,14 @@
       "line": 26,
       "filename": "core-type.2.wasm",
       "module_type": "binary",
-      "text": "declared core type has `[I64, I32]` parameter types, but actual lowering has `[I32, I32]` parameter types"
+      "text": "type mismatch when checking `core-type` canonical option"
     },
     {
       "type": "assert_invalid",
       "line": 35,
       "filename": "core-type.3.wasm",
       "module_type": "binary",
-      "text": "declared core type has `[I64]` result types, but actual lowering has `[I32]` result types"
+      "text": "type mismatch when checking `core-type` canonical option"
     },
     {
       "type": "module",


### PR DESCRIPTION
When checking that a component function's lowered parameters and results are of the correct types compared to the declared `core-type` canonical option, use spec matching rather than strict equality. This shouldn't change anything today, since reference types will never currently appear in params and results, but opens the door to their proper subtyping in future commits that allow reference types in these signatures.