### PR TITLE
Use trusted publishing for release automation in this repository

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -1,11 +1,6 @@
 name: 'Maybe perform a release'
 description: 'Steps to perform a conditional release of this repository'
 
-inputs:
-  cargo_token:
-    description: 'token used to publish crates'
-    required: false
-
 runs:
   using: composite
   steps:
@@ -74,11 +69,15 @@ runs:
     - run: rustup update stable && rustup default stable
       shell: bash
 
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+      if: steps.tag.outputs.push_tag == 'yes'
+
     - run: |
         rm -rf dist main.log
         rustc ci/publish.rs
         ./publish publish
       shell: bash
       env:
-        CARGO_REGISTRY_TOKEN: ${{ inputs.cargo_token }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       if: steps.tag.outputs.push_tag == 'yes' && github.repository_owner == 'bytecodealliance'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,20 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   create_tag:
     name: Publish artifacts of build
     runs-on: ubuntu-latest
+    environment: release
+    if: |
+      github.repository_owner == 'bytecodealliance'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v5
       with:
         submodules: true
         fetch-depth: 0
     - uses: ./.github/actions/publish-release
-      with:
-        cargo_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,31 @@ $ FUZZER=roundtrip cargo +nightly fuzz run run
 More documentation of `cargo fuzz` can [be found
 online](https://rust-fuzz.github.io/book/cargo-fuzz.html).
 
+### Adding a new Crate
+
+When a new crate is added to this repository it'll need to be accompanied with a
+reservation of the crate name on crates.io. That enables this repository to
+automatically manage publishing of the crate. The steps for adding a new crate
+are:
+
+* CI should fail when a new crate is added until the below steps are complete.
+* Update `ci/publish.rs` with the name of your crate in the array at the top.
+* A dummy empty crate should be published to crates.io with a small README
+  pointing to this repository and indicating that it's a temporary name
+  reservation until the first version is published from this repository's
+  automation.
+* A "Trusted Publishing" workflow should be added for the new crate. The
+  workflow filename is `publish.yml` and the environment name is `release`.
+* The crate should be exclusively owned by the `wasmtime-publish` crates.io
+  user. This will require a `wasm-tools` maintainer to log in, accept the
+  invite, and remove the prior owner.
+
+After these steps have been completed CI should then pass and the crate will be
+auto-published from this repository on the next release.
+
+Note that if you're adding a crate which is not published to crates.io you'll
+want to add `publish = false` to the manifest.
+
 # License
 
 This project is licensed under the Apache 2.0 license with the LLVM exception.

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -373,24 +373,24 @@ fn curl(url: &str) -> Option<String> {
 // directory registry generated from `cargo vendor` because the versions
 // referenced from `Cargo.toml` may not exist on crates.io.
 fn verify(crates: &[Crate]) {
-    // drop(fs::remove_dir_all(".cargo"));
-    // drop(fs::remove_dir_all("vendor"));
-    // let vendor = Command::new("cargo")
-    //     .arg("vendor")
-    //     .stderr(Stdio::inherit())
-    //     .output()
-    //     .unwrap();
-    // assert!(vendor.status.success());
+    drop(fs::remove_dir_all(".cargo"));
+    drop(fs::remove_dir_all("vendor"));
+    let vendor = Command::new("cargo")
+        .arg("vendor")
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    assert!(vendor.status.success());
 
-    // fs::create_dir_all(".cargo").unwrap();
-    // fs::write(".cargo/config.toml", vendor.stdout).unwrap();
+    fs::create_dir_all(".cargo").unwrap();
+    fs::write(".cargo/config.toml", vendor.stdout).unwrap();
 
     for krate in crates {
         if !krate.publish {
             continue;
         }
         verify_crates_io(krate);
-        // verify_and_vendor(&krate);
+        verify_and_vendor(&krate);
     }
 
     fn verify_and_vendor(krate: &Crate) {


### PR DESCRIPTION
This commit updates the publish scripts and CI configuration to use the "Trusted Publishing" workflow on crates.io. This enables removal of the long-lived token assigned to this repository in favor of short-lived ephemeral tokens scoped to just the `publish.yml` workflow.

Here CI configuration is updated to avoid using the token in the environment. Instead it uses `rust-lang/crates-io-auth-action@v1` to acquire a token during publishing. Documentation is added for how to add a crate to this repository as it now requires that the crate is published on crates.io before it's added to this repository. That ensures that the trusted publishing workflow is in place before a PR is merged. Finally the `publish.rs` script is updated to avoid owner management on version bumps but also check on PRs that the owners are configured correctly.