### PR TITLE
Don't fail to print known custom sections

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -569,7 +569,10 @@ impl Printer<'_, '_> {
                             })
                             .print_known_custom_section(c.clone())
                             {
-                                Ok(()) => self.print_known_custom_section(c.clone())?,
+                                Ok(true) => {
+                                    self.print_known_custom_section(c.clone())?;
+                                }
+                                Ok(false) => self.print_raw_custom_section(state, c.clone())?,
                                 Err(e) if !e.is::<BinaryReaderError>() => return Err(e),
                                 Err(e) => {
                                     let msg = format!(
@@ -1875,29 +1878,30 @@ impl Printer<'_, '_> {
         Ok(())
     }
 
-    fn print_known_custom_section(&mut self, section: CustomSectionReader<'_>) -> Result<()> {
+    fn print_known_custom_section(&mut self, section: CustomSectionReader<'_>) -> Result<bool> {
         match section.as_known() {
             // For now `wasmprinter` has invented syntax for `producers` and
             // `dylink.0` below to use in tests. Note that this syntax is not
             // official at this time.
             KnownCustom::Producers(s) => {
                 self.newline(section.range().start)?;
-                self.print_producers_section(s)
+                self.print_producers_section(s)?;
+                Ok(true)
             }
             KnownCustom::Dylink0(s) => {
                 self.newline(section.range().start)?;
-                self.print_dylink0_section(s)
+                self.print_dylink0_section(s)?;
+                Ok(true)
             }
 
             // These are parsed during `read_names` and are part of
             // printing elsewhere, so don't print them.
-            KnownCustom::Name(_) | KnownCustom::BranchHints(_) => Ok(()),
+            KnownCustom::Name(_) | KnownCustom::BranchHints(_) => Ok(true),
             #[cfg(feature = "component-model")]
-            KnownCustom::ComponentName(_) => Ok(()),
+            KnownCustom::ComponentName(_) => Ok(true),
 
-            _ => bail!("unknown custom section"),
-        }?;
-        Ok(())
+            _ => Ok(false),
+        }
     }
 
     fn print_raw_custom_section(

--- a/tests/cli/clang-custom-sections.wat
+++ b/tests/cli/clang-custom-sections.wat
@@ -1,0 +1,46 @@
+;; RUN: print %
+
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i32)))
+  (import "env" "__linear_memory" (memory (;0;) 0))
+  (import "env" "__stack_pointer" (global (;0;) (mut i32)))
+  (import "env" "foo" (func (;0;) (type 1)))
+  (import "env" "__stack_chk_fail" (func (;1;) (type 0)))
+  (func (;2;) (type 0)
+    (local i32)
+    global.get 0
+    i32.const 16
+    i32.sub
+    local.tee 0
+    global.set 0
+    local.get 0
+    i32.const 0
+    i32.load
+    i32.store offset=12
+    local.get 0
+    i32.const 8
+    i32.add
+    call 0
+    block ;; label = @1
+      i32.const 0
+      i32.load
+      local.get 0
+      i32.load offset=12
+      i32.eq
+      br_if 0 (;@1;)
+      call 1
+      unreachable
+    end
+    local.get 0
+    i32.const 16
+    i32.add
+    global.set 0
+  )
+  (@custom "linking" (after code) "\02\08\a5\80\80\80\00\05\00\04\02\03bar\02\10\00\01\10\11__stack_chk_guard\00\10\00\00\10\01")
+  (@custom "reloc.CODE" (after code) "\03\07\07\06\01\07\11\01\03\1c\02\00\00*\03\035\02\00\00C\04\07P\01")
+  (@producers
+    (processed-by "clang" "20.1.8-wasi-sdk (https://github.com/llvm/llvm-project 87f0227cb60147a26a1eeb4fb06e3b505e9c7261)")
+  )
+  (@custom "target_features" (after code) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
+)

--- a/tests/cli/clang-custom-sections.wat.stdout
+++ b/tests/cli/clang-custom-sections.wat.stdout
@@ -1,0 +1,44 @@
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i32)))
+  (import "env" "__linear_memory" (memory (;0;) 0))
+  (import "env" "__stack_pointer" (global (;0;) (mut i32)))
+  (import "env" "foo" (func (;0;) (type 1)))
+  (import "env" "__stack_chk_fail" (func (;1;) (type 0)))
+  (func (;2;) (type 0)
+    (local i32)
+    global.get 0
+    i32.const 16
+    i32.sub
+    local.tee 0
+    global.set 0
+    local.get 0
+    i32.const 0
+    i32.load
+    i32.store offset=12
+    local.get 0
+    i32.const 8
+    i32.add
+    call 0
+    block ;; label = @1
+      i32.const 0
+      i32.load
+      local.get 0
+      i32.load offset=12
+      i32.eq
+      br_if 0 (;@1;)
+      call 1
+      unreachable
+    end
+    local.get 0
+    i32.const 16
+    i32.add
+    global.set 0
+  )
+  (@custom "linking" (after code) "/02/08/a5/80/80/80/00/05/00/04/02/03bar/02/10/00/01/10/11__stack_chk_guard/00/10/00/00/10/01")
+  (@custom "reloc.CODE" (after code) "/03/07/07/06/01/07/11/01/03/1c/02/00/00*/03/035/02/00/00C/04/07P/01")
+  (@custom "target_features" (after code) "/08+/0bbulk-memory+/0fbulk-memory-opt+/16call-indirect-overlong+/0amultivalue+/0fmutable-globals+/13nontrapping-fptoint+/0freference-types+/08sign-ext")
+  (@producers
+    (processed-by "clang" "20.1.8-wasi-sdk (https://github.com/llvm/llvm-project 87f0227cb60147a26a1eeb4fb06e3b505e9c7261)")
+  )
+)


### PR DESCRIPTION
This commit updates the `wasm-tools print` subcommand to print raw custom sections for some "known" custom sections if there is not printer registered for it. For example the `linking` and `reloc.CODE` custom sections are "known" but have no text format. Previously they would fail to print but now they will print the raw bytes.