### PR TITLE
 Fix typos

### DIFF
--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -239,7 +239,7 @@ impl<'printer, 'state, 'a, 'b> PrintOperator<'printer, 'state, 'a, 'b> {
                     Some(name) if !name_conflict => name.write(self.printer)?,
 
                     // If there's no name conflict, and we're synthesizing
-                    // names, and this isn't targetting the function itself then
+                    // names, and this isn't targeting the function itself then
                     // print a synthesized names.
                     //
                     // Note that synthesized label names don't handle the

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -1234,7 +1234,7 @@ pub trait Output {
         assert!(!src.contains('\n'));
         let idented = self.indent_if_needed();
         if idented && src.starts_with(' ') {
-            panic!("cannot add a space at the begining of a line");
+            panic!("cannot add a space at the beginning of a line");
         }
         self.push_str(src);
     }


### PR DESCRIPTION

**Description:**

This pull request addresses two minor spelling errors:

*   Corrected `targetting` to `targeting` in a comment within `crates/wasmprinter/src/operator.rs`.
*   Fixed `begining` to `beginning` in a panic message in `crates/wit-component/src/printing.rs`.