### PR TITLE
Fix expanding `task.return` types in text parsing

### DIFF
--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -264,11 +264,14 @@ impl<'a> Expander<'a> {
             CanonicalFuncKind::Lift { ty, .. } => {
                 self.expand_component_type_use(ty);
             }
-            CanonicalFuncKind::Core(_) => {}
+            CanonicalFuncKind::Core(func) => {
+                self.expand_core_func_kind(func);
+            }
         }
     }
 
-    fn expand_core_func(&mut self, func: CoreFunc<'a>) -> ComponentField<'a> {
+    fn expand_core_func(&mut self, mut func: CoreFunc<'a>) -> ComponentField<'a> {
+        self.expand_core_func_kind(&mut func.kind);
         match func.kind {
             CoreFuncKind::Alias(a) => ComponentField::Alias(Alias {
                 span: func.span,
@@ -286,6 +289,19 @@ impl<'a> Expander<'a> {
                 name: func.name,
                 kind: CanonicalFuncKind::Core(other),
             }),
+        }
+    }
+
+    fn expand_core_func_kind(&mut self, func: &mut CoreFuncKind<'a>) {
+        match func {
+            CoreFuncKind::TaskReturn(f) => {
+                if let Some(ty) = &mut f.result {
+                    self.expand_component_val_ty(ty);
+                }
+            }
+
+            // Other core funcs don't need expansion at this time
+            _ => {}
         }
     }
 

--- a/tests/cli/component-model-async/task-builtins.wast
+++ b/tests/cli/component-model-async/task-builtins.wast
@@ -385,3 +385,7 @@
   (core func (canon context.set i32 0))
   (canon context.set i32 0 (core func))
 )
+
+(component
+  (canon task.return (result (stream u8)) (core func))
+)

--- a/tests/snapshots/cli/component-model-async/task-builtins.wast.json
+++ b/tests/snapshots/cli/component-model-async/task-builtins.wast.json
@@ -245,6 +245,12 @@
       "line": 318,
       "filename": "task-builtins.36.wasm",
       "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 389,
+      "filename": "task-builtins.37.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model-async/task-builtins.wast/37.print
+++ b/tests/snapshots/cli/component-model-async/task-builtins.wast/37.print
@@ -1,0 +1,4 @@
+(component
+  (type (;0;) (stream u8))
+  (core func (;0;) (canon task.return (result 0)))
+)


### PR DESCRIPTION
Closes #2188