### PR TITLE
Relax the block check in `OperatorsReader<'_>`

### DIFF
--- a/ci/generate-spec-tests.rs
+++ b/ci/generate-spec-tests.rs
@@ -44,9 +44,19 @@ fn copy_test(src: &Path, dst: &Path) {
     contents.push_str(";;      --assert default \\\n");
 
     // Allow certain assert_malformed tests to be interpreted as assert_invalid
-    if src.ends_with("binary.wast") || src.ends_with("global.wast") || src.ends_with("select.wast")
+    if src.ends_with("binary.wast")
+        || src.ends_with("global.wast")
+        || src.ends_with("select.wast")
+        || src.ends_with("try_table.wast")
     {
         contents.push_str(";;      --assert permissive \\\n");
+    }
+
+    // For this test it has legacy instructions which, for roundabout reasons,
+    // are attempted to be printed in the folded format but that doesn't work.
+    // Exclude this test for now.
+    if src.ends_with("try_table.wast") {
+        contents.push_str(";;      --assert no-test-folded \\\n");
     }
 
     contents.push_str(";;      --snapshot tests/snapshots \\\n");

--- a/src/bin/wasm-tools/wast.rs
+++ b/src/bin/wasm-tools/wast.rs
@@ -251,6 +251,12 @@ impl Opts {
                     // two error messages are swapped to `assert_invalid`.
                     "malformed mutability",
                     "integer too large",
+                    // The upstream specification requires that the legacy
+                    // exceptions proposal is textually invalid (e.g.
+                    // `assert_malformed`). This crate supports it though as
+                    // "just another proposal", so it's not malformed but it's
+                    // invalid.
+                    "unexpected token",
                 ];
                 if self.assert(Assert::Permissive) && permissive_error_messages.contains(&message) {
                     return self.test_wast_directive(

--- a/tests/cli/invalid.wast
+++ b/tests/cli/invalid.wast
@@ -1,4 +1,4 @@
-;; RUN: wast --assert default --snapshot tests/snapshots %
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots %
 
 (assert_invalid
   (module
@@ -6,7 +6,7 @@
     (func table.init 0 100))
   "unknown elem segment")
 
-(assert_malformed
+(assert_invalid
   (module
     (func else))
-  "`else` found outside `If` block")
+  "else found outside of an `if` block ")

--- a/tests/cli/legacy-exceptions/disabled.wast
+++ b/tests/cli/legacy-exceptions/disabled.wast
@@ -1,0 +1,13 @@
+;; RUN: wast %
+
+(assert_invalid
+  (module (func try end))
+  "legacy exceptions support is not enabled")
+
+(assert_invalid
+  (module (func catch 0))
+  "legacy exceptions support is not enabled")
+
+(assert_invalid
+  (module (func catch_all))
+  "legacy exceptions support is not enabled")

--- a/tests/cli/print-no-panic-dangling-else.wat
+++ b/tests/cli/print-no-panic-dangling-else.wat
@@ -1,4 +1,4 @@
-;; FAIL: print %
+;; RUN: print %
 
 (module
     (func else)

--- a/tests/cli/print-no-panic-dangling-else.wat.stderr
+++ b/tests/cli/print-no-panic-dangling-else.wat.stderr
@@ -1,1 +1,0 @@
-error: `else` found outside `If` block (at offset 0x18)

--- a/tests/cli/print-no-panic-dangling-else.wat.stdout
+++ b/tests/cli/print-no-panic-dangling-else.wat.stdout
@@ -1,3 +1,6 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
+  else
+  )
+)

--- a/tests/cli/spec/proposals/exception-handling/try_table.wast
+++ b/tests/cli/spec/proposals/exception-handling/try_table.wast
@@ -1,5 +1,7 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
+;;      --assert no-test-folded \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm2,exceptions,tail-call \

--- a/tests/cli/spec/proposals/wasm-3.0/try_table.wast
+++ b/tests/cli/spec/proposals/wasm-3.0/try_table.wast
@@ -1,5 +1,7 @@
 ;; RUN: wast \
 ;;      --assert default \
+;;      --assert permissive \
+;;      --assert no-test-folded \
 ;;      --snapshot tests/snapshots \
 ;;      --ignore-error-messages \
 ;;      --features=wasm3 \

--- a/tests/snapshots/cli/invalid.wast.json
+++ b/tests/snapshots/cli/invalid.wast.json
@@ -9,11 +9,11 @@
       "text": "unknown elem segment"
     },
     {
-      "type": "assert_malformed",
+      "type": "assert_invalid",
       "line": 10,
       "filename": "invalid.1.wasm",
       "module_type": "binary",
-      "text": "`else` found outside `If` block"
+      "text": "else found outside of an `if` block "
     }
   ]
 }


### PR DESCRIPTION
This commit relaxes a check added in #2134 which maintains a stack of frame kinds in the operators reader, in addition to the validator. The goal of #2134 was to ensure that spec-wise-syntactically-invalid-modules are caught in the parser without the need of the validator, but investigation in #2180 has shown that this is a source of at least some of a performance regression. The change here is to relax the check to still be able to pass spec tests while making such infrastructure cheaper.

The reader now maintains just a small `depth: u32` counter instead of a stack of kinds. This means that the reader can still catch invalid modules such as instructions-after-`end`, but the validator is required to handle situations such as `else` outside of an `if` block.

This required some adjustments to tests as well as some workarounds for the upstream spec tests that assert legacy exception-handling instructions are malformed, not invalid.