### PR TITLE
Revise MSRV policy for this repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,22 @@ allow_attributes_without_reason = 'warn'
 edition = '2021'
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 version = "0.231.0"
-# Current policy for wasm-tools is the same as Wasmtime which is that this
-# number can be no larger than the current stable release of Rust minus 2.
+# Current thinking for wasm-tools is that the minimum supported Rust version
+# (MSRV), or this number here, is no larger than the current stable release of
+# Rust minus 10. This is more conservative than Wasmtime's policy which is
+# stable minus two and is due to the nature of this repository and how the
+# crates are expected to be used in more situations and places than Wasmtime.
+#
+# Note that this number is not proactively updated whenever a new release of
+# Rust comes out. Instead if you run into this, for example a PR on CI is
+# failing due to needing a newer feature of Rust, you're welcome to update this
+# at any time so longer that it's no greater than the current release of Rust
+# minus 10.
+#
+# If this window is too restrictive please leave a comment on your PR or send a
+# message to wasm-tools maintainers to discuss. In some cases it's possible to
+# add version detection to build scripts but in other cases this may not be
+# reasonable to expect.
 #
 # NB: if this number increases to 1.81-or-later delete
 # `crates/wasmparser/build.rs` and `crates/wasm-encoder/build.rs` scripts


### PR DESCRIPTION
In writing the current policy for this repository's minimum supported version of Rust (MSRV) is "stable minus two" which matches Wasmtime. This does not reflect the current reality, however, where the current MSRV is 1.76 where the current Rust is 1.87. This additionally does not reflect what I think is the best decision for this repository. While "stable minus two" matches Wasmtime this repository is expected to be possibly used in more contexts than Wasmtime, for example any wasm-processing tools which can be lower-level than anything needing a wasm runtime.

Given all this the change here is to update the comments on MSRV policy for this repository to "stable minus 10, not proactively updated". That is a much larger window of Rust but the code in this repository is much less likely than Wasmtime, for example, to benefit from newer features of Rust. The hope is that this won't be too onerous to maintain while still allowing to eventually use newer features as necessary.