### PR TITLE
wasmparser: Increase `MAX_WASM_COMPONENT_TYPE_DECLS` to `1_000_000`

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -65,7 +65,7 @@ pub use self::component_limits::*;
 mod component_limits {
     pub const MAX_WASM_MODULE_SIZE: usize = 1024 * 1024 * 1024; //= 1 GiB
     pub const MAX_WASM_MODULE_TYPE_DECLS: usize = 100_000;
-    pub const MAX_WASM_COMPONENT_TYPE_DECLS: usize = 100_000;
+    pub const MAX_WASM_COMPONENT_TYPE_DECLS: usize = 1_000_000;
     pub const MAX_WASM_INSTANCE_TYPE_DECLS: usize = 1_000_000;
     pub const MAX_WASM_RECORD_FIELDS: usize = 10_000;
     pub const MAX_WASM_VARIANT_CASES: usize = 10_000;


### PR DESCRIPTION
I was hitting against a linker error when using wit-bindgen in Rust with more than 100k functions.

A simple wit file to reproduce this:
```
package x:xx;
world xxx {
	import a0: func();
	import a1: func();
	import a2: func();
	import a3: func();
        ...
        ...
	import a99999: func();
	import a100000: func();
}
```

The error:
```
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: error: failed to parse core wasm for componentization

          Caused by:
              0: decoding custom section component-type:wit-bindgen:0.43.0:x:xx:xxx:encoded world
              1: component type declaration size is out of bounds (at offset 0x2c)
```

With this change I tested up to 200k functions with no problems.

Similar to #2087