### PR TITLE
Fix Typos in Comments: "verisons" → "versions", "depenency" → "dependency"

### DIFF
--- a/crates/wast/tests/parse-fail.rs
+++ b/crates/wast/tests/parse-fail.rs
@@ -44,7 +44,7 @@ fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {
         .unwrap_or(String::new())
         .replace("\r\n", "\n");
 
-    // Compare normalize verisons which handles weirdness like path differences
+    // Compare normalize versions which handles weirdness like path differences
     if normalize(&assert) == normalize(&err) {
         return Ok(());
     }

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -307,7 +307,7 @@ fn write_details_table(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result
         }
     }
 
-    // Add depedency packages to the table
+    // Add dependency packages to the table
     if let Some(dependencies) = dependencies {
         for package in &dependencies.version_info().packages {
             table.add_row(vec![


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in code comments:
- "verisons" is changed to "versions" in `parse-fail.rs`
- "depenency" is changed to "dependency" in `metadata.rs`

