### PR TITLE
Turn on new WIT metadata format by default

### DIFF
--- a/crates/wit-parser/src/metadata.rs
+++ b/crates/wit-parser/src/metadata.rs
@@ -43,7 +43,7 @@ const PACKAGE_DOCS_SECTION_VERSION: u8 = 1;
 /// tools we'll still try to emit the v0 format by default, if the input is
 /// compatible. This will be turned off in the future once enough published
 /// versions support the v1 format.
-const TRY_TO_EMIT_V0_BY_DEFAULT: bool = true;
+const TRY_TO_EMIT_V0_BY_DEFAULT: bool = false;
 
 /// Represents serializable doc comments parsed from a WIT package.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This commit is a follow-up to #1508 where a new JSON format was added for storing docs/stability and accounting for world imports/exports allowing overlap. This support should have permeated far enough that it's reasonable to turn this on-by-default now.

This additionally fixes fuzz bugs cropping up after adding support for stability annotations in the generated WIT, the other motivation for this.