### PR TITLE
chore: reexport LibraryInfo

### DIFF
--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -17,7 +17,7 @@ mod printing;
 mod targets;
 mod validation;
 
-pub use encoding::{encode, ComponentEncoder};
+pub use encoding::{encode, ComponentEncoder, LibraryInfo};
 pub use linking::Linker;
 pub use printing::*;
 pub use targets::*;


### PR DESCRIPTION
From: https://github.com/bytecodealliance/wasm-tools/issues/2226

The [`ComponentEncoder::library`](https://docs.rs/wit-component/latest/src/wit_component/encoding.rs.html#2783-2785) method requires `LibraryInfo`, but it's not exported from the lib.