### PR TITLE
wasm-wave: Fix building with no-default-features

### DIFF
--- a/crates/wasm-wave/Cargo.toml
+++ b/crates/wasm-wave/Cargo.toml
@@ -19,7 +19,7 @@ default = ["wit"]
 wit = ["dep:wit-parser"]
 
 [dependencies]
-indexmap.workspace = true
+indexmap = { workspace = true, features = ["std"] }
 logos = { version = "0.14.2", features = ["forbid_unsafe"] }
 thiserror = { workspace = true }
 wit-parser = { workspace = true, optional = true }


### PR DESCRIPTION
Depends on `indexmap/std` which is normally transitively enabled by wit-parser.

Fixes #2258 