### PR TITLE
Ignore another error during WIT generation

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -23,7 +23,7 @@ use crate::mutators::{
     modify_const_exprs::ConstExpressionMutator, modify_data::ModifyDataMutator,
     peephole::PeepholeMutator, remove_export::RemoveExportMutator, remove_item::RemoveItemMutator,
     remove_section::RemoveSection, rename_export::RenameExportMutator, snip_function::SnipMutator,
-    Item,
+    start::RemoveStartSection, Item,
 };
 use info::ModuleInfo;
 use mutators::Mutator;
@@ -237,6 +237,7 @@ impl<'wasm> WasmMutate<'wasm> {
             &ModifyDataMutator {
                 max_data_size: 10 << 20, // 10MB
             },
+            &RemoveStartSection,
         ];
 
         // Attempt all mutators, but start at an arbitrary index.

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -444,9 +444,9 @@ impl Mutator for PeepholeMutator {
     }
 }
 
-// This macro is meant to be used for testing deep mutators
-// It receives the original wat text variable, the expression returning the mutated function and the expected wat
-// For an example, look at SwapCommutativeOperator
+/// This macro is meant to be used for testing deep mutators
+/// It receives the original wat text variable, the expression returning the mutated function and the expected wat
+/// For an example, look at SwapCommutativeOperator
 #[cfg(test)]
 #[macro_export]
 macro_rules! match_code_mutation {

--- a/crates/wit-smith/src/lib.rs
+++ b/crates/wit-smith/src/lib.rs
@@ -30,7 +30,8 @@ pub fn smith(config: &Config, u: &mut Unstructured<'_>) -> Result<Vec<u8>> {
                 if e.is::<InvalidTransitiveDependency>() {
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
-                if e.to_string().contains("shadows previously") {
+                let err = e.to_string();
+                if err.contains("shadows previously") || err.contains("mismatch in stability") {
                     log::error!("{e}");
                     return Err(arbitrary::Error::IncorrectFormat);
                 }


### PR DESCRIPTION
This commit ignores errors generating documents such as:

    world a {
        @unstable(...)
        import foo;
    }

    world b {
        include a;
        @stable(...)
        import foo;
    }

This is relatively difficult to prevent so instead let's just throw out the test case.