### PR TITLE
wasmparser: avoid skipping locals to get OperatorsReader for a function body

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -157,10 +157,11 @@ fn read_all_wasm(wasm: &[u8]) -> Result<()> {
                 }
             }
             CodeSectionEntry(body) => {
-                for item in body.get_locals_reader()? {
+                let mut locals = body.get_locals_reader()?.into_iter();
+                for item in locals.by_ref() {
                     let _ = item?;
                 }
-                let mut ops = body.get_operators_reader()?;
+                let mut ops = locals.into_operators_reader();
                 while !ops.eof() {
                     ops.visit_operator(&mut NopVisit)?;
                 }

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -266,7 +266,7 @@ impl<'a> Dump<'a> {
                         write!(self.state, "{amt} locals of type {ty:?}")?;
                         self.print(locals.original_position())?;
                     }
-                    self.print_ops(body.get_operators_reader()?)?;
+                    self.print_ops(OperatorsReader::new(locals.get_binary_reader()))?;
                 }
 
                 // Component sections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,10 +317,11 @@ pub fn parse_binary_wasm(parser: wasmparser::Parser, bytes: &[u8]) -> Result<()>
             wasmparser::Payload::ElementSection(s) => parse_section(s)?,
             wasmparser::Payload::DataSection(s) => parse_section(s)?,
             wasmparser::Payload::CodeSectionEntry(body) => {
-                for item in body.get_locals_reader()? {
+                let mut locals = body.get_locals_reader()?.into_iter();
+                for item in locals.by_ref() {
                     let _ = item?;
                 }
-                let mut ops = body.get_operators_reader()?;
+                let mut ops = locals.into_operators_reader();
                 while !ops.eof() {
                     ops.read()?;
                 }


### PR DESCRIPTION
This PR lets users turn a finished LocalsReader into an OperatorsReader, avoiding a need to ask the FunctionBody to skip through the locals again (as suggested at https://github.com/bytecodealliance/wasm-tools/issues/2180#issuecomment-2894881384 -- @alexcrichton if you prefer a different/better way to do this please feel free to ignore this one!).

This seems to yield roughly a 3-4.5% improvement in the `parse/tests`, `parse/bz2`, `parse/spidermonkey`, etc. benchmarks.

The validator was already doing this (https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasmparser/src/validator/func.rs#L82-L87) and is unchanged by this PR, so I didn't expect this to affect validation time -- although I am seeing a ~1.5-2% slowdown in the validate tests for reasons unknown (hopefully just random variation from how this is being compiled).