### PR TITLE
Remove error-context intrinsics from `--dummy`

### DIFF
--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -384,13 +384,6 @@ fn push_root_async_intrinsics(dst: &mut String) {
 (import "$root" "[thread-yield]" (func (result i32)))
 (import "$root" "[subtask-drop]" (func (param i32)))
 (import "$root" "[subtask-cancel]" (func (param i32) (result i32)))
-(import "$root" "[error-context-new-utf8]" (func (param i32 i32) (result i32)))
-(import "$root" "[error-context-new-utf16]" (func (param i32 i32) (result i32)))
-(import "$root" "[error-context-new-latin1+utf16]" (func (param i32 i32) (result i32)))
-(import "$root" "[error-context-debug-message-utf8]" (func (param i32 i32)))
-(import "$root" "[error-context-debug-message-utf16]" (func (param i32 i32)))
-(import "$root" "[error-context-debug-message-latin1+utf16]" (func (param i32 i32)))
-(import "$root" "[error-context-drop]" (func (param i32)))
 (import "$root" "[context-get-0]" (func (result i32)))
 (import "$root" "[context-set-0]" (func (param i32)))
 
@@ -400,6 +393,15 @@ fn push_root_async_intrinsics(dst: &mut String) {
 ;;(import "$root" "[cancellable][thread-yield]" (func (result i32)))
 ;;(import "$root" "[context-get-1]" (func (result i32)))
 ;;(import "$root" "[context-set-1]" (func (param i32)))
+
+;; deferred behind 📝 upstream
+;;(import "$root" "[error-context-new-utf8]" (func (param i32 i32) (result i32)))
+;;(import "$root" "[error-context-new-utf16]" (func (param i32 i32) (result i32)))
+;;(import "$root" "[error-context-new-latin1+utf16]" (func (param i32 i32) (result i32)))
+;;(import "$root" "[error-context-debug-message-utf8]" (func (param i32 i32)))
+;;(import "$root" "[error-context-debug-message-utf16]" (func (param i32 i32)))
+;;(import "$root" "[error-context-debug-message-latin1+utf16]" (func (param i32 i32)))
+;;(import "$root" "[error-context-drop]" (func (param i32)))
 "#,
     );
 }


### PR DESCRIPTION
These are gated behind a separate feature from component-model-async, so defer adding them to later.