### PR TITLE
Add color to offsets printed by wasmprinter

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1571,7 +1571,11 @@ impl Printer<'_, '_> {
 
         if self.config.print_offsets {
             match offset {
-                Some(offset) => write!(self.result, "(;@{offset:<6x};)")?,
+                Some(offset) => {
+                    self.result.start_comment()?;
+                    write!(self.result, "(;@{offset:<6x};)")?;
+                    self.result.reset_color()?;
+                }
                 None => self.result.write_str("           ")?,
             }
         }


### PR DESCRIPTION
Helps distinguish the offsets from the rest of the file.