### PR TITLE
Support lists of WITs in `Resolve::select_world`

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2971,7 +2971,7 @@ world test {
 "#,
             )
             .unwrap();
-        let world = resolve.select_world(Some(pkg), None).unwrap();
+        let world = resolve.select_world(&[pkg], None).unwrap();
 
         let mut module = dummy_module(&resolve, world, ManglingAndAbi::Standard32);
 

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2971,7 +2971,7 @@ world test {
 "#,
             )
             .unwrap();
-        let world = resolve.select_world(pkg, None).unwrap();
+        let world = resolve.select_world(Some(pkg), None).unwrap();
 
         let mut module = dummy_module(&resolve, world, ManglingAndAbi::Standard32);
 

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -147,7 +147,7 @@ world test-world {}
         // Parse pre-canned WIT to build resolver
         let mut resolver = Resolve::default();
         let pkg = resolver.push_str("in-code.wit", COMPONENT_WIT)?;
-        let world = resolver.select_world(Some(pkg), Some("test-world"))?;
+        let world = resolver.select_world(&[pkg], Some("test-world"))?;
 
         // Embed component metadata
         embed_component_metadata(&mut bytes, &resolver, world, StringEncoding::UTF8)?;

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -147,7 +147,7 @@ world test-world {}
         // Parse pre-canned WIT to build resolver
         let mut resolver = Resolve::default();
         let pkg = resolver.push_str("in-code.wit", COMPONENT_WIT)?;
-        let world = resolver.select_world(pkg, Some("test-world"))?;
+        let world = resolver.select_world(Some(pkg), Some("test-world"))?;
 
         // Embed component metadata
         embed_component_metadata(&mut bytes, &resolver, world, StringEncoding::UTF8)?;

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -364,7 +364,7 @@ impl Bindgen {
                     DecodedWasm::Component(..) => bail!("expected encoded wit package(s)"),
                 };
                 resolve = r;
-                world = resolve.select_world(pkg, Some(world_name.into()))?;
+                world = resolve.select_world(Some(pkg), Some(world_name.into()))?;
             }
 
             // Current format where `data` is a wasm component itself.

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -364,7 +364,7 @@ impl Bindgen {
                     DecodedWasm::Component(..) => bail!("expected encoded wit package(s)"),
                 };
                 resolve = r;
-                world = resolve.select_world(Some(pkg), Some(world_name.into()))?;
+                world = resolve.select_world(&[pkg], Some(world_name.into()))?;
             }
 
             // Current format where `data` is a wasm component itself.

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -243,7 +243,7 @@ fn read_core_module(path: &Path, resolve: &Resolve, pkg: PackageId) -> Result<Ve
     let mut wasm = wat::parse_file(path)?;
     let name = path.file_stem().and_then(|s| s.to_str()).unwrap();
     let world = resolve
-        .select_world(Some(pkg), Some(name))
+        .select_world(&[pkg], Some(name))
         .context("failed to select a world")?;
 
     // Add this producer data to the wit-component metadata so we can make sure it gets through the

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -243,7 +243,7 @@ fn read_core_module(path: &Path, resolve: &Resolve, pkg: PackageId) -> Result<Ve
     let mut wasm = wat::parse_file(path)?;
     let name = path.file_stem().and_then(|s| s.to_str()).unwrap();
     let world = resolve
-        .select_world(pkg, Some(name))
+        .select_world(Some(pkg), Some(name))
         .context("failed to select a world")?;
 
     // Add this producer data to the wit-component metadata so we can make sure it gets through the

--- a/crates/wit-component/tests/linking.rs
+++ b/crates/wit-component/tests/linking.rs
@@ -141,7 +141,7 @@ fn encode(wat: &str, wit: Option<&str>) -> Result<Vec<u8>> {
     if let Some(wit) = wit {
         let mut resolve = Resolve::default();
         let pkg = resolve.push_str("test.wit", wit)?;
-        let world = resolve.select_world(pkg, None)?;
+        let world = resolve.select_world(Some(pkg), None)?;
 
         wit_component::embed_component_metadata(
             &mut module,

--- a/crates/wit-component/tests/linking.rs
+++ b/crates/wit-component/tests/linking.rs
@@ -141,7 +141,7 @@ fn encode(wat: &str, wit: Option<&str>) -> Result<Vec<u8>> {
     if let Some(wit) = wit {
         let mut resolve = Resolve::default();
         let pkg = resolve.push_str("test.wit", wit)?;
-        let world = resolve.select_world(Some(pkg), None)?;
+        let world = resolve.select_world(&[pkg], None)?;
 
         wit_component::embed_component_metadata(
             &mut module,

--- a/crates/wit-component/tests/targets.rs
+++ b/crates/wit-component/tests/targets.rs
@@ -82,7 +82,7 @@ fn load_test_wit(path: &Path) -> Result<(Resolve, WorldId)> {
     let mut resolve = Resolve::default();
     let pkg = resolve.push_file(&test_wit_path)?;
     let world_id = resolve
-        .select_world(Some(pkg), Some(TEST_TARGET_WORLD_ID))
+        .select_world(&[pkg], Some(TEST_TARGET_WORLD_ID))
         .with_context(|| "failed to select world from package".to_string())?;
 
     Ok((resolve, world_id))

--- a/crates/wit-component/tests/targets.rs
+++ b/crates/wit-component/tests/targets.rs
@@ -82,7 +82,7 @@ fn load_test_wit(path: &Path) -> Result<(Resolve, WorldId)> {
     let mut resolve = Resolve::default();
     let pkg = resolve.push_file(&test_wit_path)?;
     let world_id = resolve
-        .select_world(pkg, Some(TEST_TARGET_WORLD_ID))
+        .select_world(Some(pkg), Some(TEST_TARGET_WORLD_ID))
         .with_context(|| "failed to select world from package".to_string())?;
 
     Ok((resolve, world_id))

--- a/crates/wit-component/tests/wit.rs
+++ b/crates/wit-component/tests/wit.rs
@@ -12,7 +12,7 @@ fn parse_wit_dir() -> Result<()> {
     let (package_id, _) = resolver.push_path("tests/wit/parse-dir/wit")?;
     assert!(
         resolver
-            .select_world(package_id, "foo-world".into())
+            .select_world(Some(package_id), "foo-world".into())
             .is_ok()
     );
 
@@ -26,7 +26,7 @@ fn parse_wit_file() -> Result<()> {
 
     let mut resolver = Resolve::default();
     let (package_id, _) = resolver.push_path("tests/wit/parse-dir/wit/deps/bar/bar.wit")?;
-    resolver.select_world(package_id, "bar-world".into())?;
+    resolver.select_world(Some(package_id), "bar-world".into())?;
     assert!(
         resolver
             .interfaces

--- a/crates/wit-component/tests/wit.rs
+++ b/crates/wit-component/tests/wit.rs
@@ -12,7 +12,7 @@ fn parse_wit_dir() -> Result<()> {
     let (package_id, _) = resolver.push_path("tests/wit/parse-dir/wit")?;
     assert!(
         resolver
-            .select_world(Some(package_id), "foo-world".into())
+            .select_world(&[package_id], "foo-world".into())
             .is_ok()
     );
 
@@ -26,7 +26,7 @@ fn parse_wit_file() -> Result<()> {
 
     let mut resolver = Resolve::default();
     let (package_id, _) = resolver.push_path("tests/wit/parse-dir/wit/deps/bar/bar.wit")?;
-    resolver.select_world(Some(package_id), "bar-world".into())?;
+    resolver.select_world(&[package_id], "bar-world".into())?;
     assert!(
         resolver
             .interfaces

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1430,7 +1430,7 @@ package {name} is defined in two different locations:\n\
                     }
 
                     // We have a main package.
-                    (Some(pkg), ParsedUsePath::Name(name)) => (pkg, dbg!(name)),
+                    (Some(pkg), ParsedUsePath::Name(name)) => (pkg, name),
 
                     // The world name is fully-qualified.
                     (_, ParsedUsePath::Package(pkg, world_name)) => {

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1477,7 +1477,7 @@ package {name} is defined in two different locations:\n\
                 Some(main_package) => {
                     let pkg = &self.packages[main_package];
                     match pkg.worlds.len() {
-                        0 => bail!("The package `{}` contains no worlds", pkg.name),
+                        0 => bail!("The main package `{}` contains no worlds", pkg.name),
                         1 => Ok(pkg.worlds[0]),
                         _ => bail!(
                             "There are multiple worlds in `{}`; one must be explicitly chosen:{}",

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -349,7 +349,7 @@ impl EmbedOpts {
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
 
-        let world = resolve.select_world(Some(pkg_id), self.world.as_deref())?;
+        let world = resolve.select_world(&[pkg_id], self.world.as_deref())?;
 
         if self.only_custom {
             let encoded = metadata::encode(
@@ -706,7 +706,7 @@ impl WitOpts {
                     );
                 }
                 DecodedWasm::WitPackage(resolve, id) => {
-                    let world = resolve.select_world(Some(*id), Some(world))?;
+                    let world = resolve.select_world(&[*id], Some(world))?;
                     (resolve, world)
                 }
             };
@@ -814,7 +814,7 @@ impl WitOpts {
                 );
             }
             (DecodedWasm::WitPackage(resolve, id), world) => {
-                let world = resolve.select_world(Some(*id), world)?;
+                let world = resolve.select_world(&[*id], world)?;
                 (resolve, world)
             }
         };
@@ -959,7 +959,7 @@ impl TargetsOpts {
     /// Executes the application.
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
-        let world = resolve.select_world(Some(pkg_id), self.world.as_deref())?;
+        let world = resolve.select_world(&[pkg_id], self.world.as_deref())?;
         let component_to_test = self.input.get_binary_wasm()?;
 
         wit_component::targets(&resolve, world, &component_to_test)?;
@@ -999,8 +999,8 @@ impl SemverCheckOpts {
 
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
-        let prev = resolve.select_world(Some(pkg_id), Some(self.prev.as_str()))?;
-        let new = resolve.select_world(Some(pkg_id), Some(self.new.as_str()))?;
+        let prev = resolve.select_world(&[pkg_id], Some(self.prev.as_str()))?;
+        let new = resolve.select_world(&[pkg_id], Some(self.new.as_str()))?;
         wit_component::semver_check(resolve, prev, new)?;
         Ok(())
     }

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -349,7 +349,7 @@ impl EmbedOpts {
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
 
-        let world = resolve.select_world(pkg_id, self.world.as_deref())?;
+        let world = resolve.select_world(Some(pkg_id), self.world.as_deref())?;
 
         if self.only_custom {
             let encoded = metadata::encode(
@@ -706,7 +706,7 @@ impl WitOpts {
                     );
                 }
                 DecodedWasm::WitPackage(resolve, id) => {
-                    let world = resolve.select_world(*id, Some(world))?;
+                    let world = resolve.select_world(Some(*id), Some(world))?;
                     (resolve, world)
                 }
             };
@@ -814,7 +814,7 @@ impl WitOpts {
                 );
             }
             (DecodedWasm::WitPackage(resolve, id), world) => {
-                let world = resolve.select_world(*id, world)?;
+                let world = resolve.select_world(Some(*id), world)?;
                 (resolve, world)
             }
         };
@@ -959,7 +959,7 @@ impl TargetsOpts {
     /// Executes the application.
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
-        let world = resolve.select_world(pkg_id, self.world.as_deref())?;
+        let world = resolve.select_world(Some(pkg_id), self.world.as_deref())?;
         let component_to_test = self.input.get_binary_wasm()?;
 
         wit_component::targets(&resolve, world, &component_to_test)?;
@@ -999,8 +999,8 @@ impl SemverCheckOpts {
 
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
-        let prev = resolve.select_world(pkg_id, Some(self.prev.as_str()))?;
-        let new = resolve.select_world(pkg_id, Some(self.new.as_str()))?;
+        let prev = resolve.select_world(Some(pkg_id), Some(self.prev.as_str()))?;
+        let new = resolve.select_world(Some(pkg_id), Some(self.new.as_str()))?;
         wit_component::semver_check(resolve, prev, new)?;
         Ok(())
     }

--- a/tests/cli/multiple-packages-multiple-main-worlds.wit.stderr
+++ b/tests/cli/multiple-packages-multiple-main-worlds.wit.stderr
@@ -1,3 +1,3 @@
-error: multiple worlds found; one must be explicitly chosen:
+error: There are multiple worlds in `test:root`; one must be explicitly chosen:
   test:root/w1
   test:root/w2


### PR DESCRIPTION
This extends `Resolve::select_world` to be usable for lists of WITs. One such example is wit-bindgen's `generate` macro's `path:` parameter, which can take a list of WIT paths. It currently uses a [custom `select_world` implementation], but with this patch in wit-parser, it would be able to use `Resolve::select_world` instead.

I'm also considering extending the wit-bindgen CLI to accept multiple WIT paths; with this patch, it could use `Resolve::select_world` as well.

[custom `select_world` implementation]: https://github.com/bytecodealliance/wit-bindgen/blob/0e2201b8629b4144f45867161de7bc1fe26133bb/crates/guest-rust/macro/src/lib.rs#L191

Specifically, this PR makes the package argument to `Resolve::select_world` an `Option`, and adds code to handle the case where it's `None`. A `None` means the caller has a list of WITs and as such doesn't have a single main package.

This also rewrites the documentation for `select_world` to clean up already-obsolete references to the `packages` array argument, and to hopefully make it more clear how `select_world` makes its choice.