### PR TITLE
`wasm-encoder`: Use tuple-struct syntax for Ieee{32,64} fields

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -304,7 +304,7 @@ pub struct Ieee32(pub(crate) u32);
 impl Ieee32 {
     /// Creates a new Ieee32
     pub fn new(bits: u32) -> Self {
-        Ieee32 { 0: bits }
+        Ieee32(bits)
     }
 
     /// Gets the underlying bits of the 32-bit float.
@@ -315,9 +315,7 @@ impl Ieee32 {
 
 impl From<f32> for Ieee32 {
     fn from(value: f32) -> Self {
-        Ieee32 {
-            0: u32::from_le_bytes(value.to_le_bytes()),
-        }
+        Ieee32(u32::from_le_bytes(value.to_le_bytes()))
     }
 }
 
@@ -344,7 +342,7 @@ pub struct Ieee64(pub(crate) u64);
 impl Ieee64 {
     /// Creates a new Ieee64
     pub fn new(bits: u64) -> Self {
-        Ieee64 { 0: bits }
+        Ieee64(bits)
     }
 
     /// Gets the underlying bits of the 64-bit float.
@@ -355,9 +353,7 @@ impl Ieee64 {
 
 impl From<f64> for Ieee64 {
     fn from(value: f64) -> Self {
-        Ieee64 {
-            0: u64::from_le_bytes(value.to_le_bytes()),
-        }
+        Ieee64(u64::from_le_bytes(value.to_le_bytes()))
     }
 }
 


### PR DESCRIPTION
I didn't even know you could do named field syntax with the indices. In any case, the tuple-struct syntax is more idiomatic and vastly more common.