### PR TITLE
wasmparser(CM+GC): Add support for lowering variants, options, and results to GC types

### DIFF
--- a/tests/cli/component-model-gc/option-types.wast
+++ b/tests/cli/component-model-gc/option-types.wast
@@ -1,0 +1,86 @@
+;; RUN: wast --assert default --snapshot tests/snapshots % -f gc,cm-gc
+
+;; Basic.
+(component
+  (type $opt (option u32))
+
+  (core type $opt (struct))
+  (core type $ty (func (param (ref $opt))))
+
+  (import "i" (instance $i
+                (export "ty" (type $opt' (eq $opt)))
+                (export "f" (func (param "x" $opt')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a nullable reference.
+(component
+  (type $opt (option u32))
+
+  (core type $opt (struct))
+  (core type $ty (func (param (ref null $opt))))
+
+  (import "i" (instance $i
+                (export "ty" (type $opt' (eq $opt)))
+                (export "f" (func (param "x" $opt')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom rec group.
+(component
+  (type $opt (option u32))
+
+  (core rec
+    (type $opt (struct))
+    (type $ty (func (param (ref $opt)))))
+
+  (import "i" (instance $i
+                (export "ty" (type $opt' (eq $opt)))
+                (export "f" (func (param "x" $opt')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom subtype.
+(component
+  (type $opt (option u32))
+
+  (core type $base (sub (struct)))
+  (core type $opt (sub $base (struct)))
+  (core type $ty (func (param (ref $opt))))
+
+  (import "i" (instance $i
+                (export "ty" (type $opt' (eq $opt)))
+                (export "f" (func (param "x" $opt')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; Unexpected field.
+(assert_invalid
+  (component
+    (type $opt (option u32))
+
+    (core type $opt (struct (field i32)))
+    (core type $ty (func (param (ref $opt))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $opt' (eq $opt)))
+                          (export "f" (func (param "x" $opt')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `option` type to core `(ref null? (struct))`"
+)
+
+;; Lowering into a non-struct.
+(assert_invalid
+  (component
+    (type $opt (option u32))
+
+    (core type $ty (func (param externref)))
+
+    (import "i" (instance $i
+                          (export "ty" (type $opt' (eq $opt)))
+                          (export "f" (func (param "x" $opt')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `option` type to core `(ref null? (struct))`"
+)

--- a/tests/cli/component-model-gc/result-types.wast
+++ b/tests/cli/component-model-gc/result-types.wast
@@ -1,0 +1,118 @@
+;; RUN: wast --assert default --snapshot tests/snapshots % -f gc,cm-gc
+
+;; Basic.
+(component
+  (type $result (result u32 (error u8)))
+
+  (core type $result (struct (field i8)))
+  (core type $ty (func (param (ref $result))))
+
+  (import "i" (instance $i
+                (export "ty" (type $result' (eq $result)))
+                (export "f" (func (param "x" $result')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a nullable reference.
+(component
+  (type $result (result u32 (error u8)))
+
+  (core type $result (struct (field i8)))
+  (core type $ty (func (param (ref null $result))))
+
+  (import "i" (instance $i
+                (export "ty" (type $result' (eq $result)))
+                (export "f" (func (param "x" $result')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom rec group.
+(component
+  (type $result (result u32 (error u8)))
+
+  (core rec
+    (type $result (struct (field i8)))
+    (type $ty (func (param (ref null $result)))))
+
+  (import "i" (instance $i
+                (export "ty" (type $result' (eq $result)))
+                (export "f" (func (param "x" $result')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom subtype.
+(component
+  (type $result (result u32 (error u8)))
+
+  (core type $base (sub (struct)))
+  (core type $result (sub $base (struct (field i8))))
+  (core type $ty (func (param (ref null $result))))
+
+  (import "i" (instance $i
+                (export "ty" (type $result' (eq $result)))
+                (export "f" (func (param "x" $result')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; Missing discriminant.
+(assert_invalid
+  (component
+    (type $result (result u32 (error u8)))
+
+    (core type $result (struct))
+    (core type $ty (func (param (ref $result))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $result' (eq $result)))
+                          (export "f" (func (param "x" $result')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+)
+
+;; Wrong type for discriminant.
+(assert_invalid
+  (component
+    (type $result (result u32 (error u8)))
+
+    (core type $result (struct (field i32)))
+    (core type $ty (func (param (ref $result))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $result' (eq $result)))
+                          (export "f" (func (param "x" $result')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+)
+
+;; Additional fields after discriminant.
+(assert_invalid
+  (component
+    (type $result (result u32 (error u8)))
+
+    (core type $result (struct (field i8) (field i8)))
+    (core type $ty (func (param (ref $result))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $result' (eq $result)))
+                          (export "f" (func (param "x" $result')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+)
+
+;; Lowering into a non-struct.
+(assert_invalid
+  (component
+    (type $result (result u32 (error u8)))
+
+    (core type $ty (func (param externref)))
+
+    (import "i" (instance $i
+                          (export "ty" (type $result' (eq $result)))
+                          (export "f" (func (param "x" $result')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+)

--- a/tests/cli/component-model-gc/result-types.wast
+++ b/tests/cli/component-model-gc/result-types.wast
@@ -4,7 +4,7 @@
 (component
   (type $result (result u32 (error u8)))
 
-  (core type $result (struct (field i8)))
+  (core type $result (struct))
   (core type $ty (func (param (ref $result))))
 
   (import "i" (instance $i
@@ -17,7 +17,7 @@
 (component
   (type $result (result u32 (error u8)))
 
-  (core type $result (struct (field i8)))
+  (core type $result (struct))
   (core type $ty (func (param (ref null $result))))
 
   (import "i" (instance $i
@@ -31,7 +31,7 @@
   (type $result (result u32 (error u8)))
 
   (core rec
-    (type $result (struct (field i8)))
+    (type $result (struct))
     (type $ty (func (param (ref null $result)))))
 
   (import "i" (instance $i
@@ -45,7 +45,7 @@
   (type $result (result u32 (error u8)))
 
   (core type $base (sub (struct)))
-  (core type $result (sub $base (struct (field i8))))
+  (core type $result (sub $base (struct)))
   (core type $ty (func (param (ref null $result))))
 
   (import "i" (instance $i
@@ -54,39 +54,7 @@
   (core func (canon lower (func $i "f") gc (core-type $ty)))
 )
 
-;; Missing discriminant.
-(assert_invalid
-  (component
-    (type $result (result u32 (error u8)))
-
-    (core type $result (struct))
-    (core type $ty (func (param (ref $result))))
-
-    (import "i" (instance $i
-                          (export "ty" (type $result' (eq $result)))
-                          (export "f" (func (param "x" $result')))))
-    (core func (canon lower (func $i "f") gc (core-type $ty)))
-  )
-  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
-)
-
-;; Wrong type for discriminant.
-(assert_invalid
-  (component
-    (type $result (result u32 (error u8)))
-
-    (core type $result (struct (field i32)))
-    (core type $ty (func (param (ref $result))))
-
-    (import "i" (instance $i
-                          (export "ty" (type $result' (eq $result)))
-                          (export "f" (func (param "x" $result')))))
-    (core func (canon lower (func $i "f") gc (core-type $ty)))
-  )
-  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
-)
-
-;; Additional fields after discriminant.
+;; Unexpected fields in struct type.
 (assert_invalid
   (component
     (type $result (result u32 (error u8)))
@@ -99,7 +67,7 @@
                           (export "f" (func (param "x" $result')))))
     (core func (canon lower (func $i "f") gc (core-type $ty)))
   )
-  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+  "expected to lower component `result` type to core `(ref null? (struct))`"
 )
 
 ;; Lowering into a non-struct.
@@ -114,5 +82,5 @@
                           (export "f" (func (param "x" $result')))))
     (core func (canon lower (func $i "f") gc (core-type $ty)))
   )
-  "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+  "expected to lower component `result` type to core `(ref null? (struct))`"
 )

--- a/tests/cli/component-model-gc/variant-types.wast
+++ b/tests/cli/component-model-gc/variant-types.wast
@@ -6,7 +6,7 @@
                           (case "b" bool)
                           (case "c" u8)))
 
-  (core type $variant (struct (field i32)))
+  (core type $variant (struct))
   (core type $ty (func (param (ref $variant))))
 
   (import "i" (instance $i
@@ -21,7 +21,7 @@
                           (case "b" bool)
                           (case "c" u8)))
 
-  (core type $variant (struct (field i32)))
+  (core type $variant (struct))
   (core type $ty (func (param (ref null $variant))))
 
   (import "i" (instance $i
@@ -37,7 +37,7 @@
                           (case "c" u8)))
 
   (core rec
-    (type $variant (struct (field i32)))
+    (type $variant (struct))
     (type $ty (func (param (ref null $variant)))))
 
   (import "i" (instance $i
@@ -53,7 +53,7 @@
                           (case "c" u8)))
 
   (core type $base (sub (struct)))
-  (core type $variant (sub $base (struct (field i32))))
+  (core type $variant (sub $base (struct)))
   (core type $ty (func (param (ref null $variant))))
 
   (import "i" (instance $i
@@ -62,25 +62,7 @@
   (core func (canon lower (func $i "f") gc (core-type $ty)))
 )
 
-;; Missing discriminant.
-(assert_invalid
-  (component
-    (type $variant (variant (case "a" bool)
-                            (case "b" bool)
-                            (case "c" u8)))
-
-    (core type $variant (struct))
-    (core type $ty (func (param (ref $variant))))
-
-    (import "i" (instance $i
-                          (export "ty" (type $variant' (eq $variant)))
-                          (export "f" (func (param "x" $variant')))))
-    (core func (canon lower (func $i "f") gc (core-type $ty)))
-  )
-  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
-)
-
-;; Wrong type for discriminant.
+;; Unexpected field in struct.
 (assert_invalid
   (component
     (type $variant (variant (case "a" bool)
@@ -95,25 +77,7 @@
                           (export "f" (func (param "x" $variant')))))
     (core func (canon lower (func $i "f") gc (core-type $ty)))
   )
-  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
-)
-
-;; Additional fields after discriminant.
-(assert_invalid
-  (component
-    (type $variant (variant (case "a" bool)
-                            (case "b" bool)
-                            (case "c" u8)))
-
-    (core type $variant (struct (field i32) (field i32)))
-    (core type $ty (func (param (ref $variant))))
-
-    (import "i" (instance $i
-                          (export "ty" (type $variant' (eq $variant)))
-                          (export "f" (func (param "x" $variant')))))
-    (core func (canon lower (func $i "f") gc (core-type $ty)))
-  )
-  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+  "expected to lower component `variant` type to core `(ref null? (struct))`"
 )
 
 ;; Lowering into a non-struct.
@@ -130,5 +94,5 @@
                           (export "f" (func (param "x" $variant')))))
     (core func (canon lower (func $i "f") gc (core-type $ty)))
   )
-  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+  "expected to lower component `variant` type to core `(ref null? (struct))`"
 )

--- a/tests/cli/component-model-gc/variant-types.wast
+++ b/tests/cli/component-model-gc/variant-types.wast
@@ -1,0 +1,134 @@
+;; RUN: wast --assert default --snapshot tests/snapshots % -f gc,cm-gc
+
+;; Basic.
+(component
+  (type $variant (variant (case "a" bool)
+                          (case "b" bool)
+                          (case "c" u8)))
+
+  (core type $variant (struct (field i32)))
+  (core type $ty (func (param (ref $variant))))
+
+  (import "i" (instance $i
+                (export "ty" (type $variant' (eq $variant)))
+                (export "f" (func (param "x" $variant')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a nullable reference.
+(component
+  (type $variant (variant (case "a" bool)
+                          (case "b" bool)
+                          (case "c" u8)))
+
+  (core type $variant (struct (field i32)))
+  (core type $ty (func (param (ref null $variant))))
+
+  (import "i" (instance $i
+                (export "ty" (type $variant' (eq $variant)))
+                (export "f" (func (param "x" $variant')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom rec group.
+(component
+  (type $variant (variant (case "a" bool)
+                          (case "b" bool)
+                          (case "c" u8)))
+
+  (core rec
+    (type $variant (struct (field i32)))
+    (type $ty (func (param (ref null $variant)))))
+
+  (import "i" (instance $i
+                (export "ty" (type $variant' (eq $variant)))
+                (export "f" (func (param "x" $variant')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; With a custom subtype.
+(component
+  (type $variant (variant (case "a" bool)
+                          (case "b" bool)
+                          (case "c" u8)))
+
+  (core type $base (sub (struct)))
+  (core type $variant (sub $base (struct (field i32))))
+  (core type $ty (func (param (ref null $variant))))
+
+  (import "i" (instance $i
+                (export "ty" (type $variant' (eq $variant)))
+                (export "f" (func (param "x" $variant')))))
+  (core func (canon lower (func $i "f") gc (core-type $ty)))
+)
+
+;; Missing discriminant.
+(assert_invalid
+  (component
+    (type $variant (variant (case "a" bool)
+                            (case "b" bool)
+                            (case "c" u8)))
+
+    (core type $variant (struct))
+    (core type $ty (func (param (ref $variant))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $variant' (eq $variant)))
+                          (export "f" (func (param "x" $variant')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+)
+
+;; Wrong type for discriminant.
+(assert_invalid
+  (component
+    (type $variant (variant (case "a" bool)
+                            (case "b" bool)
+                            (case "c" u8)))
+
+    (core type $variant (struct (field i8)))
+    (core type $ty (func (param (ref $variant))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $variant' (eq $variant)))
+                          (export "f" (func (param "x" $variant')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+)
+
+;; Additional fields after discriminant.
+(assert_invalid
+  (component
+    (type $variant (variant (case "a" bool)
+                            (case "b" bool)
+                            (case "c" u8)))
+
+    (core type $variant (struct (field i32) (field i32)))
+    (core type $ty (func (param (ref $variant))))
+
+    (import "i" (instance $i
+                          (export "ty" (type $variant' (eq $variant)))
+                          (export "f" (func (param "x" $variant')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+)
+
+;; Lowering into a non-struct.
+(assert_invalid
+  (component
+    (type $variant (variant (case "a" bool)
+                            (case "b" bool)
+                            (case "c" u8)))
+
+    (core type $ty (func (param externref)))
+
+    (import "i" (instance $i
+                          (export "ty" (type $variant' (eq $variant)))
+                          (export "f" (func (param "x" $variant')))))
+    (core func (canon lower (func $i "f") gc (core-type $ty)))
+  )
+  "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+)

--- a/tests/snapshots/cli/component-model-gc/option-types.wast.json
+++ b/tests/snapshots/cli/component-model-gc/option-types.wast.json
@@ -1,0 +1,43 @@
+{
+  "source_filename": "tests/cli/component-model-gc/option-types.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "option-types.0.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 17,
+      "filename": "option-types.1.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 30,
+      "filename": "option-types.2.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 44,
+      "filename": "option-types.3.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 59,
+      "filename": "option-types.4.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `option` type to core `(ref null? (struct))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 75,
+      "filename": "option-types.5.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `option` type to core `(ref null? (struct))`"
+    }
+  ]
+}

--- a/tests/snapshots/cli/component-model-gc/option-types.wast/0.print
+++ b/tests/snapshots/cli/component-model-gc/option-types.wast/0.print
@@ -1,0 +1,16 @@
+(component
+  (type $opt (;0;) (option u32))
+  (core type $opt (;0;) (struct))
+  (core type $ty (;1;) (func (param (ref $opt))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $opt (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/option-types.wast/1.print
+++ b/tests/snapshots/cli/component-model-gc/option-types.wast/1.print
@@ -1,0 +1,16 @@
+(component
+  (type $opt (;0;) (option u32))
+  (core type $opt (;0;) (struct))
+  (core type $ty (;1;) (func (param (ref null $opt))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $opt (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/option-types.wast/2.print
+++ b/tests/snapshots/cli/component-model-gc/option-types.wast/2.print
@@ -1,0 +1,18 @@
+(component
+  (type $opt (;0;) (option u32))
+  (core rec
+    (type $opt (;0;) (struct))
+    (type $ty (;1;) (func (param (ref $opt))))
+  )
+  (type (;1;)
+    (instance
+      (alias outer 1 $opt (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/option-types.wast/3.print
+++ b/tests/snapshots/cli/component-model-gc/option-types.wast/3.print
@@ -1,0 +1,17 @@
+(component
+  (type $opt (;0;) (option u32))
+  (core type $base (;0;) (sub (struct)))
+  (core type $opt (;1;) (sub $base (struct)))
+  (core type $ty (;2;) (func (param (ref $opt))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $opt (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/result-types.wast.json
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast.json
@@ -30,28 +30,14 @@
       "line": 59,
       "filename": "result-types.4.wasm",
       "module_type": "binary",
-      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+      "text": "expected to lower component `result` type to core `(ref null? (struct))`"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "result-types.5.wasm",
       "module_type": "binary",
-      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 91,
-      "filename": "result-types.6.wasm",
-      "module_type": "binary",
-      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 107,
-      "filename": "result-types.7.wasm",
-      "module_type": "binary",
-      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+      "text": "expected to lower component `result` type to core `(ref null? (struct))`"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model-gc/result-types.wast.json
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast.json
@@ -1,0 +1,57 @@
+{
+  "source_filename": "tests/cli/component-model-gc/result-types.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "result-types.0.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 17,
+      "filename": "result-types.1.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 30,
+      "filename": "result-types.2.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 44,
+      "filename": "result-types.3.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 59,
+      "filename": "result-types.4.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 75,
+      "filename": "result-types.5.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 91,
+      "filename": "result-types.6.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 107,
+      "filename": "result-types.7.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `result` type to core `(ref null? (struct (field i8)))`"
+    }
+  ]
+}

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/0.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/0.print
@@ -1,0 +1,16 @@
+(component
+  (type $result (;0;) (result u32 (error u8)))
+  (core type $result (;0;) (struct (field i8)))
+  (core type $ty (;1;) (func (param (ref $result))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $result (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/0.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/0.print
@@ -1,6 +1,6 @@
 (component
   (type $result (;0;) (result u32 (error u8)))
-  (core type $result (;0;) (struct (field i8)))
+  (core type $result (;0;) (struct))
   (core type $ty (;1;) (func (param (ref $result))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/1.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/1.print
@@ -1,6 +1,6 @@
 (component
   (type $result (;0;) (result u32 (error u8)))
-  (core type $result (;0;) (struct (field i8)))
+  (core type $result (;0;) (struct))
   (core type $ty (;1;) (func (param (ref null $result))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/1.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/1.print
@@ -1,0 +1,16 @@
+(component
+  (type $result (;0;) (result u32 (error u8)))
+  (core type $result (;0;) (struct (field i8)))
+  (core type $ty (;1;) (func (param (ref null $result))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $result (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/2.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/2.print
@@ -1,7 +1,7 @@
 (component
   (type $result (;0;) (result u32 (error u8)))
   (core rec
-    (type $result (;0;) (struct (field i8)))
+    (type $result (;0;) (struct))
     (type $ty (;1;) (func (param (ref null $result))))
   )
   (type (;1;)

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/2.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/2.print
@@ -1,0 +1,18 @@
+(component
+  (type $result (;0;) (result u32 (error u8)))
+  (core rec
+    (type $result (;0;) (struct (field i8)))
+    (type $ty (;1;) (func (param (ref null $result))))
+  )
+  (type (;1;)
+    (instance
+      (alias outer 1 $result (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/3.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/3.print
@@ -1,7 +1,7 @@
 (component
   (type $result (;0;) (result u32 (error u8)))
   (core type $base (;0;) (sub (struct)))
-  (core type $result (;1;) (sub $base (struct (field i8))))
+  (core type $result (;1;) (sub $base (struct)))
   (core type $ty (;2;) (func (param (ref null $result))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/result-types.wast/3.print
+++ b/tests/snapshots/cli/component-model-gc/result-types.wast/3.print
@@ -1,0 +1,17 @@
+(component
+  (type $result (;0;) (result u32 (error u8)))
+  (core type $base (;0;) (sub (struct)))
+  (core type $result (;1;) (sub $base (struct (field i8))))
+  (core type $ty (;2;) (func (param (ref null $result))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $result (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast.json
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast.json
@@ -30,28 +30,14 @@
       "line": 67,
       "filename": "variant-types.4.wasm",
       "module_type": "binary",
-      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+      "text": "expected to lower component `variant` type to core `(ref null? (struct))`"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "variant-types.5.wasm",
       "module_type": "binary",
-      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 103,
-      "filename": "variant-types.6.wasm",
-      "module_type": "binary",
-      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 121,
-      "filename": "variant-types.7.wasm",
-      "module_type": "binary",
-      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+      "text": "expected to lower component `variant` type to core `(ref null? (struct))`"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast.json
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast.json
@@ -1,0 +1,57 @@
+{
+  "source_filename": "tests/cli/component-model-gc/variant-types.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "variant-types.0.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 19,
+      "filename": "variant-types.1.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 34,
+      "filename": "variant-types.2.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 50,
+      "filename": "variant-types.3.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 67,
+      "filename": "variant-types.4.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 85,
+      "filename": "variant-types.5.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 103,
+      "filename": "variant-types.6.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 121,
+      "filename": "variant-types.7.wasm",
+      "module_type": "binary",
+      "text": "expected to lower component `variant` type to core `(ref null? (struct (field i32)))`"
+    }
+  ]
+}

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/0.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/0.print
@@ -1,6 +1,6 @@
 (component
   (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
-  (core type $variant (;0;) (struct (field i32)))
+  (core type $variant (;0;) (struct))
   (core type $ty (;1;) (func (param (ref $variant))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/0.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/0.print
@@ -1,0 +1,16 @@
+(component
+  (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
+  (core type $variant (;0;) (struct (field i32)))
+  (core type $ty (;1;) (func (param (ref $variant))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $variant (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/1.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/1.print
@@ -1,6 +1,6 @@
 (component
   (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
-  (core type $variant (;0;) (struct (field i32)))
+  (core type $variant (;0;) (struct))
   (core type $ty (;1;) (func (param (ref null $variant))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/1.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/1.print
@@ -1,0 +1,16 @@
+(component
+  (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
+  (core type $variant (;0;) (struct (field i32)))
+  (core type $ty (;1;) (func (param (ref null $variant))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $variant (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/2.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/2.print
@@ -1,0 +1,18 @@
+(component
+  (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
+  (core rec
+    (type $variant (;0;) (struct (field i32)))
+    (type $ty (;1;) (func (param (ref null $variant))))
+  )
+  (type (;1;)
+    (instance
+      (alias outer 1 $variant (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/2.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/2.print
@@ -1,7 +1,7 @@
 (component
   (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
   (core rec
-    (type $variant (;0;) (struct (field i32)))
+    (type $variant (;0;) (struct))
     (type $ty (;1;) (func (param (ref null $variant))))
   )
   (type (;1;)

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/3.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/3.print
@@ -1,7 +1,7 @@
 (component
   (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
   (core type $base (;0;) (sub (struct)))
-  (core type $variant (;1;) (sub $base (struct (field i32))))
+  (core type $variant (;1;) (sub $base (struct)))
   (core type $ty (;2;) (func (param (ref null $variant))))
   (type (;1;)
     (instance

--- a/tests/snapshots/cli/component-model-gc/variant-types.wast/3.print
+++ b/tests/snapshots/cli/component-model-gc/variant-types.wast/3.print
@@ -1,0 +1,17 @@
+(component
+  (type $variant (;0;) (variant (case "a" bool) (case "b" bool) (case "c" u8)))
+  (core type $base (;0;) (sub (struct)))
+  (core type $variant (;1;) (sub $base (struct (field i32))))
+  (core type $ty (;2;) (func (param (ref null $variant))))
+  (type (;1;)
+    (instance
+      (alias outer 1 $variant (type (;0;)))
+      (export (;1;) "ty" (type (eq 0)))
+      (type (;2;) (func (param "x" 1)))
+      (export (;0;) "f" (func (type 2)))
+    )
+  )
+  (import "i" (instance $i (;0;) (type 1)))
+  (alias export $i "f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0) gc (core-type $ty)))
+)


### PR DESCRIPTION
This completes prototype support for GC in the component model by filling out the lowering of sum types (variants, options, and results) to GC types.