### PR TITLE
feat(wasm-encoder): expose Ieee32 and Ieee64 constructors

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -299,9 +299,14 @@ impl Encode for Function {
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Ieee32(pub u32);
+pub struct Ieee32(pub(crate) u32);
 
 impl Ieee32 {
+    /// Creates a new Ieee32
+    pub fn new(bits: u32) -> Self {
+        Ieee32 { 0: bits }
+    }
+
     /// Gets the underlying bits of the 32-bit float.
     pub fn bits(self) -> u32 {
         self.0
@@ -334,9 +339,14 @@ impl Encode for Ieee32 {
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Ieee64(pub u64);
+pub struct Ieee64(pub(crate) u64);
 
 impl Ieee64 {
+    /// Creates a new Ieee64
+    pub fn new(bits: u64) -> Self {
+        Ieee64 { 0: bits }
+    }
+
     /// Gets the underlying bits of the 64-bit float.
     pub fn bits(self) -> u64 {
         self.0

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -299,7 +299,7 @@ impl Encode for Function {
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Ieee32(pub(crate) u32);
+pub struct Ieee32(pub u32);
 
 impl Ieee32 {
     /// Gets the underlying bits of the 32-bit float.
@@ -334,7 +334,7 @@ impl Encode for Ieee32 {
 ///
 /// All bit patterns are allowed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct Ieee64(pub(crate) u64);
+pub struct Ieee64(pub u64);
 
 impl Ieee64 {
     /// Gets the underlying bits of the 64-bit float.


### PR DESCRIPTION
This allows consumers who already have their float bit pattern as a `u32`/`u64` to not have to go through a cast to `f32`/`f64` just for the `Ieee32` or `Ieee64` constructors to cast it back. If being able to directly read/write the stored bit pattern is undesirable, I could impl `new` instead. It doesn't look like #2157 added any tests for this struct, so I didn't add any either.