### PR TITLE
reencoder: allow implementers to fail to reencode indices and such

### DIFF
--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -24,36 +24,36 @@ use alloc::vec::Vec;
 pub trait Reencode {
     type Error;
 
-    fn data_index(&mut self, data: u32) -> u32 {
-        utils::data_index(self, data)
+    fn data_index(&mut self, data: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::data_index(self, data))
     }
 
-    fn element_index(&mut self, element: u32) -> u32 {
-        utils::element_index(self, element)
+    fn element_index(&mut self, element: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::element_index(self, element))
     }
 
-    fn function_index(&mut self, func: u32) -> u32 {
-        utils::function_index(self, func)
+    fn function_index(&mut self, func: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::function_index(self, func))
     }
 
-    fn global_index(&mut self, global: u32) -> u32 {
-        utils::global_index(self, global)
+    fn global_index(&mut self, global: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::global_index(self, global))
     }
 
-    fn memory_index(&mut self, memory: u32) -> u32 {
-        utils::memory_index(self, memory)
+    fn memory_index(&mut self, memory: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::memory_index(self, memory))
     }
 
-    fn table_index(&mut self, table: u32) -> u32 {
-        utils::table_index(self, table)
+    fn table_index(&mut self, table: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::table_index(self, table))
     }
 
-    fn tag_index(&mut self, tag: u32) -> u32 {
-        utils::tag_index(self, tag)
+    fn tag_index(&mut self, tag: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::tag_index(self, tag))
     }
 
-    fn type_index(&mut self, ty: u32) -> u32 {
-        utils::type_index(self, ty)
+    fn type_index(&mut self, ty: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(utils::type_index(self, ty))
     }
 
     fn type_index_unpacked(
@@ -63,7 +63,11 @@ pub trait Reencode {
         utils::type_index_unpacked(self, ty)
     }
 
-    fn external_index(&mut self, kind: wasmparser::ExternalKind, index: u32) -> u32 {
+    fn external_index(
+        &mut self,
+        kind: wasmparser::ExternalKind,
+        index: u32,
+    ) -> Result<u32, Error<Self::Error>> {
         match kind {
             wasmparser::ExternalKind::Func => self.function_index(index),
             wasmparser::ExternalKind::Table => self.table_index(index),
@@ -76,8 +80,8 @@ pub trait Reencode {
     fn abstract_heap_type(
         &mut self,
         value: wasmparser::AbstractHeapType,
-    ) -> crate::AbstractHeapType {
-        utils::abstract_heap_type(self, value)
+    ) -> Result<crate::AbstractHeapType, Error<Self::Error>> {
+        Ok(utils::abstract_heap_type(self, value))
     }
 
     fn array_type(
@@ -101,7 +105,7 @@ pub trait Reencode {
         utils::const_expr(self, const_expr)
     }
 
-    fn catch(&mut self, arg: wasmparser::Catch) -> crate::Catch {
+    fn catch(&mut self, arg: wasmparser::Catch) -> Result<crate::Catch, Error<Self::Error>> {
         utils::catch(self, arg)
     }
 
@@ -119,8 +123,11 @@ pub trait Reencode {
         utils::entity_type(self, type_ref)
     }
 
-    fn export_kind(&mut self, external_kind: wasmparser::ExternalKind) -> crate::ExportKind {
-        utils::export_kind(self, external_kind)
+    fn export_kind(
+        &mut self,
+        external_kind: wasmparser::ExternalKind,
+    ) -> Result<crate::ExportKind, Error<Self::Error>> {
+        Ok(utils::export_kind(self, external_kind))
     }
 
     fn field_type(
@@ -151,7 +158,7 @@ pub trait Reencode {
         utils::global_type(self, global_ty)
     }
 
-    fn handle(&mut self, on: wasmparser::Handle) -> crate::Handle {
+    fn handle(&mut self, on: wasmparser::Handle) -> Result<crate::Handle, Error<Self::Error>> {
         utils::handle(self, on)
     }
 
@@ -169,24 +176,30 @@ pub trait Reencode {
         utils::instruction(self, arg)
     }
 
-    fn memory_type(&mut self, memory_ty: wasmparser::MemoryType) -> crate::MemoryType {
-        utils::memory_type(self, memory_ty)
+    fn memory_type(
+        &mut self,
+        memory_ty: wasmparser::MemoryType,
+    ) -> Result<crate::MemoryType, Error<Self::Error>> {
+        Ok(utils::memory_type(self, memory_ty))
     }
 
-    fn ieee32_arg(&mut self, arg: wasmparser::Ieee32) -> crate::Ieee32 {
-        utils::ieee32_arg(self, arg)
+    fn ieee32_arg(&mut self, arg: wasmparser::Ieee32) -> Result<crate::Ieee32, Error<Self::Error>> {
+        Ok(utils::ieee32_arg(self, arg))
     }
 
-    fn ieee64_arg(&mut self, arg: wasmparser::Ieee64) -> crate::Ieee64 {
-        utils::ieee64_arg(self, arg)
+    fn ieee64_arg(&mut self, arg: wasmparser::Ieee64) -> Result<crate::Ieee64, Error<Self::Error>> {
+        Ok(utils::ieee64_arg(self, arg))
     }
 
-    fn mem_arg(&mut self, arg: wasmparser::MemArg) -> crate::MemArg {
+    fn mem_arg(&mut self, arg: wasmparser::MemArg) -> Result<crate::MemArg, Error<Self::Error>> {
         utils::mem_arg(self, arg)
     }
 
-    fn ordering(&mut self, arg: wasmparser::Ordering) -> crate::Ordering {
-        utils::ordering(self, arg)
+    fn ordering(
+        &mut self,
+        arg: wasmparser::Ordering,
+    ) -> Result<crate::Ordering, Error<Self::Error>> {
+        Ok(utils::ordering(self, arg))
     }
 
     fn ref_type(
@@ -224,11 +237,17 @@ pub trait Reencode {
         utils::table_type(self, table_ty)
     }
 
-    fn tag_kind(&mut self, kind: wasmparser::TagKind) -> crate::TagKind {
-        utils::tag_kind(self, kind)
+    fn tag_kind(
+        &mut self,
+        kind: wasmparser::TagKind,
+    ) -> Result<crate::TagKind, Error<Self::Error>> {
+        Ok(utils::tag_kind(self, kind))
     }
 
-    fn tag_type(&mut self, tag_ty: wasmparser::TagType) -> crate::TagType {
+    fn tag_type(
+        &mut self,
+        tag_ty: wasmparser::TagType,
+    ) -> Result<crate::TagType, Error<Self::Error>> {
         utils::tag_type(self, tag_ty)
     }
 
@@ -264,8 +283,8 @@ pub trait Reencode {
     fn custom_section<'a>(
         &mut self,
         section: wasmparser::CustomSectionReader<'a>,
-    ) -> crate::CustomSection<'a> {
-        utils::custom_section(self, section)
+    ) -> Result<crate::CustomSection<'a>, Error<Self::Error>> {
+        Ok(utils::custom_section(self, section))
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
@@ -362,7 +381,11 @@ pub trait Reencode {
 
     /// Parses the single [`wasmparser::Export`] provided and adds it to the
     /// `exports` section.
-    fn parse_export(&mut self, exports: &mut crate::ExportSection, export: wasmparser::Export<'_>) {
+    fn parse_export(
+        &mut self,
+        exports: &mut crate::ExportSection,
+        export: wasmparser::Export<'_>,
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_export(self, exports, export)
     }
 
@@ -533,11 +556,11 @@ pub trait Reencode {
         utils::parse_custom_name_subsection(self, names, section)
     }
 
-    fn data_count(&mut self, count: u32) -> u32 {
-        count
+    fn data_count(&mut self, count: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(count)
     }
 
-    fn start_section(&mut self, start: u32) -> u32 {
+    fn start_section(&mut self, start: u32) -> Result<u32, Error<Self::Error>> {
         self.function_index(start)
     }
 }
@@ -767,7 +790,7 @@ pub mod utils {
                         Some(crate::SectionId::Start),
                     )?;
                     module.section(&crate::StartSection {
-                        function_index: reencoder.start_section(func),
+                        function_index: reencoder.start_section(func)?,
                     });
                 }
                 wasmparser::Payload::ElementSection(section) => {
@@ -788,7 +811,7 @@ pub mod utils {
                         &mut last_section,
                         Some(crate::SectionId::DataCount),
                     )?;
-                    let count = reencoder.data_count(count);
+                    let count = reencoder.data_count(count)?;
                     module.section(&crate::DataCountSection { count });
                 }
                 wasmparser::Payload::DataSection(section) => {
@@ -910,12 +933,12 @@ pub mod utils {
     pub fn mem_arg<T: ?Sized + Reencode>(
         reencoder: &mut T,
         arg: wasmparser::MemArg,
-    ) -> crate::MemArg {
-        crate::MemArg {
+    ) -> Result<crate::MemArg, Error<T::Error>> {
+        Ok(crate::MemArg {
             offset: arg.offset,
             align: arg.align.into(),
-            memory_index: reencoder.memory_index(arg.memory),
-        }
+            memory_index: reencoder.memory_index(arg.memory)?,
+        })
     }
 
     pub fn ordering<T: ?Sized + Reencode>(
@@ -936,34 +959,37 @@ pub mod utils {
         tag
     }
 
-    pub fn catch<T: ?Sized + Reencode>(reencoder: &mut T, arg: wasmparser::Catch) -> crate::Catch {
-        match arg {
+    pub fn catch<T: ?Sized + Reencode>(
+        reencoder: &mut T,
+        arg: wasmparser::Catch,
+    ) -> Result<crate::Catch, Error<T::Error>> {
+        Ok(match arg {
             wasmparser::Catch::One { tag, label } => crate::Catch::One {
-                tag: reencoder.tag_index(tag),
+                tag: reencoder.tag_index(tag)?,
                 label,
             },
             wasmparser::Catch::OneRef { tag, label } => crate::Catch::OneRef {
-                tag: reencoder.tag_index(tag),
+                tag: reencoder.tag_index(tag)?,
                 label,
             },
             wasmparser::Catch::All { label } => crate::Catch::All { label },
             wasmparser::Catch::AllRef { label } => crate::Catch::AllRef { label },
-        }
+        })
     }
 
     pub fn handle<T: ?Sized + Reencode>(
         reencoder: &mut T,
         arg: wasmparser::Handle,
-    ) -> crate::Handle {
-        match arg {
+    ) -> Result<crate::Handle, Error<T::Error>> {
+        Ok(match arg {
             wasmparser::Handle::OnLabel { tag, label } => crate::Handle::OnLabel {
-                tag: reencoder.tag_index(tag),
+                tag: reencoder.tag_index(tag)?,
                 label,
             },
             wasmparser::Handle::OnSwitch { tag } => crate::Handle::OnSwitch {
-                tag: reencoder.tag_index(tag),
+                tag: reencoder.tag_index(tag)?,
             },
-        }
+        })
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and
@@ -978,7 +1004,7 @@ pub mod utils {
                 module.section(&reencoder.custom_name_section(name)?);
             }
             _ => {
-                module.section(&reencoder.custom_section(section));
+                module.section(&reencoder.custom_section(section)?);
             }
         }
         Ok(())
@@ -1040,18 +1066,18 @@ pub mod utils {
         ty: wasmparser::UnpackedIndex,
     ) -> Result<u32, Error<T::Error>> {
         ty.as_module_index()
-            .map(|ty| reencoder.type_index(ty))
             .ok_or(Error::CanonicalizedHeapTypeReference)
+            .and_then(|ty| reencoder.type_index(ty))
     }
 
     pub fn tag_type<T: ?Sized + Reencode>(
         reencoder: &mut T,
         tag_ty: wasmparser::TagType,
-    ) -> crate::TagType {
-        crate::TagType {
-            kind: reencoder.tag_kind(tag_ty.kind),
-            func_type_idx: reencoder.type_index(tag_ty.func_type_idx),
-        }
+    ) -> Result<crate::TagType, Error<T::Error>> {
+        Ok(crate::TagType {
+            kind: reencoder.tag_kind(tag_ty.kind)?,
+            func_type_idx: reencoder.type_index(tag_ty.func_type_idx)?,
+        })
     }
 
     pub fn abstract_heap_type<T: ?Sized + Reencode>(
@@ -1245,7 +1271,7 @@ pub mod utils {
             }
             wasmparser::HeapType::Abstract { shared, ty } => crate::HeapType::Abstract {
                 shared,
-                ty: reencoder.abstract_heap_type(ty),
+                ty: reencoder.abstract_heap_type(ty)?,
             },
         })
     }
@@ -1303,7 +1329,7 @@ pub mod utils {
     ) -> Result<(), Error<T::Error>> {
         for tag in section {
             let tag = tag?;
-            tags.tag(reencoder.tag_type(tag));
+            tags.tag(reencoder.tag_type(tag)?);
         }
         Ok(())
     }
@@ -1316,7 +1342,7 @@ pub mod utils {
         section: wasmparser::ExportSectionReader<'_>,
     ) -> Result<(), Error<T::Error>> {
         for export in section {
-            reencoder.parse_export(exports, export?);
+            reencoder.parse_export(exports, export?)?;
         }
         Ok(())
     }
@@ -1327,12 +1353,13 @@ pub mod utils {
         reencoder: &mut T,
         exports: &mut crate::ExportSection,
         export: wasmparser::Export<'_>,
-    ) {
+    ) -> Result<(), Error<T::Error>> {
         exports.export(
             export.name,
-            reencoder.export_kind(export.kind),
-            reencoder.external_index(export.kind, export.index),
+            reencoder.export_kind(export.kind)?,
+            reencoder.external_index(export.kind, export.index)?,
         );
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
@@ -1378,11 +1405,11 @@ pub mod utils {
         type_ref: wasmparser::TypeRef,
     ) -> Result<crate::EntityType, Error<T::Error>> {
         Ok(match type_ref {
-            wasmparser::TypeRef::Func(i) => crate::EntityType::Function(reencoder.type_index(i)),
+            wasmparser::TypeRef::Func(i) => crate::EntityType::Function(reencoder.type_index(i)?),
             wasmparser::TypeRef::Table(t) => crate::EntityType::Table(reencoder.table_type(t)?),
-            wasmparser::TypeRef::Memory(m) => crate::EntityType::Memory(reencoder.memory_type(m)),
+            wasmparser::TypeRef::Memory(m) => crate::EntityType::Memory(reencoder.memory_type(m)?),
             wasmparser::TypeRef::Global(g) => crate::EntityType::Global(reencoder.global_type(g)?),
-            wasmparser::TypeRef::Tag(t) => crate::EntityType::Tag(reencoder.tag_type(t)),
+            wasmparser::TypeRef::Tag(t) => crate::EntityType::Tag(reencoder.tag_type(t)?),
         })
     }
 
@@ -1423,7 +1450,7 @@ pub mod utils {
     ) -> Result<(), Error<T::Error>> {
         for memory in section {
             let memory = memory?;
-            memories.memory(reencoder.memory_type(memory));
+            memories.memory(reencoder.memory_type(memory)?);
         }
         Ok(())
     }
@@ -1436,7 +1463,7 @@ pub mod utils {
         section: wasmparser::FunctionSectionReader<'_>,
     ) -> Result<(), Error<T::Error>> {
         for func in section {
-            functions.function(reencoder.type_index(func?));
+            functions.function(reencoder.type_index(func?)?);
         }
         Ok(())
     }
@@ -1465,7 +1492,7 @@ pub mod utils {
                 memory_index,
                 offset_expr,
             } => data.active(
-                reencoder.memory_index(memory_index),
+                reencoder.memory_index(memory_index)?,
                 &reencoder.const_expr(offset_expr)?,
                 datum.data.iter().copied(),
             ),
@@ -1509,7 +1536,10 @@ pub mod utils {
                 // preserve this encoding and keep it at `None`. Otherwise if
                 // the result is nonzero or it was previously nonzero then keep
                 // that encoding too.
-                match (table_index, reencoder.table_index(table_index.unwrap_or(0))) {
+                match (
+                    table_index,
+                    reencoder.table_index(table_index.unwrap_or(0))?,
+                ) {
                     (None, 0) => None,
                     (_, n) => Some(n),
                 },
@@ -1530,7 +1560,7 @@ pub mod utils {
             wasmparser::ElementItems::Functions(f) => {
                 let mut funcs = Vec::new();
                 for func in f {
-                    funcs.push(reencoder.function_index(func?));
+                    funcs.push(reencoder.function_index(func?)?);
                 }
                 crate::Elements::Functions(funcs.into())
             }
@@ -1582,7 +1612,7 @@ pub mod utils {
         match arg {
             wasmparser::BlockType::Empty => Ok(crate::BlockType::Empty),
             wasmparser::BlockType::FuncType(n) => {
-                Ok(crate::BlockType::FunctionType(reencoder.type_index(n)))
+                Ok(crate::BlockType::FunctionType(reencoder.type_index(n)?))
             }
             wasmparser::BlockType::Type(t) => Ok(crate::BlockType::Result(reencoder.val_type(t)?)),
         }
@@ -1613,25 +1643,25 @@ pub mod utils {
             // This case is used to map, based on the name of the field, from the
             // wasmparser payload type to the wasm-encoder payload type through
             // `Translator` as applicable.
-            (map $arg:ident tag_index) => (reencoder.tag_index($arg));
-            (map $arg:ident function_index) => (reencoder.function_index($arg));
-            (map $arg:ident table) => (reencoder.table_index($arg));
-            (map $arg:ident table_index) => (reencoder.table_index($arg));
-            (map $arg:ident dst_table) => (reencoder.table_index($arg));
-            (map $arg:ident src_table) => (reencoder.table_index($arg));
-            (map $arg:ident type_index) => (reencoder.type_index($arg));
-            (map $arg:ident array_type_index) => (reencoder.type_index($arg));
-            (map $arg:ident array_type_index_dst) => (reencoder.type_index($arg));
-            (map $arg:ident array_type_index_src) => (reencoder.type_index($arg));
-            (map $arg:ident struct_type_index) => (reencoder.type_index($arg));
-            (map $arg:ident global_index) => (reencoder.global_index($arg));
-            (map $arg:ident mem) => (reencoder.memory_index($arg));
-            (map $arg:ident src_mem) => (reencoder.memory_index($arg));
-            (map $arg:ident dst_mem) => (reencoder.memory_index($arg));
-            (map $arg:ident data_index) => (reencoder.data_index($arg));
-            (map $arg:ident elem_index) => (reencoder.element_index($arg));
-            (map $arg:ident array_data_index) => (reencoder.data_index($arg));
-            (map $arg:ident array_elem_index) => (reencoder.element_index($arg));
+            (map $arg:ident tag_index) => (reencoder.tag_index($arg)?);
+            (map $arg:ident function_index) => (reencoder.function_index($arg)?);
+            (map $arg:ident table) => (reencoder.table_index($arg)?);
+            (map $arg:ident table_index) => (reencoder.table_index($arg)?);
+            (map $arg:ident dst_table) => (reencoder.table_index($arg)?);
+            (map $arg:ident src_table) => (reencoder.table_index($arg)?);
+            (map $arg:ident type_index) => (reencoder.type_index($arg)?);
+            (map $arg:ident array_type_index) => (reencoder.type_index($arg)?);
+            (map $arg:ident array_type_index_dst) => (reencoder.type_index($arg)?);
+            (map $arg:ident array_type_index_src) => (reencoder.type_index($arg)?);
+            (map $arg:ident struct_type_index) => (reencoder.type_index($arg)?);
+            (map $arg:ident global_index) => (reencoder.global_index($arg)?);
+            (map $arg:ident mem) => (reencoder.memory_index($arg)?);
+            (map $arg:ident src_mem) => (reencoder.memory_index($arg)?);
+            (map $arg:ident dst_mem) => (reencoder.memory_index($arg)?);
+            (map $arg:ident data_index) => (reencoder.data_index($arg)?);
+            (map $arg:ident elem_index) => (reencoder.element_index($arg)?);
+            (map $arg:ident array_data_index) => (reencoder.data_index($arg)?);
+            (map $arg:ident array_elem_index) => (reencoder.element_index($arg)?);
             (map $arg:ident blockty) => (reencoder.block_type($arg)?);
             (map $arg:ident relative_depth) => ($arg);
             (map $arg:ident targets) => ((
@@ -1646,8 +1676,8 @@ pub mod utils {
             (map $arg:ident hty) => (reencoder.heap_type($arg)?);
             (map $arg:ident from_ref_type) => (reencoder.ref_type($arg)?);
             (map $arg:ident to_ref_type) => (reencoder.ref_type($arg)?);
-            (map $arg:ident memarg) => (reencoder.mem_arg($arg));
-            (map $arg:ident ordering) => (reencoder.ordering($arg));
+            (map $arg:ident memarg) => (reencoder.mem_arg($arg)?);
+            (map $arg:ident ordering) => (reencoder.ordering($arg)?);
             (map $arg:ident local_index) => ($arg);
             (map $arg:ident value) => ($arg);
             (map $arg:ident lane) => ($arg);
@@ -1655,11 +1685,14 @@ pub mod utils {
             (map $arg:ident array_size) => ($arg);
             (map $arg:ident field_index) => ($arg);
             (map $arg:ident try_table) => ($arg);
-            (map $arg:ident argument_index) => (reencoder.type_index($arg));
-            (map $arg:ident result_index) => (reencoder.type_index($arg));
-            (map $arg:ident cont_type_index) => (reencoder.type_index($arg));
+            (map $arg:ident argument_index) => (reencoder.type_index($arg)?);
+            (map $arg:ident result_index) => (reencoder.type_index($arg)?);
+            (map $arg:ident cont_type_index) => (reencoder.type_index($arg)?);
             (map $arg:ident resume_table) => ((
-                $arg.handlers.into_iter().map(|h| reencoder.handle(h)).collect::<Vec<_>>().into()
+                $arg.handlers.into_iter()
+                    .map(|h| reencoder.handle(h))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into()
             ));
 
             // This case takes the arguments of a wasmparser instruction and creates
@@ -1675,7 +1708,10 @@ pub mod utils {
             (build F64Const $arg:ident) => (Instruction::F64Const($arg.into()));
             (build V128Const $arg:ident) => (Instruction::V128Const($arg.i128()));
             (build TryTable $table:ident) => (Instruction::TryTable(reencoder.block_type($table.ty)?, {
-                $table.catches.into_iter().map(|c| reencoder.catch(c)).collect::<Vec<_>>().into()
+                $table.catches.into_iter()
+                    .map(|c| reencoder.catch(c))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into()
             }));
             (build $op:ident $arg:ident) => (Instruction::$op($arg));
             (build $op:ident $($arg:ident)*) => (Instruction::$op { $($arg),* });
@@ -1805,26 +1841,29 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn name_map(
+    pub fn name_map<E>(
         map: wasmparser::NameMap<'_>,
-        mut map_index: impl FnMut(u32) -> u32,
-    ) -> wasmparser::Result<crate::NameMap> {
+        mut map_index: impl FnMut(u32) -> Result<u32, Error<E>>,
+    ) -> Result<crate::NameMap, Error<E>> {
         let mut ret = crate::NameMap::new();
         for naming in map {
             let naming = naming?;
-            ret.append(map_index(naming.index), naming.name);
+            ret.append(map_index(naming.index)?, naming.name);
         }
         Ok(ret)
     }
 
-    pub fn indirect_name_map(
+    pub fn indirect_name_map<E>(
         map: wasmparser::IndirectNameMap<'_>,
-        mut map_index: impl FnMut(u32) -> u32,
-    ) -> wasmparser::Result<crate::IndirectNameMap> {
+        mut map_index: impl FnMut(u32) -> Result<u32, Error<E>>,
+    ) -> Result<crate::IndirectNameMap, Error<E>> {
         let mut ret = crate::IndirectNameMap::new();
         for naming in map {
             let naming = naming?;
-            ret.append(map_index(naming.index), &name_map(naming.names, |i| i)?);
+            ret.append(
+                map_index(naming.index)?,
+                &name_map(naming.names, |i| Ok(i))?,
+            );
         }
         Ok(ret)
     }
@@ -1832,25 +1871,26 @@ pub mod utils {
 
 impl From<wasmparser::Ieee32> for crate::Ieee32 {
     fn from(arg: wasmparser::Ieee32) -> Self {
-        RoundtripReencoder.ieee32_arg(arg)
+        utils::ieee32_arg(&mut RoundtripReencoder, arg)
     }
 }
 
 impl From<wasmparser::Ieee64> for crate::Ieee64 {
     fn from(arg: wasmparser::Ieee64) -> Self {
-        RoundtripReencoder.ieee64_arg(arg)
+        utils::ieee64_arg(&mut RoundtripReencoder, arg)
     }
 }
 
-impl From<wasmparser::MemArg> for crate::MemArg {
-    fn from(arg: wasmparser::MemArg) -> Self {
+impl TryFrom<wasmparser::MemArg> for crate::MemArg {
+    type Error = Error;
+    fn try_from(arg: wasmparser::MemArg) -> Result<Self, Self::Error> {
         RoundtripReencoder.mem_arg(arg)
     }
 }
 
 impl From<wasmparser::Ordering> for crate::Ordering {
     fn from(arg: wasmparser::Ordering) -> Self {
-        RoundtripReencoder.ordering(arg)
+        utils::ordering(&mut RoundtripReencoder, arg)
     }
 }
 
@@ -1870,8 +1910,10 @@ impl<'a> TryFrom<wasmparser::Operator<'a>> for crate::Instruction<'a> {
     }
 }
 
-impl From<wasmparser::Catch> for crate::Catch {
-    fn from(arg: wasmparser::Catch) -> Self {
+impl TryFrom<wasmparser::Catch> for crate::Catch {
+    type Error = Error;
+
+    fn try_from(arg: wasmparser::Catch) -> Result<Self, Self::Error> {
         RoundtripReencoder.catch(arg)
     }
 }
@@ -1886,13 +1928,13 @@ impl<'a> TryFrom<wasmparser::ConstExpr<'a>> for crate::ConstExpr {
 
 impl<'a> From<wasmparser::CustomSectionReader<'a>> for crate::CustomSection<'a> {
     fn from(section: wasmparser::CustomSectionReader<'a>) -> Self {
-        RoundtripReencoder.custom_section(section)
+        utils::custom_section(&mut RoundtripReencoder, section)
     }
 }
 
 impl From<wasmparser::ExternalKind> for crate::ExportKind {
     fn from(external_kind: wasmparser::ExternalKind) -> Self {
-        RoundtripReencoder.export_kind(external_kind)
+        utils::export_kind(&mut RoundtripReencoder, external_kind)
     }
 }
 
@@ -1904,8 +1946,9 @@ impl TryFrom<wasmparser::GlobalType> for crate::GlobalType {
     }
 }
 
-impl From<wasmparser::Handle> for crate::Handle {
-    fn from(arg: wasmparser::Handle) -> Self {
+impl TryFrom<wasmparser::Handle> for crate::Handle {
+    type Error = Error;
+    fn try_from(arg: wasmparser::Handle) -> Result<Self, Self::Error> {
         RoundtripReencoder.handle(arg)
     }
 }
@@ -1920,7 +1963,7 @@ impl TryFrom<wasmparser::TypeRef> for crate::EntityType {
 
 impl From<wasmparser::MemoryType> for crate::MemoryType {
     fn from(memory_ty: wasmparser::MemoryType) -> Self {
-        RoundtripReencoder.memory_type(memory_ty)
+        utils::memory_type(&mut RoundtripReencoder, memory_ty)
     }
 }
 
@@ -1934,12 +1977,13 @@ impl TryFrom<wasmparser::TableType> for crate::TableType {
 
 impl From<wasmparser::TagKind> for crate::TagKind {
     fn from(kind: wasmparser::TagKind) -> Self {
-        RoundtripReencoder.tag_kind(kind)
+        utils::tag_kind(&mut RoundtripReencoder, kind)
     }
 }
 
-impl From<wasmparser::TagType> for crate::TagType {
-    fn from(tag_ty: wasmparser::TagType) -> Self {
+impl TryFrom<wasmparser::TagType> for crate::TagType {
+    type Error = Error;
+    fn try_from(tag_ty: wasmparser::TagType) -> Result<Self, Self::Error> {
         RoundtripReencoder.tag_type(tag_ty)
     }
 }
@@ -2026,6 +2070,6 @@ impl TryFrom<wasmparser::HeapType> for crate::HeapType {
 
 impl From<wasmparser::AbstractHeapType> for crate::AbstractHeapType {
     fn from(value: wasmparser::AbstractHeapType) -> Self {
-        RoundtripReencoder.abstract_heap_type(value)
+        utils::abstract_heap_type(&mut RoundtripReencoder, value)
     }
 }

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -40,14 +40,14 @@ impl<'cfg, 'wasm> Reencode for InitTranslator<'cfg, 'wasm> {
 
     /// Handle `elem`s with values of the `ElementItem::Func` kind. This function will not be
     /// called for values of the `ElementItem::Expr` kind.
-    fn function_index(&mut self, idx: u32) -> u32 {
+    fn function_index(&mut self, idx: u32) -> ReencodeResult<u32> {
         if self.kind != ConstExpressionMutator::ElementFunc || !self.should_process() {
-            return idx;
+            return Ok(idx);
         }
 
         log::trace!("... replacing referenced function index with 0");
         // FIXME: generate random function indices when `!config.reduce`.
-        0
+        Ok(0)
     }
 
     /// Handle `global` initializers and `elem`s with values of the `ElementItem::Expr` kind.

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -538,10 +538,10 @@ impl<'a> Module<'a> {
             let ty = map.memory_type(mem.ty);
             match &mem.def {
                 Definition::Import(m, n) => {
-                    imports.import(m, n, ty);
+                    imports.import(m, n, ty?);
                 }
                 Definition::Local(()) => {
-                    memories.memory(ty);
+                    memories.memory(ty?);
                 }
             }
             num_memories += 1;
@@ -1030,23 +1030,25 @@ struct Encoder {
     tables: Remap,
 }
 
+type ReencodeResult<T> = Result<T, wasm_encoder::reencode::Error<Infallible>>;
+
 impl Reencode for Encoder {
     type Error = Infallible;
 
-    fn type_index(&mut self, i: u32) -> u32 {
-        self.types.remap(i)
+    fn type_index(&mut self, i: u32) -> ReencodeResult<u32> {
+        Ok(self.types.remap(i))
     }
-    fn function_index(&mut self, i: u32) -> u32 {
-        self.funcs.remap(i)
+    fn function_index(&mut self, i: u32) -> ReencodeResult<u32> {
+        Ok(self.funcs.remap(i))
     }
-    fn memory_index(&mut self, i: u32) -> u32 {
-        self.memories.remap(i)
+    fn memory_index(&mut self, i: u32) -> ReencodeResult<u32> {
+        Ok(self.memories.remap(i))
     }
-    fn global_index(&mut self, i: u32) -> u32 {
-        self.globals.remap(i)
+    fn global_index(&mut self, i: u32) -> ReencodeResult<u32> {
+        Ok(self.globals.remap(i))
     }
-    fn table_index(&mut self, i: u32) -> u32 {
-        self.tables.remap(i)
+    fn table_index(&mut self, i: u32) -> ReencodeResult<u32> {
+        Ok(self.tables.remap(i))
     }
 }
 

--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -171,8 +171,8 @@ struct RemoveImports<'a, 'b> {
 impl Reencode for RemoveImports<'_, '_> {
     type Error = std::convert::Infallible;
 
-    fn function_index(&mut self, idx: u32) -> u32 {
-        idx - self.removed_funcs
+    fn function_index(&mut self, idx: u32) -> Result<u32, reencode::Error<Self::Error>> {
+        Ok(idx - self.removed_funcs)
     }
 
     fn parse_import(

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -1273,12 +1273,12 @@ struct ModuleExtractor<'a> {
 impl Reencode for ModuleExtractor<'_> {
     type Error = std::convert::Infallible;
 
-    fn type_index(&mut self, index: u32) -> u32 {
-        if self.depth == 0 {
+    fn type_index(&mut self, index: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(if self.depth == 0 {
             index + self.extra_core_types
         } else {
             index
-        }
+        })
     }
 }
 
@@ -1291,12 +1291,12 @@ impl ReencodeComponent for ModuleExtractor<'_> {
         }
     }
 
-    fn outer_type_index(&mut self, count: u32, index: u32) -> u32 {
-        if self.depth == count {
+    fn outer_type_index(&mut self, count: u32, index: u32) -> Result<u32, Error<Self::Error>> {
+        Ok(if self.depth == count {
             index + self.extra_core_types
         } else {
             index
-        }
+        })
     }
 
     fn outer_module_index(&mut self, count: u32, index: u32) -> u32 {


### PR DESCRIPTION
I have found myself wanting to return an error from `Reencode::type_index`. This is admittedly a pretty invasive change though and I punted on component stuff.

Thoughts?