### PR TITLE
fix: added musl builds x86_64 and aarch64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
         include:
         - build: x86_64-linux
           os: ubuntu-latest
+        - build: x86_64-musl
+          os: ubuntu-latest
+          target: x86_64-unknown-linux-musl
         - build: x86_64-macos
           os: macos-latest
           target: x86_64-apple-darwin
@@ -40,6 +43,9 @@ jobs:
         - build: aarch64-linux
           os: ubuntu-latest
           target: aarch64-unknown-linux-gnu
+        - build: aarch64-musl
+          os: ubuntu-latest
+          target: aarch64-unknown-linux-musl
         - build: wasm32-wasip1
           os: ubuntu-latest
           target: wasm32-wasip1

--- a/ci/docker/aarch64-musl/Dockerfile
+++ b/ci/docker/aarch64-musl/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl
+
+RUN apt-get update -y && apt-get install -y ninja-build
+RUN git config --global --add safe.directory '*'
+ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static

--- a/ci/docker/aarch64-musl/Dockerfile
+++ b/ci/docker/aarch64-musl/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl
 
 RUN apt-get update -y && apt-get install -y ninja-build
 RUN git config --global --add safe.directory '*'
-ENV RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static

--- a/ci/docker/aarch64-musl/Dockerfile
+++ b/ci/docker/aarch64-musl/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl
 
 RUN apt-get update -y && apt-get install -y ninja-build
 RUN git config --global --add safe.directory '*'
-ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV RUSTFLAGS=-Ctarget-feature=-crt-static

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates git
+RUN git config --global --add safe.directory '*'
+
+ENV PATH=$PATH:/rust/bin
+ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -12,5 +12,5 @@ RUN git config --global --add safe.directory '*'
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
-ENV RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -12,5 +12,5 @@ RUN git config --global --add safe.directory '*'
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
-ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV RUSTFLAGS=-Ctarget-feature=-crt-static
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -1,8 +1,16 @@
-FROM ubuntu:16.04
+# Rust binaries need `libgcc_s.so` but ubuntu's musl toolchain does not have it.
+# Get it from alpine instead.
+FROM alpine:3.16 as libgcc_s_src
+RUN apk add libgcc
 
-RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates git
+# Use something glibc-based for the actual compile because the Rust toolchain
+# we're using is glibc-based in CI.
+FROM ubuntu:24.04
+RUN apt-get update -y && apt-get install -y cmake musl-tools git ninja-build
+COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 RUN git config --global --add safe.directory '*'
 
-ENV PATH=$PATH:/rust/bin
-ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+# Note that `-crt-feature` is passed here to specifically disable static linking
+# with musl. We want a `*.so` to pop out so static linking isn't what we want.
+ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc


### PR DESCRIPTION
https://github.com/bytecodealliance/wasm-tools/issues/2257


The build are copied from https://github.com/bytecodealliance/wasmtime/blob/v29.0.1/ci/build-build-matrix.js

I see it uses version 28.0 but I don't see aarch64-musl in that tag. However in 29.0 I dont see the 'bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@release-28.0.0' workflow anymore 🤔 
