### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -229,7 +229,7 @@ pub struct RelocationEntry {
     /// Relocation entry type.
     pub ty: RelocationType,
     /// Offset in bytes from the start of the section indicated by
-    /// `RelocSectionReader::section` targetted by this relocation.
+    /// `RelocSectionReader::section` targeted by this relocation.
     pub offset: u32,
     /// Index in the symbol table contained in the linking section that
     /// corresponds to the value at `offset`.
@@ -241,7 +241,7 @@ pub struct RelocationEntry {
 
 impl RelocationEntry {
     /// Byte range relative to the start of the section indicated by
-    /// `RelocSectionReader::section` targetted by this relocation.
+    /// `RelocSectionReader::section` targeted by this relocation.
     pub fn relocation_range(&self) -> Range<usize> {
         (self.offset as usize)..(self.offset as usize + self.ty.extent())
     }

--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -985,7 +985,7 @@ pub struct ComponentType {
     /// `Vec<usize>` payload here. For more information about the indexes see
     /// the documentation on `ComponentState::imported_resources`.
     ///
-    /// This should technically be inferrable from the structure of `imports`,
+    /// This should technically be inferable from the structure of `imports`,
     /// but it's stored as an auxiliary set for subtype checking and
     /// instantiation.
     ///


### PR DESCRIPTION


Description:  
This pull request corrects several typos in documentation comments across the codebase. Specifically, it changes "targetted" to "targeted" in `reloc.rs` and "inferrable" to "inferable" in `component_types.rs`. These changes improve the clarity and professionalism of the documentation without affecting any code logic or functionality.