### PR TITLE
Fix `var_u{32,64}` parsing in `memories` and `tables`

### DIFF
--- a/crates/wasmparser/src/readers/core/memories.rs
+++ b/crates/wasmparser/src/readers/core/memories.rs
@@ -35,14 +35,14 @@ impl<'a> FromReader<'a> for MemoryType {
         Ok(MemoryType {
             memory64,
             shared,
-            initial: if reader.memory64() {
+            initial: if memory64 {
                 reader.read_var_u64()?
             } else {
                 reader.read_var_u32()?.into()
             },
             maximum: if !has_max {
                 None
-            } else if reader.memory64() {
+            } else if memory64 {
                 Some(reader.read_var_u64()?)
             } else {
                 Some(reader.read_var_u32()?.into())

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -78,14 +78,14 @@ impl<'a> FromReader<'a> for TableType {
         Ok(TableType {
             element_type,
             table64,
-            initial: if reader.memory64() {
+            initial: if table64 {
                 reader.read_var_u64()?
             } else {
                 reader.read_var_u32()?.into()
             },
             maximum: if !has_max {
                 None
-            } else if reader.memory64() {
+            } else if table64 {
                 Some(reader.read_var_u64()?)
             } else {
                 Some(reader.read_var_u32()?.into())


### PR DESCRIPTION
I tried to update Wasmi to `wasmparser v0.229` and encountered the following bug in the existing Wasm spec testsuite:

```
thread 'wasm_binary_leb128' panicked at crates/wast/tests/mod.rs:11:9:
failed directive on testsuite/binary-leb128:217:1: module succeeded to compile and validate but should have failed with: integer representation too long
```

After some debugging I found that [this PR](https://github.com/bytecodealliance/wasm-tools/pull/2134) recently changed the logic to parse `var_u32` or `var_u64` depending on `memory64` flags [for `memories.rs`](https://github.com/keithw/wasm-tools/blob/68ec57dfbbbae243d58b662371945ad1072002ea/crates/wasmparser/src/readers/core/memories.rs#L38) and [for `tables.rs`](https://github.com/keithw/wasm-tools/blob/68ec57dfbbbae243d58b662371945ad1072002ea/crates/wasmparser/src/readers/core/tables.rs#L81).

With this PR I fixed the bugs I found on Wasmi, however, the Wasm spec testsuite of `wasm-tools` is unhappy now. This is probably due to Wasmi and `wasm-tools` using different versions of the Wasm spec testsuite. Was there a Wasm spec divergence in what Wasm files are supposed to be accepted in the recent past?