### PR TITLE
Print offset of final `end` in `wasm-tools print -p`

### DIFF
--- a/tests/cli/print-offsets.wat
+++ b/tests/cli/print-offsets.wat
@@ -1,0 +1,18 @@
+;; RUN[stack]: print -p %
+;; RUN[fold]: print -p % -f
+;; RUN[stack-valid]: print -p % | validate
+;; RUN[fold-valid]: print -p % -f | validate
+
+(module
+  (import "" "" (func))
+  (memory 1)
+  (table 1 funcref)
+  (global i32 i32.const 0)
+
+
+  (func)
+  (func i32.const 0 drop)
+
+  (data (i32.const 0) "100")
+  (elem (i32.const 0) func 0)
+)

--- a/tests/cli/print-offsets.wat.fold.stdout
+++ b/tests/cli/print-offsets.wat.fold.stdout
@@ -1,0 +1,18 @@
+(module
+(;@b     ;)  (type (;0;) (func))
+(;@11    ;)  (import "" "" (func (;0;) (type 0)))
+(;@1d    ;)  (table (;0;) 1 funcref)
+(;@23    ;)  (memory (;0;) 1)
+(;@28    ;)  (global (;0;) i32 (i32.const 0))
+(;@30    ;)  (elem (;0;) (i32.const 0) func 0)
+(;@3a    ;)  (func (;1;) (type 0)
+(;@3b    ;)    (;end;)
+             )
+(;@3d    ;)  (func (;2;) (type 0)
+(;@40    ;)    (drop
+(;@3e    ;)      (i32.const 0))
+(;@41    ;)    (;end;)
+             )
+(;@45    ;)  (data (;0;) (i32.const 0) "100")
+           )
+(;@4d    ;)

--- a/tests/cli/print-offsets.wat.stack.stdout
+++ b/tests/cli/print-offsets.wat.stack.stdout
@@ -1,0 +1,18 @@
+(module
+(;@b     ;)  (type (;0;) (func))
+(;@11    ;)  (import "" "" (func (;0;) (type 0)))
+(;@1d    ;)  (table (;0;) 1 funcref)
+(;@23    ;)  (memory (;0;) 1)
+(;@28    ;)  (global (;0;) i32 i32.const 0)
+(;@30    ;)  (elem (;0;) (i32.const 0) func 0)
+(;@3a    ;)  (func (;1;) (type 0)
+(;@3b    ;)    (;end;)
+             )
+(;@3d    ;)  (func (;2;) (type 0)
+(;@3e    ;)    i32.const 0
+(;@40    ;)    drop
+(;@41    ;)    (;end;)
+             )
+(;@45    ;)  (data (;0;) (i32.const 0) "100")
+           )
+(;@4d    ;)


### PR DESCRIPTION
I was looking at a validation error recently where the offset printed for an error wasn't present in `wasm-tools print -p`, and that was because the error was on the final `end` instruction of a function which isn't printed in the text format. This commit updates the output of `-p` to include a comment with an offset for the `end` instruction.