### PR TITLE
Remove --generate-dwarf from options in --help messages where it doesn't make sense

### DIFF
--- a/src/bin/wasm-tools/addr2line.rs
+++ b/src/bin/wasm-tools/addr2line.rs
@@ -21,6 +21,9 @@ use wasm_tools::addr2line::Addr2lineModules;
 #[derive(clap::Parser)]
 pub struct Opts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     /// Addresses to convert to filenames and line numbers.
@@ -44,7 +47,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let wasm = self.io.get_input_wasm()?;
+        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
 
         let mut modules = Addr2lineModules::parse(&wasm)
             .context("failed to parse input and read custom sections")?;

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -129,6 +129,9 @@ pub struct NewOpts {
     import_names: Vec<(String, String)>,
 
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     /// Skip validation of the output component.
@@ -169,7 +172,7 @@ impl NewOpts {
 
     /// Executes the application.
     fn run(self) -> Result<()> {
-        let wasm = self.io.get_input_wasm()?;
+        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
         let mut encoder = ComponentEncoder::default()
             .validate(!self.skip_validation)
             .reject_legacy_names(self.reject_legacy_names);
@@ -259,6 +262,9 @@ impl WitResolve {
 pub struct EmbedOpts {
     #[clap(flatten)]
     resolve: WitResolve,
+
+    #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
 
     #[clap(flatten)]
     io: wasm_tools::InputOutput,
@@ -391,7 +397,7 @@ impl EmbedOpts {
                 },
             )
         } else {
-            self.io.get_input_wasm()?
+            self.io.get_input_wasm(Some(&self.generate_dwarf))?
         };
 
         embed_component_metadata(
@@ -960,7 +966,7 @@ impl TargetsOpts {
     fn run(self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
         let world = resolve.select_world(&[pkg_id], self.world.as_deref())?;
-        let component_to_test = self.input.get_binary_wasm()?;
+        let component_to_test = self.input.get_binary_wasm(None)?;
 
         wit_component::targets(&resolve, world, &component_to_test)?;
 
@@ -1016,6 +1022,9 @@ impl SemverCheckOpts {
 #[derive(Parser)]
 pub struct UnbundleOpts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     /// Where to place unbundled core wasm modules.
@@ -1048,7 +1057,7 @@ impl UnbundleOpts {
     }
 
     fn run(self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
         if !wasmparser::Parser::is_component(&input) {
             return self.io.output_wasm(&input, self.wat);
         }

--- a/src/bin/wasm-tools/demangle.rs
+++ b/src/bin/wasm-tools/demangle.rs
@@ -24,7 +24,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
         let mut module = wasm_encoder::Module::new();
 
         for payload in Parser::new(0).parse_all(&input) {

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -20,7 +20,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
         let output = self.io.output_writer()?;
         let mut d = Dump::new(&input, output);
         d.run()?;

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -48,7 +48,7 @@ impl ShowOpts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
         let mut output = self.io.output_writer()?;
 
         let payload = wasm_metadata::Payload::from_binary(&input)?;
@@ -66,6 +66,9 @@ impl ShowOpts {
 #[derive(clap::Parser)]
 pub struct AddOpts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     #[clap(flatten)]
@@ -82,7 +85,7 @@ impl AddOpts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
 
         let add_metadata: AddMetadata = self.add_metadata.clone().into();
         let output = add_metadata.to_wasm(&input)?;

--- a/src/bin/wasm-tools/mutate.rs
+++ b/src/bin/wasm-tools/mutate.rs
@@ -54,7 +54,7 @@ impl Opts {
     }
 
     pub fn run(mut self) -> Result<()> {
-        let input_wasm = self.io.get_input_wasm()?;
+        let input_wasm = self.io.get_input_wasm(None)?;
 
         // Currently `self.wasm_mutate` is typed as `'static` for the input wasm
         // due to how this subcommand is defined. To get the input wasm to live

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -20,7 +20,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
 
         let mut printer = Printer {
             indices: Vec::new(),

--- a/src/bin/wasm-tools/parse.rs
+++ b/src/bin/wasm-tools/parse.rs
@@ -8,6 +8,9 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct Opts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     /// Output the text format of WebAssembly instead of the binary format.
@@ -21,7 +24,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let binary = self.io.parse_input_wasm()?;
+        let binary = self.io.parse_input_wasm(Some(&self.generate_dwarf))?;
         self.io.output_wasm(&binary, self.wat)?;
         Ok(())
     }

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -5,6 +5,9 @@ use clap::Parser;
 #[derive(Parser)]
 pub struct Opts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
     /// Whether or not to print binary offsets intermingled in the text format
@@ -49,7 +52,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let wasm = self.io.get_input_wasm()?;
+        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
 
         let mut config = wasmprinter::Config::new();
         config.print_offsets(self.print_offsets);

--- a/src/bin/wasm-tools/shrink.rs
+++ b/src/bin/wasm-tools/shrink.rs
@@ -41,7 +41,7 @@ impl Opts {
     }
 
     pub fn run(self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
         let initial_size = input.len();
 
         // Prerequisites for the predicate.

--- a/src/bin/wasm-tools/strip.rs
+++ b/src/bin/wasm-tools/strip.rs
@@ -32,7 +32,7 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
-        let input = self.io.get_input_wasm()?;
+        let input = self.io.get_input_wasm(None)?;
         let to_delete = regex::RegexSet::new(self.delete.iter())?;
 
         let strip_custom_section = |name: &str| {

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -36,6 +36,9 @@ Examples:
 ")]
 pub struct Opts {
     #[clap(flatten)]
+    generate_dwarf: wasm_tools::GenerateDwarfArg,
+
+    #[clap(flatten)]
     features: CliFeatures,
 
     #[clap(flatten)]
@@ -81,7 +84,7 @@ impl Opts {
 
     pub fn run(&self) -> Result<()> {
         let start = Instant::now();
-        let wasm = self.io.get_input_wasm()?; // no need to parse as the validator will do this
+        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?; // no need to parse as the validator will do this
         log::info!("read module in {:?}", start.elapsed());
 
         // If validation fails then try to attach extra information to the


### PR DESCRIPTION
Previously, a lot of subcommands listed the --generate-dwarf option in cases where no output file is produced, or where it doesn't make sense to add debug info. This change refactors the options to separate the option to generate DWARF from the generic input/output options.

The commands affected are: shrink, mutate, dump, objdump, strip, demangle, `component wit`, `component targets`, and `metadata show`. The --help messages for these commands no longer include --generate-dwarf.