### PR TITLE
fail validation if callback missing for async export

### DIFF
--- a/crates/wit-component/tests/components/error-async-export-missing-callback/error.txt
+++ b/crates/wit-component/tests/components/error-async-export-missing-callback/error.txt
@@ -1,0 +1,1 @@
+failed to decode world from module: module was not valid: missing callback for `[async-lift]foo`

--- a/crates/wit-component/tests/components/error-async-export-missing-callback/module.wat
+++ b/crates/wit-component/tests/components/error-async-export-missing-callback/module.wat
@@ -1,0 +1,6 @@
+(module
+  (func (export "[async-lift]foo") (param i32 i32) (result i32) unreachable)
+  (func (export "[async-lift]foo:foo/bar#foo") (param i32 i32) (result i32) unreachable)
+  (memory (export "memory") 1)
+  (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) unreachable)
+)

--- a/crates/wit-component/tests/components/error-async-export-missing-callback/module.wit
+++ b/crates/wit-component/tests/components/error-async-export-missing-callback/module.wit
@@ -1,0 +1,10 @@
+package foo:foo;
+
+interface bar {
+  foo: func(s: string) -> string;
+}
+
+world module {
+  export bar;
+  export foo: func(s: string) -> string;
+}


### PR DESCRIPTION
If the module exports a function with the `[async-lift]` prefix (rather than the `[async-lift-stackful]` one), then we must be able to match that up with a corresponding callback function; otherwise, we fail validation.

Prior to this fix, we'd silently generate an invalid component and leave it to `wasmparser` to notice, which is bad form, plus the diagnostic message wasn't very helpful.