### PR TITLE
Add ability to detect name clashes on includes in wit-smith

### DIFF
--- a/crates/wit-smith/src/lib.rs
+++ b/crates/wit-smith/src/lib.rs
@@ -29,6 +29,7 @@ pub fn smith(config: &Config, u: &mut Unstructured<'_>) -> Result<Vec<u8>> {
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
                 if e.to_string().contains("shadows previously") {
+                    log::error!("{e}");
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
                 panic!("bad wit parse: {e:?}")


### PR DESCRIPTION
fixes: #2191 

This PR adds the ability to detect name clashes on includes by tracking names in each world/package combination.  It doesn't catch every edge case but I found that it is successful more often than without some type of tracking of the world names for includes.  As mentioned in the linked issue not catching every edge case in generation is fine.

