### PR TITLE
Support `--features` CLI arguments for `wasm-tools component new`

### DIFF
--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -8,7 +8,7 @@ use wasm_encoder::ExportKind;
 use wasmparser::names::{ComponentName, ComponentNameKind};
 use wasmparser::{
     Encoding, ExternalKind, FuncType, Parser, Payload, TypeRef, ValType, ValidPayload, Validator,
-    types::TypesRef,
+    WasmFeatures, types::TypesRef,
 };
 use wit_parser::{
     Function, InterfaceId, PackageName, Resolve, Type, TypeDefKind, TypeId, World, WorldId,
@@ -59,7 +59,7 @@ impl ValidatedModule {
         import_map: Option<&ModuleImportMap>,
         info: Option<&LibraryInfo>,
     ) -> Result<ValidatedModule> {
-        let mut validator = Validator::new();
+        let mut validator = Validator::new_with_features(WasmFeatures::all());
         let mut ret = ValidatedModule::default();
 
         for payload in Parser::new(0).parse_all(bytes) {

--- a/crates/wit-component/tests/components/custom-page-sizes/component.wat
+++ b/crates/wit-component/tests/components/custom-page-sizes/component.wat
@@ -1,0 +1,23 @@
+(component
+  (core module $main (;0;)
+    (type (;0;) (func))
+    (table (;0;) 1 1 funcref)
+    (memory (;0;) 65536 (pagesize 0x1))
+    (global (;0;) (mut i32) i32.const 1024)
+    (export "memory" (memory 0))
+    (func (;0;) (type 0))
+    (func (;1;) (type 0)
+      call 0
+      call 0
+    )
+    (@producers
+      (processed-by "wit-component" "$CARGO_PKG_VERSION")
+      (processed-by "my-fake-bindgen" "123.45")
+    )
+  )
+  (core instance $main (;0;) (instantiate $main))
+  (alias core export $main "memory" (core memory $memory (;0;)))
+  (@producers
+    (processed-by "wit-component" "$CARGO_PKG_VERSION")
+  )
+)

--- a/crates/wit-component/tests/components/custom-page-sizes/component.wit.print
+++ b/crates/wit-component/tests/components/custom-page-sizes/component.wit.print
@@ -1,0 +1,4 @@
+package root:component;
+
+world root {
+}

--- a/crates/wit-component/tests/components/custom-page-sizes/module.wat
+++ b/crates/wit-component/tests/components/custom-page-sizes/module.wat
@@ -1,0 +1,12 @@
+(module
+  (type (;0;) (func))
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 65536 (pagesize 0x1))
+  (global (;0;) (mut i32) i32.const 1024)
+  (export "memory" (memory 0))
+  (func (;0;) (type 0))
+  (func (;1;) (type 0)
+    call 0
+    call 0
+  )
+)

--- a/crates/wit-component/tests/components/custom-page-sizes/module.wit
+++ b/crates/wit-component/tests/components/custom-page-sizes/module.wit
@@ -1,0 +1,3 @@
+package foo:foo;
+
+world module { }


### PR DESCRIPTION
Closes #2310 

~~This PR adds a `--features` argument to `wasm-tools component new` using the model of `wasm-tools validate`. This is done by parsing the `--features` arguments and propagating the features down to `ValidatedModule::new` which is the function responsible for initializing the `Validator` used when parsing the provided Wasm Module~~

This PR enables all of the features supported by `wasm-tools` in the `Validator` used when parsing the provided Wasm Module in `wasm-tools component new`

This PR is trying to be as targeted as possible but I would argue that  `--features` should be a argument global to `wasm-tools` and forwarded to every validator used when parsing `.wasm` modules.

