### PR TITLE
Add missing feature to dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ cpp_demangle = { version = "0.4.0", optional = true }
 rustc-demangle = { version = "0.1.21", optional = true }
 
 # Dependencies of `component`
-wast = { workspace = true, optional = true, features = ['wasm-module'] }
+wast = { workspace = true, optional = true, features = ['wasm-module', 'component-model'] }
 wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat', 'semver-check'] }
 wit-encoder = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true, features = ['decoding', 'wat', 'serde'] }


### PR DESCRIPTION
This only shows up when installing via crates.io without `--locked`, so unfortunately difficult to write a test for.

Closes #2244