### PR TITLE
Initial skeleton of async support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbtest"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3be567977128c0f71ad1462d9624ccda712193d124e944252f0c5789a06d46"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +147,15 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 name = "artifacts"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cargo_metadata",
+ "tempfile",
+ "wasi-preview1-component-adapter-provider",
+ "wasm-compose",
+ "wasmparser 0.239.0",
+ "wit-component 0.239.0",
+ "wit-dylib",
+ "wit-parser 0.239.0",
 ]
 
 [[package]]
@@ -777,6 +794,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fuzz-stats"
 version = "0.0.0"
 dependencies = [
@@ -1378,6 +1484,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1539,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1729,6 +1857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1968,8 @@ dependencies = [
 name = "test-programs"
 version = "0.1.0"
 dependencies = [
+ "rand",
+ "wit-bindgen",
  "wit-dylib-ffi",
 ]
 
@@ -2070,6 +2206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2247,18 @@ dependencies = [
  "url",
  "wasm-encoder 0.239.0",
  "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
+dependencies = [
+ "anyhow",
+ "indexmap 2.10.0",
+ "wasm-encoder 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2314,6 +2472,18 @@ dependencies = [
  "wasm-encoder 0.239.0",
  "wast",
  "wat",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
+ "semver",
 ]
 
 [[package]]
@@ -2769,6 +2939,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "git+https://github.com/alexcrichton/wit-bindgen?branch=wit-dylib-support#36e1e77c8a7c7d2735b0929a72316b29d3438754"
+dependencies = [
+ "futures",
+ "once_cell",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.46.0"
+source = "git+https://github.com/alexcrichton/wit-bindgen?branch=wit-dylib-support#36e1e77c8a7c7d2735b0929a72316b29d3438754"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +2974,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.46.0"
+source = "git+https://github.com/alexcrichton/wit-bindgen?branch=wit-dylib-support#36e1e77c8a7c7d2735b0929a72316b29d3438754"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.10.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-bindgen-core",
+ "wit-component 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.46.0"
+source = "git+https://github.com/alexcrichton/wit-bindgen?branch=wit-dylib-support#36e1e77c8a7c7d2735b0929a72316b29d3438754"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -2831,26 +3050,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.10.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-metadata 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wit-dylib"
 version = "0.239.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
+ "arbtest",
  "artifacts",
  "clap",
+ "env_logger",
  "indexmap 2.10.0",
  "libtest-mimic",
  "tempfile",
- "wasi-preview1-component-adapter-provider",
- "wasm-compose",
  "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
  "wit-component 0.239.0",
  "wit-parser 0.239.0",
+ "wit-smith",
 ]
 
 [[package]]
 name = "wit-dylib-ffi"
 version = "0.1.0"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wit-encoder"
@@ -2920,6 +3162,24 @@ dependencies = [
  "wasmparser 0.239.0",
  "wat",
  "wit-parser 0.239.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.10.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.239.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,8 @@ url = "2.0.0"
 wasmtime = { version = "34.0.1", default-features = false, features = ['cranelift', 'component-model', 'runtime', 'gc-drc'] }
 thiserror = "2.0.12"
 tempfile = "3.2.0"
+# wit-bindgen = { version = '0.46', default-features = false }
+wit-bindgen = { git = 'https://github.com/alexcrichton/wit-bindgen', branch = 'wit-dylib-support', default-features = false }
 
 wasm-compose = { version = "0.239.0", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.239.0", path = "crates/wasm-encoder", default-features = false }

--- a/crates/wit-dylib/Cargo.toml
+++ b/crates/wit-dylib/Cargo.toml
@@ -19,16 +19,19 @@ wit-parser = { workspace = true }
 wasm-encoder = { workspace = true }
 indexmap = { workspace = true }
 clap = { workspace = true, optional = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 artifacts = { path = './test-programs/artifacts' }
 libtest-mimic = { workspace = true }
 anyhow = { workspace = true }
-wit-component = { workspace = true }
-wasi-preview1-component-adapter-provider = "36.0.2"
 tempfile = { workspace = true }
-wasm-compose = { workspace = true }
-wasmparser = { workspace = true }
+wit-smith = { workspace = true }
+arbitrary = { workspace = true }
+arbtest = "0.3.2"
+indexmap = { workspace = true }
+wit-component = { workspace = true }
+env_logger = { workspace = true }
 
 [lib]
 test = false

--- a/crates/wit-dylib/ffi/Cargo.toml
+++ b/crates/wit-dylib/ffi/Cargo.toml
@@ -10,3 +10,10 @@ workspace = true
 [lib]
 test = false
 doctest = false
+
+[dependencies]
+wit-bindgen = { workspace = true, optional = true, features = ['async'] }
+
+[features]
+default = ['async']
+async = ['dep:wit-bindgen']

--- a/crates/wit-dylib/ffi/src/ffi.rs
+++ b/crates/wit-dylib/ffi/src/ffi.rs
@@ -33,15 +33,31 @@ pub const WIT_V0: u32 = 0;
 pub type wit_type_t = u32;
 pub type wit_import_fn_t =
     ::std::option::Option<unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void)>;
+pub type wit_import_async_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        cx: *mut ::std::os::raw::c_void,
+        abi_area: *mut ::std::os::raw::c_void,
+    ) -> u32,
+>;
+pub type wit_import_async_lift_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void, abi_area: *mut ::std::os::raw::c_void),
+>;
+pub type wit_export_task_return_fn_t =
+    ::std::option::Option<unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wit_func {
     pub interface: *const ::std::os::raw::c_char,
     pub name: *const ::std::os::raw::c_char,
     pub impl_: wit_import_fn_t,
+    pub async_impl: wit_import_async_fn_t,
+    pub async_lift_impl: wit_import_async_lift_fn_t,
+    pub task_return: wit_export_task_return_fn_t,
     pub nparams: usize,
     pub params: *const wit_type_t,
     pub result: wit_type_t,
+    pub async_abi_area_size: usize,
+    pub async_abi_area_align: usize,
 }
 pub type wit_func_t = wit_func;
 pub type wit_resource_drop_t = ::std::option::Option<unsafe extern "C" fn(arg1: u32)>;

--- a/crates/wit-dylib/src/async_.rs
+++ b/crates/wit-dylib/src/async_.rs
@@ -1,0 +1,195 @@
+use anyhow::{Result, bail};
+use std::collections::HashSet;
+use std::fmt;
+use wit_parser::{Function, FunctionKind, Resolve, WorldKey};
+
+/// Structure used to parse the command line argument `--async` consistently
+/// across guest generators.
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[derive(Clone, Default, Debug)]
+pub struct AsyncFilterSet {
+    /// Determines which functions to lift or lower `async`, if any.
+    ///
+    /// This option can be passed multiple times and additionally accepts
+    /// comma-separated values for each option passed. Each individual argument
+    /// passed here can be one of:
+    ///
+    /// - `all` - all imports and exports will be async
+    /// - `-all` - force all imports and exports to be sync
+    /// - `foo:bar/baz#method` - force this method to be async
+    /// - `import:foo:bar/baz#method` - force this method to be async, but only
+    ///   as an import
+    /// - `-export:foo:bar/baz#method` - force this export to be sync
+    ///
+    /// If a method is not listed in this option then the WIT's default bindings
+    /// mode will be used. If the WIT function is defined as `async` then async
+    /// bindings will be generated, otherwise sync bindings will be generated.
+    ///
+    /// Options are processed in the order they are passed here, so if a method
+    /// matches two directives passed the least-specific one should be last.
+    #[cfg_attr(
+        feature = "clap",
+        arg(
+            long = "async",
+            value_parser = parse_async,
+            value_delimiter =',',
+            value_name = "FILTER",
+        ),
+    )]
+    async_: Vec<Async>,
+
+    #[cfg_attr(feature = "clap", arg(skip))]
+    used_options: HashSet<usize>,
+}
+
+#[cfg(feature = "clap")]
+fn parse_async(s: &str) -> Result<Async, String> {
+    Ok(Async::parse(s))
+}
+
+impl AsyncFilterSet {
+    /// Returns a set where all functions should be async or not depending on
+    /// `async_` provided.
+    pub fn all(async_: bool) -> AsyncFilterSet {
+        AsyncFilterSet {
+            async_: vec![Async {
+                enabled: async_,
+                filter: AsyncFilter::All,
+            }],
+            used_options: HashSet::new(),
+        }
+    }
+
+    /// Returns whether the `func` provided is to be bound `async` or not.
+    pub fn is_async(
+        &mut self,
+        resolve: &Resolve,
+        interface: Option<&WorldKey>,
+        func: &Function,
+        is_import: bool,
+    ) -> bool {
+        let name_to_test = match interface {
+            Some(key) => format!("{}#{}", resolve.name_world_key(key), func.name),
+            None => func.name.clone(),
+        };
+        for (i, opt) in self.async_.iter().enumerate() {
+            let name = match &opt.filter {
+                AsyncFilter::All => {
+                    self.used_options.insert(i);
+                    return opt.enabled;
+                }
+                AsyncFilter::Function(s) => s,
+                AsyncFilter::Import(s) => {
+                    if !is_import {
+                        continue;
+                    }
+                    s
+                }
+                AsyncFilter::Export(s) => {
+                    if is_import {
+                        continue;
+                    }
+                    s
+                }
+            };
+            if *name == name_to_test {
+                self.used_options.insert(i);
+                return opt.enabled;
+            }
+        }
+
+        match &func.kind {
+            FunctionKind::Freestanding
+            | FunctionKind::Method(_)
+            | FunctionKind::Static(_)
+            | FunctionKind::Constructor(_) => false,
+            FunctionKind::AsyncFreestanding
+            | FunctionKind::AsyncMethod(_)
+            | FunctionKind::AsyncStatic(_) => true,
+        }
+    }
+
+    /// Intended to be used in the header comment of generated code to help
+    /// indicate what options were specified.
+    pub fn debug_opts(&self) -> impl Iterator<Item = String> + '_ {
+        self.async_.iter().map(|opt| opt.to_string())
+    }
+
+    /// Tests whether all `--async` options were used throughout bindings
+    /// generation, returning an error if any were unused.
+    pub fn ensure_all_used(&self) -> Result<()> {
+        for (i, opt) in self.async_.iter().enumerate() {
+            if self.used_options.contains(&i) {
+                continue;
+            }
+            if !matches!(opt.filter, AsyncFilter::All) {
+                bail!("unused async option: {opt}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns whether any option explicitly requests that async is enabled.
+    pub fn any_enabled(&self) -> bool {
+        self.async_.iter().any(|o| o.enabled)
+    }
+
+    /// Pushes a new option into this set.
+    pub fn push(&mut self, directive: &str) {
+        self.async_.push(Async::parse(directive));
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Async {
+    enabled: bool,
+    filter: AsyncFilter,
+}
+
+impl Async {
+    fn parse(s: &str) -> Async {
+        let (s, enabled) = match s.strip_prefix('-') {
+            Some(s) => (s, false),
+            None => (s, true),
+        };
+        let filter = match s {
+            "all" => AsyncFilter::All,
+            other => match other.strip_prefix("import:") {
+                Some(s) => AsyncFilter::Import(s.to_string()),
+                None => match other.strip_prefix("export:") {
+                    Some(s) => AsyncFilter::Export(s.to_string()),
+                    None => AsyncFilter::Function(s.to_string()),
+                },
+            },
+        };
+        Async { enabled, filter }
+    }
+}
+
+impl fmt::Display for Async {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.enabled {
+            write!(f, "-")?;
+        }
+        self.filter.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AsyncFilter {
+    All,
+    Function(String),
+    Import(String),
+    Export(String),
+}
+
+impl fmt::Display for AsyncFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AsyncFilter::All => write!(f, "all"),
+            AsyncFilter::Function(s) => write!(f, "{s}"),
+            AsyncFilter::Import(s) => write!(f, "import:{s}"),
+            AsyncFilter::Export(s) => write!(f, "export:{s}"),
+        }
+    }
+}

--- a/crates/wit-dylib/src/bindgen.rs
+++ b/crates/wit-dylib/src/bindgen.rs
@@ -32,10 +32,12 @@ macro_rules! intrinsics {
 intrinsics! {
     initialize : [ValType::I32] -> [] = "wit_dylib_initialize",
     cabi_realloc : [ValType::I32; 4] -> [ValType::I32] = "cabi_realloc",
-    dealloc_bytes : [ValType::I32; 3] -> [] = "wit_dylib_dealloc_bytes",
+    dealloc_bytes : [ValType::I32; 5] -> [] = "wit_dylib_dealloc_bytes",
 
     export_start : [ValType::I32] -> [ValType::I32] = "wit_dylib_export_start",
     export_call : [ValType::I32; 2] -> [] = "wit_dylib_export_call",
+    export_async_call : [ValType::I32; 2] -> [ValType::I32] = "wit_dylib_export_async_call",
+    export_async_callback : [ValType::I32; 4] -> [ValType::I32] = "wit_dylib_export_async_callback",
     export_finish : [ValType::I32; 2] -> [] = "wit_dylib_export_finish",
     resource_dtor : [ValType::I32; 2] -> [] = "wit_dylib_resource_dtor",
 
@@ -104,17 +106,157 @@ pub fn import(
     import_idx: u32,
 ) -> Function {
     let sig = resolve.wasm_signature(abi, func);
-    let mut c = FunctionCompiler::new(adapter, resolve, 1);
+    let initial_locals = if abi.is_async() { 2 } else { 1 };
+    let mut c = FunctionCompiler::new(adapter, resolve, initial_locals);
     let frame = c.stack_frame(func, &sig, abi);
-    let fp = c.allocate_stack_frame(&frame);
+    c.allocate_stack_frame(&frame);
     c.ctx = Some(TempLocal::new(0, ValType::I32));
 
-    c.lower_import_params(func, &sig, &frame, fp.as_ref());
-    c.ins().call(import_idx);
-    c.lift_import_results(func, &sig, &frame, fp.as_ref());
+    let async_retptr_offset = async_import_retptr_offset(c.adapter, resolve, func);
 
-    c.deallocate_lowered_lists();
-    c.deallocate_stack_frame(&frame, fp);
+    c.lower_import_params(
+        func,
+        &sig,
+        |me| {
+            if abi.is_async() {
+                // Async lowering requires a long-lived pointer meaning that it
+                // must be provided by the caller. It's the second parameter to
+                // the function.
+                Memory {
+                    addr: TempLocal::new(1, ValType::I32),
+                    offset: 0,
+                }
+            } else {
+                // Sync lowering only requires a temporary pointer, so use the
+                // space allocated in `stack_frame` for us.
+                let fp = me.fp.as_ref().unwrap();
+                Memory {
+                    addr: TempLocal::new(fp.idx, fp.ty),
+                    offset: frame.abi_param_offset.unwrap(),
+                }
+            }
+        },
+        |me| {
+            if abi.is_async() {
+                // Async results, like parameters, must be in a long-lived
+                // location. This is in the same allocation as parameters, but
+                // at an offset further in.
+                Memory {
+                    addr: TempLocal::new(1, ValType::I32),
+                    offset: async_retptr_offset.unwrap().try_into().unwrap(),
+                }
+            } else {
+                // Sync results are stored on the stack, also allocated in
+                // `stack_frame` above like with indirect parameters.
+                let fp = me.fp.as_ref().unwrap();
+                let AbiLoc::Memory(mem) = frame.abi_loc(fp).unwrap() else {
+                    unreachable!()
+                };
+                mem
+            }
+        },
+    );
+    c.ins().call(import_idx);
+
+    // Async imports return the result of the raw function directly, the
+    // status code result. Sync imports need to actually lift results and then
+    // clean up any temporary allocations/stack space.
+    if !abi.is_async() {
+        let tmp = if !sig.retptr && func.result.is_some() {
+            let tmp_ty = c.adapter.map_wasm_type(sig.results[0]);
+            Some(c.local_set_new_tmp(tmp_ty))
+        } else {
+            None
+        };
+
+        c.lift_import_results(
+            func,
+            &sig,
+            || AbiLoc::Stack(slice::from_ref(tmp.as_ref().unwrap())),
+            |me| frame.abi_loc(me.fp.as_ref().unwrap()).unwrap(),
+        );
+        if let Some(tmp) = tmp {
+            c.free_temp_local(tmp);
+        }
+    }
+    c.deallocate_stack_frame(&frame);
+    c.finish()
+}
+
+/// Returns the list of types that are going to be stored in the "abi area" that
+/// is long-lived for a function call.
+///
+/// This returns all parameters, if they're passed indirectly, and then always
+/// returns the result if there is one.
+pub fn async_import_abi_area_types<'a>(
+    resolve: &Resolve,
+    func: &'a wit_parser::Function,
+) -> impl Iterator<Item = &'a Type> {
+    let sig = resolve.wasm_signature(AbiVariant::GuestImportAsync, func);
+    let include_params = sig.indirect_params;
+    func.params
+        .iter()
+        .filter_map(move |(_, ty)| if include_params { Some(ty) } else { None })
+        .chain(func.result.iter())
+}
+
+/// Returns the offset, in bytes, within the async_abi_area allocated for an
+/// async import call, to the return value.
+///
+/// Async parameters, if indirect, and async results, always, are required to be
+/// in a long-lived location outside of the original call itself. This function
+/// returns the offset from the start of this allocation to the return value.
+/// This is plubmed through to the guest in `async_abi_area_{size,align}`.
+fn async_import_retptr_offset(
+    adapter: &mut Adapter,
+    resolve: &Resolve,
+    func: &wit_parser::Function,
+) -> Option<u32> {
+    if !func.result.is_some() {
+        return None;
+    }
+
+    let types = async_import_abi_area_types(resolve, func);
+    let (size, _ty) = adapter.sizes.field_offsets(types).pop().unwrap();
+    Some(size.size_wasm32().try_into().unwrap())
+}
+
+/// Generates a function that is suitable for learning about the results of an
+/// async function call.
+///
+/// This can't be bundled into `import` for async functions because they
+/// complete at a different point of time from when the import is invoked. This
+/// function is passed the `cx` argument plus the "abi area" that was also
+/// passed to `import`. This location in linear memory is where results are
+/// lifted from and converted via `wit_dylib_push_*` into the `cx` argument.
+pub fn lift_async_import_results(
+    adapter: &mut Adapter,
+    resolve: &Resolve,
+    func: &wit_parser::Function,
+    abi: AbiVariant,
+) -> Function {
+    assert!(abi.is_async());
+    let sig = resolve.wasm_signature(abi, func);
+    let mut c = FunctionCompiler::new(adapter, resolve, 2);
+    c.ctx = Some(TempLocal::new(0, ValType::I32));
+
+    let async_retptr_offset = async_import_retptr_offset(c.adapter, resolve, func);
+    c.lift_import_results(
+        func,
+        &sig,
+        // Not possible to lift arguments from the stack for async functions,
+        // it's always through a "retptr"
+        || unreachable!(),
+        // The pointer to results is in the second parameter passed to this
+        // function, and results are located at the offset defined by
+        // `async_import_retptr_offset`.
+        |_| {
+            AbiLoc::Memory(Memory {
+                addr: TempLocal::new(1, ValType::I32),
+                offset: async_retptr_offset.unwrap(),
+            })
+        },
+    );
 
     c.finish()
 }
@@ -125,14 +267,13 @@ pub fn export(
     func: &wit_parser::Function,
     abi: AbiVariant,
     func_metadata_index: usize,
-) -> (Function, bool) {
+) -> Function {
     let sig = resolve.wasm_signature(abi, func);
     let mut c = FunctionCompiler::new(adapter, resolve, sig.params.len() as u32);
     let frame = c.stack_frame(func, &sig, abi);
-    let fp = c.allocate_stack_frame(&frame);
+    c.allocate_stack_frame(&frame);
 
     let export_start = c.adapter.intrinsics().export_start;
-    let export_call = c.adapter.intrinsics().export_call;
 
     c.ins().i32_const(func_metadata_index.try_into().unwrap());
     c.ins().call(export_start);
@@ -140,58 +281,64 @@ pub fn export(
 
     c.lift_export_params(func, &sig);
 
-    c.local_get_ctx();
-    c.ins().i32_const(func_metadata_index.try_into().unwrap());
-    c.ins().call(export_call);
+    if abi.is_async() {
+        // Async exports use the lifted params from above, but do not handle the
+        // lowered results. That's the responsibility of the
+        // `task_return`-generated function. Here the `cx` is passed along with
+        // the function index. Notably this has different ownership semantics
+        // around `cx` where the callee gets onwership, unlike sync where
+        // `export_call` does not get ownership.
+        //
+        // Additionally the `export_async_call` function always returns an `i32`
+        // status code, which is plumbed through here to the end.
+        let export_async_call = c.adapter.intrinsics().export_async_call;
+        c.local_get_ctx();
+        let l_ctx = c.ctx.take().unwrap();
+        c.free_temp_local(l_ctx);
+        c.ins().i32_const(func_metadata_index.try_into().unwrap());
+        c.ins().call(export_async_call);
+        c.deallocate_stack_frame(&frame);
+    } else {
+        let export_call = c.adapter.intrinsics().export_call;
+        c.local_get_ctx();
+        c.ins().i32_const(func_metadata_index.try_into().unwrap());
+        c.ins().call(export_call);
 
-    c.lower_export_results(func, &sig, &frame, fp.as_ref());
+        c.lower_export_results(func, &sig, &frame);
 
-    // Note that this function intentionally does not deallocate the stack space
-    // allocated above in `allocate_stack_frame`. That is the responsibility of
-    // the post-return function to ensure that the owned value on the stack, the
-    // return value, can get cleaned up properly. Additionally any dynamically
-    // allocated lists will be stored on the stack and will get cleaned up
-    // during post-return.
-    //
-    // Instead this actually allocates *more* stack space to save off `c.ctx`
-    // into the stack-local memory. This also stores the dynamic number of lists
-    // to deallocate if that was generated during this function.
+        // Note that this function intentionally does not deallocate the stack space
+        // allocated above in `allocate_stack_frame`. That is the responsibility of
+        // the post-return function to ensure that the owned value on the stack, the
+        // return value, can get cleaned up properly. Additionally any dynamically
+        // allocated lists will be stored on the stack and will get cleaned up
+        // during post-return.
+        //
+        // Instead this actually allocates *more* stack space to save off `c.ctx`
+        // into the stack-local memory. This also stores the dynamic number of lists
+        // to deallocate if that was generated during this function.
 
-    let sp = c.adapter.stack_pointer();
-    c.ins().global_get(sp);
-    c.ins().i32_const(8);
-    c.ins().i32_sub();
-    let l_scratch = c.local_tee_new_tmp(ValType::I32);
-    c.ins().global_set(sp);
+        let sp = c.adapter.stack_pointer();
+        c.ins().global_get(sp);
+        c.ins().i32_const(8);
+        c.ins().i32_sub();
+        let l_scratch = c.local_tee_new_tmp(ValType::I32);
+        c.ins().global_set(sp);
 
-    let l_ctx = c.ctx.take().unwrap();
-    c.ins().local_get(l_scratch.idx);
-    c.ins().local_get(l_ctx.idx);
-    c.ins().i32_store(MemArg {
-        memory_index: 0,
-        align: 2,
-        offset: 0,
-    });
-    c.free_temp_local(l_ctx);
-
-    let may_have_dynamic_lists_to_free = c.num_dynamic_lists_to_free.is_some();
-    if let Some(l_num) = c.num_dynamic_lists_to_free.take() {
+        let l_ctx = c.ctx.take().unwrap();
         c.ins().local_get(l_scratch.idx);
-        c.ins().local_get(l_num.idx);
+        c.ins().local_get(l_ctx.idx);
         c.ins().i32_store(MemArg {
             memory_index: 0,
             align: 2,
-            offset: 4,
+            offset: 0,
         });
-        c.free_temp_local(l_num);
+        c.free_temp_local(l_ctx);
+        c.free_temp_local(l_scratch);
+        if let Some(fp) = c.fp.take() {
+            c.free_temp_local(fp);
+        }
     }
-
-    c.free_temp_local(l_scratch);
-    if let Some(fp) = fp {
-        c.free_temp_local(fp);
-    }
-
-    (c.finish(), may_have_dynamic_lists_to_free)
+    c.finish()
 }
 
 pub fn post_return(
@@ -200,8 +347,8 @@ pub fn post_return(
     func: &wit_parser::Function,
     abi: AbiVariant,
     func_metadata_index: usize,
-    may_have_dynamic_lists_to_free: bool,
 ) -> Function {
+    assert!(!abi.is_async());
     let sig = resolve.wasm_signature(abi, func);
     let mut c = FunctionCompiler::new(adapter, resolve, sig.results.len() as u32);
     let frame = c.stack_frame(func, &sig, abi);
@@ -220,22 +367,6 @@ pub fn post_return(
     });
     c.ctx = Some(c.local_set_new_tmp(ValType::I32));
 
-    // If the main exported function may have dynamically allocated lists during
-    // lowering then the metadata for what to deallocate is at the bottom of the
-    // stack. The last element is the number of lists to free, and then there's
-    // N entries of what to free. Load the number here, then use
-    // deallocate_lowered_lists` later to handle the actual deallocation and
-    // restoration of the stack pointer.
-    if may_have_dynamic_lists_to_free {
-        c.ins().local_get(l_sp.idx);
-        c.ins().i32_load(MemArg {
-            memory_index: 0,
-            align: 2,
-            offset: 4,
-        });
-        c.num_dynamic_lists_to_free = Some(c.local_set_new_tmp(ValType::I32));
-    }
-
     // Bump sp by 8 bytes to restore it to just before the end of the export
     // call originally.
     c.ins().local_get(l_sp.idx);
@@ -243,12 +374,6 @@ pub fn post_return(
     c.ins().i32_const(8);
     c.ins().i32_add();
     c.ins().global_set(sp);
-
-    // Restore the stack by discarding all lists only needed for the canonical
-    // ABI which are no longer necessary.
-    if c.num_dynamic_lists_to_free.is_some() {
-        c.deallocate_lowered_lists();
-    }
 
     // Tell the interpreter that the export has now finished.
     let export_finish = c.adapter.intrinsics().export_finish;
@@ -262,10 +387,42 @@ pub fn post_return(
     // And finally deallocate the stack frame, if present.
     if frame.size > 0 {
         c.ins().global_get(sp);
-        let fp = c.local_set_new_tmp(ValType::I32);
-        c.deallocate_stack_frame(&frame, Some(fp));
+        c.fp = Some(c.local_set_new_tmp(ValType::I32));
+        c.deallocate_stack_frame(&frame);
     }
     c.finish()
+}
+
+/// Generates a function suitable to use as `task.return` for a particular
+/// exported function.
+///
+/// This function takes a single `cx` argument from which languages values are
+/// "popped" and placed into their ABI locations to return from an async export.
+pub fn task_return(
+    adapter: &mut Adapter,
+    resolve: &Resolve,
+    func: &wit_parser::Function,
+    abi: AbiVariant,
+    task_return_import: u32,
+) -> Function {
+    assert!(abi.is_async());
+
+    // The `task.return` intrinsic works as-if the return value of this function
+    // is passed to an imported function. Simulate bindings for it by literally
+    // running the `import` bindings generator with a dummy function that has
+    // its type modified to reflect what the `task.return` intrinsic looks like.
+    let mut dummy_func = func.clone();
+    dummy_func.params = Vec::new();
+    if let Some(ty) = dummy_func.result.take() {
+        dummy_func.params.push(("x".to_string(), ty));
+    }
+    import(
+        adapter,
+        resolve,
+        &dummy_func,
+        AbiVariant::GuestImport,
+        task_return_import,
+    )
 }
 
 struct FunctionCompiler<'a> {
@@ -275,9 +432,17 @@ struct FunctionCompiler<'a> {
     locals: Vec<(u32, ValType)>,
     free_locals: HashMap<ValType, Vec<u32>>,
     nlocals: u32,
-    using_temp_stack: u32,
 
-    num_dynamic_lists_to_free: Option<TempLocal>,
+    /// A local which is the "frame pointer" or a pointer to the base of this
+    /// frame's stack allocation.
+    ///
+    /// This is `None` until `allocate_stack_frame` and will continue to be
+    /// `None` if the stack size is 0.
+    fp: Option<TempLocal>,
+
+    /// A static offset from `fp` to the "temp location" on the stack.
+    stack_temp_offset: Option<u32>,
+
     ctx: Option<TempLocal>,
 }
 
@@ -290,9 +455,9 @@ impl<'a> FunctionCompiler<'a> {
             locals: Vec::new(),
             free_locals: HashMap::new(),
             nlocals,
-            num_dynamic_lists_to_free: None,
-            using_temp_stack: 0,
             ctx: None,
+            fp: None,
+            stack_temp_offset: None,
         }
     }
 
@@ -322,6 +487,14 @@ impl<'a> FunctionCompiler<'a> {
     fn local_get_ctx(&mut self) {
         let idx = self.ctx.as_ref().unwrap().idx;
         self.ins().local_get(idx);
+    }
+
+    fn local_get_stack_temp_addr(&mut self) {
+        let fp = self.fp.as_ref().unwrap().idx;
+        self.ins().local_get(fp);
+        let off = self.stack_temp_offset.unwrap();
+        self.ins().i32_const(off.try_into().unwrap());
+        self.ins().i32_add();
     }
 
     fn gen_temp_local(&mut self, ty: ValType) -> TempLocal {
@@ -362,73 +535,18 @@ impl<'a> FunctionCompiler<'a> {
     }
 
     fn finish(self) -> Function {
-        assert!(self.num_dynamic_lists_to_free.is_none());
-        assert!(self.using_temp_stack == 0);
         let mut func = Function::new(self.locals);
         func.raw(self.bytecode);
         func.instructions().end();
         func
     }
 
-    fn deallocate_lowered_lists(&mut self) {
-        let dealloc_bytes = self.adapter.intrinsics().dealloc_bytes;
-
-        let Some(l_dynamic) = self.num_dynamic_lists_to_free.take() else {
-            return;
-        };
-        let sp = self.adapter.stack_pointer();
-        self.ins().global_get(sp);
-        let l_sp = self.local_set_new_tmp(ValType::I32);
-        let memarg = |offset| MemArg {
-            memory_index: 0,
-            offset,
-            align: 2,
-        };
-        self.ins().loop_(BlockType::Empty);
-        {
-            // if the counter is > 0 then keep going.
-            self.ins().local_get(l_dynamic.idx);
-            self.ins().if_(BlockType::Empty);
-            {
-                // Load ptr/len/align and deallocate
-                self.ins().local_get(l_sp.idx);
-                self.ins().i32_load(memarg(0));
-                self.ins().local_get(l_sp.idx);
-                self.ins().i32_load(memarg(4));
-                self.ins().local_get(l_sp.idx);
-                self.ins().i32_load(memarg(8));
-                self.ins().call(dealloc_bytes);
-
-                // Bump l_sp
-                self.ins().local_get(l_sp.idx);
-                self.ins().i32_const(16);
-                self.ins().i32_add();
-                self.ins().local_set(l_sp.idx);
-
-                // Decrement l_dynamic
-                self.ins().local_get(l_dynamic.idx);
-                self.ins().i32_const(1);
-                self.ins().i32_sub();
-                self.ins().local_set(l_dynamic.idx);
-
-                self.ins().br(1);
-            }
-            self.ins().end();
-        }
-        self.ins().end();
-
-        self.ins().local_get(l_sp.idx);
-        self.ins().global_set(sp);
-
-        self.free_temp_local(l_sp);
-        self.free_temp_local(l_dynamic);
-    }
-
-    fn deallocate_stack_frame(&mut self, frame: &StackFrame, fp: Option<TempLocal>) {
+    fn deallocate_stack_frame(&mut self, frame: &StackFrame) {
         if frame.size == 0 {
             return;
         }
-        let fp = fp.unwrap();
+        let fp = self.fp.take().unwrap();
+        self.stack_temp_offset = None;
         let sp = self.adapter.stack_pointer();
         self.ins().local_get(fp.idx);
         self.ins().i32_const(frame.size as i32);
@@ -447,98 +565,114 @@ impl<'a> FunctionCompiler<'a> {
         // that this is used for both imported and exported functions. The way
         // exports work is that we defer stack cleanup to happening in
         // post-return.
-        let ret_size = if sig.retptr {
+        let (ret_size, ret_align) = if sig.retptr && !abi.is_async() {
             let info = self.adapter.sizes.record(&func.result);
-            assert!(info.align.align_wasm32() <= 8);
-
-            info.size.size_wasm32().try_into().unwrap()
+            (
+                info.size.size_wasm32().try_into().unwrap(),
+                info.align.align_wasm32().try_into().unwrap(),
+            )
         } else {
-            0
+            (0, 1)
         };
 
         // Allocate space for the in-memory abi parameters for imports. Note
         // that exports are heap-allocated by the caller but for imports it's
         // the responsibility of the caller to provide an appropriate parameter.
-        let abi_param_size = match abi {
+        let (abi_param_size, abi_param_align) = match abi {
             AbiVariant::GuestImport if sig.indirect_params => {
                 let info = self
                     .adapter
                     .sizes
                     .params(func.params.iter().map(|(_, ty)| ty));
-                info.size.size_wasm32().try_into().unwrap()
+                (
+                    info.size.size_wasm32().try_into().unwrap(),
+                    info.align.align_wasm32().try_into().unwrap(),
+                )
             }
-            AbiVariant::GuestImport => 0,
-            AbiVariant::GuestExport => 0,
-            AbiVariant::GuestImportAsync => todo!("async"),
-            AbiVariant::GuestExportAsync => todo!("async"),
+            AbiVariant::GuestImport => (0, 1),
+            AbiVariant::GuestExport => (0, 1),
+            AbiVariant::GuestImportAsync => (0, 1),
+            AbiVariant::GuestExportAsync => (0, 1),
             AbiVariant::GuestExportAsyncStackful => todo!("async"),
         };
 
-        let size = align_up(align_up(ret_size, 4) + align_up(abi_param_size, 4), 8);
-        let mut offset = 0;
-        let abi_param_offset = if abi_param_size > 0 {
-            let ret = offset;
-            offset += align_up(abi_param_size, 4);
-            Some(ret.try_into().unwrap())
-        } else {
-            None
-        };
-        let retptr_offset = if ret_size > 0 {
-            let ret = offset;
-            offset += align_up(ret_size, 4);
-            Some(ret.try_into().unwrap())
-        } else {
-            None
-        };
+        // TODO: should look at the operation being done and the types in play
+        // to see if this is actually needed.
+        let (stack_temp_size, stack_temp_align) = (4, 4);
 
-        let _ = offset;
+        // The stack frame is allocated as, in order of lower-to-higher
+        // addresses:
+        //
+        // * The ABI parameter area
+        // * The return pointer area
+        // * The stack temp area
+        //
+        // TODO: should probably sort these areas by alignment to minimize the
+        // size of the allocation.
+
+        let mut offset = 0;
+        let mut bump = |size, align| {
+            // If the natural wasm stack alignment is exceeded we'd need more
+            // instructions here, so defer that to some other time if it's actually
+            // needed.
+            assert!(align <= 16);
+            if size == 0 {
+                None
+            } else {
+                let ret = align_up(offset, align);
+                offset = ret + size;
+                Some(ret.try_into().unwrap())
+            }
+        };
+        let abi_param_offset = bump(abi_param_size, abi_param_align);
+        let retptr_offset = bump(ret_size, ret_align);
+        let stack_temp_offset = bump(stack_temp_size, stack_temp_align);
 
         StackFrame {
-            size: size.try_into().unwrap(),
+            // The entire stack frame must be 16-byte aligned, so apply that
+            // here.
+            size: align_up(offset, 16).try_into().unwrap(),
             abi_param_offset,
             retptr_offset,
+            stack_temp_offset,
         }
     }
 
-    fn allocate_stack_frame(&mut self, frame: &StackFrame) -> Option<TempLocal> {
+    fn allocate_stack_frame(&mut self, frame: &StackFrame) {
+        assert!(self.fp.is_none());
+        assert!(self.stack_temp_offset.is_none());
         if frame.size == 0 {
-            return None;
+            return;
         }
-        assert!(frame.size % 8 == 0);
+        // CABI for wasm is 16-byte alignment for stack at all times.
+        assert!(frame.size % 16 == 0);
         let sp = self.adapter.stack_pointer();
         self.ins().global_get(sp);
         self.ins().i32_const(frame.size as i32);
         self.ins().i32_sub();
-        let ret = self.local_tee_new_tmp(ValType::I32);
+        self.fp = Some(self.local_tee_new_tmp(ValType::I32));
+        self.stack_temp_offset = frame.stack_temp_offset;
         self.ins().global_set(sp);
-        Some(ret)
     }
 
     fn lower_import_params(
         &mut self,
         func: &wit_parser::Function,
         sig: &WasmSignature,
-        frame: &StackFrame,
-        fp: Option<&TempLocal>,
+        indirect_params: impl FnOnce(&Self) -> Memory,
+        retptr: impl FnOnce(&Self) -> Memory,
     ) {
         let tys = func.params.iter().map(|(_, ty)| ty);
 
         if sig.indirect_params {
-            let fp = fp.unwrap();
-            let offset = frame.abi_param_offset.unwrap();
-            let dsts = self.record_field_locs(
-                &AbiLoc::Memory(Memory {
-                    addr: TempLocal::new(fp.idx, fp.ty),
-                    offset,
-                }),
-                tys.clone(),
-            );
+            let mem = indirect_params(self);
+            let dsts = self.record_field_locs(&AbiLoc::Memory(mem.bump(0)), tys.clone());
             for (param, dst) in tys.zip(dsts) {
                 self.lower(*param, &dst);
             }
 
-            self.ins().local_get(fp.idx);
-            self.ins().i32_const(offset.try_into().unwrap());
+            self.ins().local_get(mem.addr.idx);
+            self.ins().i32_const(mem.offset.try_into().unwrap());
             self.ins().i32_add();
         } else {
             let mut locals = sig
@@ -564,21 +698,19 @@ impl<'a> FunctionCompiler<'a> {
         }
 
         if sig.retptr {
-            let AbiLoc::Memory(mem) = frame.abi_loc(fp.unwrap()).unwrap() else {
-                unreachable!()
-            };
+            let mem = retptr(self);
             self.ins().local_get(mem.addr.idx);
             self.ins().i32_const(mem.offset as i32);
             self.ins().i32_add();
         }
     }
 
-    fn lift_import_results(
+    fn lift_import_results<'b>(
         &mut self,
         func: &wit_parser::Function,
         sig: &WasmSignature,
-        frame: &StackFrame,
-        fp: Option<&TempLocal>,
+        stack_src: impl FnOnce() -> AbiLoc<'b>,
+        retptr_src: impl FnOnce(&Self) -> AbiLoc<'b>,
     ) {
         let ty = match func.result {
             Some(ty) => ty,
@@ -587,18 +719,13 @@ impl<'a> FunctionCompiler<'a> {
                 return;
             }
         };
-        if sig.retptr {
-            assert_eq!(sig.results.len(), 0);
-            let src = frame.abi_loc(fp.unwrap()).unwrap();
-            self.lift(&src, ty);
+        let src = if sig.retptr {
+            retptr_src(self)
         } else {
             assert_eq!(sig.results.len(), 1);
-            let tmp_ty = self.adapter.map_wasm_type(sig.results[0]);
-            let tmp = self.local_set_new_tmp(tmp_ty);
-            let src = AbiLoc::Stack(slice::from_ref(&tmp));
-            self.lift(&src, ty);
-            self.free_temp_local(tmp);
-        }
+            stack_src()
+        };
+        self.lift(&src, ty);
     }
 
     fn lift_export_params(&mut self, func: &wit_parser::Function, sig: &WasmSignature) {
@@ -632,12 +759,14 @@ impl<'a> FunctionCompiler<'a> {
                 .adapter
                 .sizes
                 .record(func.params.iter().map(|(_, ty)| ty));
+            self.local_get_ctx();
             self.ins().local_get(mem.addr.idx);
             assert_eq!(mem.offset, 0);
             self.ins()
                 .i32_const(info.size.size_wasm32().try_into().unwrap());
             self.ins()
                 .i32_const(info.align.align_wasm32().try_into().unwrap());
+            self.ins().i32_const(0);
             let dealloc_bytes = self.adapter.intrinsics().dealloc_bytes;
             self.ins().call(dealloc_bytes);
         }
@@ -648,7 +777,6 @@ impl<'a> FunctionCompiler<'a> {
         func: &wit_parser::Function,
         sig: &WasmSignature,
         frame: &StackFrame,
-        fp: Option<&TempLocal>,
     ) {
         let ty = match func.result {
             Some(ty) => ty,
@@ -660,7 +788,7 @@ impl<'a> FunctionCompiler<'a> {
 
         if sig.retptr {
             assert_eq!(sig.results.len(), 1);
-            let dst = frame.abi_loc(fp.unwrap()).unwrap();
+            let dst = frame.abi_loc(self.fp.as_ref().unwrap()).unwrap();
             self.lower(ty, &dst);
 
             let AbiLoc::Memory(mem) = dst else {
@@ -698,21 +826,19 @@ impl<'a> FunctionCompiler<'a> {
             Type::F64 => self.pop_scalar(dest, ValType::F64, i.pop_f64, 3),
             Type::ErrorContext => todo!("error-context"),
             Type::String => {
-                let pop_string = i.pop_string;
-                self.with_temp_stack(4, |me, addr| {
-                    me.local_get_ctx();
-                    me.ins().local_get(addr.idx);
-                    me.ins().call(pop_string);
-                    me.ins().local_get(addr.idx);
-                    me.ins().i32_load(MemArg {
-                        memory_index: 0,
-                        offset: 0,
-                        align: 2,
-                    });
-                });
                 let (dst_ptr, dst_len) = dest.split_ptr_len();
-                self.store_scalar_from_top_of_stack(&dst_ptr, ValType::I32, 2);
+                let pop_string = i.pop_string;
+                self.local_get_ctx();
+                self.local_get_stack_temp_addr();
+                self.ins().call(pop_string);
                 self.store_scalar_from_top_of_stack(&dst_len, ValType::I32, 2);
+                self.local_get_stack_temp_addr();
+                self.ins().i32_load(MemArg {
+                    memory_index: 0,
+                    offset: 0,
+                    align: 2,
+                });
+                self.store_scalar_from_top_of_stack(&dst_ptr, ValType::I32, 2);
             }
             Type::Id(id) => self.lower_id(id, dest),
         }
@@ -815,20 +941,18 @@ impl<'a> FunctionCompiler<'a> {
                 let (dst_ptr, dst_len) = dest.split_ptr_len();
 
                 // Load the list ptr/len into locals
-                self.with_temp_stack(4, |me, addr| {
-                    me.local_get_ctx();
-                    me.ins().i32_const(list_index.try_into().unwrap());
-                    me.ins().local_get(addr.idx);
-                    me.ins().call(pop_list);
-                    me.ins().local_get(addr.idx);
-                    me.ins().i32_load(MemArg {
-                        memory_index: 0,
-                        offset: 0,
-                        align: 2,
-                    });
+                self.local_get_ctx();
+                self.ins().i32_const(list_index.try_into().unwrap());
+                self.local_get_stack_temp_addr();
+                self.ins().call(pop_list);
+                let l_len = self.local_set_new_tmp(ValType::I32);
+                self.local_get_stack_temp_addr();
+                self.ins().i32_load(MemArg {
+                    memory_index: 0,
+                    offset: 0,
+                    align: 2,
                 });
                 let l_ptr = self.local_set_new_tmp(ValType::I32);
-                let l_len = self.local_set_new_tmp(ValType::I32);
 
                 // If the pointer is null then the interpreter doesn't support
                 // the same canonical ABI view of this list so a loop is
@@ -1402,9 +1526,11 @@ impl<'a> FunctionCompiler<'a> {
                     self.ins().local_get(l_byte_size.idx);
                     self.ins().if_(BlockType::Empty);
                     {
+                        self.local_get_ctx();
                         self.ins().local_get(l_ptr_to_free.idx);
                         self.ins().local_get(l_byte_size.idx);
                         self.ins().i32_const(elem_align.try_into().unwrap());
+                        self.ins().i32_const(0);
                         self.ins().call(dealloc_bytes);
                     }
                     self.ins().end();
@@ -1649,77 +1775,20 @@ impl<'a> FunctionCompiler<'a> {
         l_byte_size: &TempLocal,
         align: usize,
     ) {
-        let sp = self.adapter.stack_pointer();
-        assert!(self.using_temp_stack == 0);
-
-        let num_lists = if self.num_dynamic_lists_to_free.is_some() {
-            self.num_dynamic_lists_to_free.as_ref().unwrap().idx
-        } else {
-            self.ins().i32_const(0);
-            let tmp = self.local_set_new_tmp(ValType::I32);
-            let ret = tmp.idx;
-            self.num_dynamic_lists_to_free = Some(tmp);
-            ret
-        };
+        let dealloc_bytes = self.adapter.intrinsics().dealloc_bytes;
 
         // Only defer a cleanup if this list is of nonzero size.
         self.ins().local_get(l_byte_size.idx);
         self.ins().if_(BlockType::Empty);
         {
-            // Increase the number of lists to deallocate
-            self.ins().local_get(num_lists);
-            self.ins().i32_const(1);
-            self.ins().i32_add();
-            self.ins().local_set(num_lists);
-
-            // Store the ptr/size/align onto the stack after allocating 16 more
-            // bytes of stack space. (16 instead of 12 to keep the stack
-            // aligned)
-            self.ins().global_get(sp);
-            self.ins().i32_const(16);
-            self.ins().i32_sub();
-            let addr = self.local_tee_new_tmp(ValType::I32);
-            self.ins().global_set(sp);
-
-            let memarg = |offset| MemArg {
-                memory_index: 0,
-                offset,
-                align: 2,
-            };
-            self.ins().local_get(addr.idx);
+            self.local_get_ctx();
             self.ins().local_get(l_ptr.idx);
-            self.ins().i32_store(memarg(0));
-            self.ins().local_get(addr.idx);
             self.ins().local_get(l_byte_size.idx);
-            self.ins().i32_store(memarg(4));
-            self.ins().local_get(addr.idx);
             self.ins().i32_const(align.try_into().unwrap());
-            self.ins().i32_store(memarg(8));
-
-            self.free_temp_local(addr);
+            self.ins().i32_const(1);
+            self.ins().call(dealloc_bytes);
         }
         self.ins().end();
-    }
-
-    fn with_temp_stack(&mut self, size: usize, f: impl FnOnce(&mut Self, &TempLocal)) {
-        self.using_temp_stack += 1;
-        let sp = self.adapter.stack_pointer();
-
-        self.ins().global_get(sp);
-        self.ins().i32_const(size.try_into().unwrap());
-        self.ins().i32_sub();
-        let tmp = self.local_tee_new_tmp(ValType::I32);
-        self.ins().global_set(sp);
-
-        f(self, &tmp);
-
-        self.ins().local_get(tmp.idx);
-        self.ins().i32_const(size.try_into().unwrap());
-        self.ins().i32_add();
-        self.ins().global_set(sp);
-
-        self.using_temp_stack -= 1;
-        self.free_temp_local(tmp);
     }
 }
 
@@ -1727,6 +1796,7 @@ struct StackFrame {
     size: u32,
     abi_param_offset: Option<u32>,
     retptr_offset: Option<u32>,
+    stack_temp_offset: Option<u32>,
 }
 
 impl StackFrame {

--- a/crates/wit-dylib/test-programs/Cargo.toml
+++ b/crates/wit-dylib/test-programs/Cargo.toml
@@ -6,6 +6,8 @@ publish = false
 
 [dependencies]
 wit-dylib-ffi = { path = '../ffi' }
+wit-bindgen = { workspace = true }
+rand = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/wit-dylib/test-programs/artifacts/Cargo.toml
+++ b/crates/wit-dylib/test-programs/artifacts/Cargo.toml
@@ -4,6 +4,16 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[dependencies]
+wit-component = { workspace = true }
+wasmparser = { workspace = true }
+anyhow = { workspace = true }
+tempfile = { workspace = true }
+wit-dylib = { workspace = true }
+wit-parser = { workspace = true }
+wasi-preview1-component-adapter-provider = "36.0.2"
+wasm-compose = { workspace = true }
+
 [build-dependencies]
 cargo_metadata = "0.19.0"
 

--- a/crates/wit-dylib/test-programs/artifacts/build.rs
+++ b/crates/wit-dylib/test-programs/artifacts/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let target = "wasm32-wasip2";
     let upcase = target.to_uppercase().replace("-", "_");
     let mut cargo = Command::new("cargo");
+    let debug = std::env::var("OPT_LEVEL").unwrap() == "0";
     cargo
         .arg("build")
         .arg("--target").arg(target)
@@ -16,6 +17,9 @@ fn main() {
         .env(format!("CARGO_TARGET_{upcase}_RUSTFLAGS"), "-Clink-self-contained=n -Clink-arg=-Wl,--skip-wit-component,--no-entry,--export=cabi_realloc -Clink-arg=-shared")
         .env(format!("CARGO_TARGET_{upcase}_LINKER"), wasi_sdk_path.join("bin/clang"))
         .env_remove("CARGO_ENCODED_RUSTFLAGS");
+    if !debug {
+        cargo.arg("--release");
+    }
     eprintln!("running {cargo:?}");
     let status = cargo.status().unwrap();
     assert!(status.success());
@@ -45,6 +49,8 @@ fn main() {
     let cwd = std::env::current_dir().unwrap();
 
     let mut deps = HashSet::new();
+    let mut roundtrip = None;
+    let artifact_dir = if debug { "debug" } else { "release" };
     for target_name in targets {
         if target_name.ends_with("_callee") {
             continue;
@@ -53,19 +59,22 @@ fn main() {
         let callee = format!("{name}_callee");
         let caller = out_dir
             .join(target)
-            .join("debug")
+            .join(artifact_dir)
             .join(format!("{target_name}.wasm"));
         let callee = out_dir
             .join(target)
-            .join("debug")
+            .join(artifact_dir)
             .join(format!("{callee}.wasm"));
+        read_deps_of(&mut deps, &caller);
+        read_deps_of(&mut deps, &callee);
+        if name == "roundtrip" {
+            roundtrip = Some((caller, callee));
+            continue;
+        }
         let wit_file = cwd.join("..").join("src/bin").join(format!("{name}.wit"));
         assert!(caller.exists());
         assert!(callee.exists());
         assert!(wit_file.exists());
-
-        read_deps_of(&mut deps, &caller);
-        read_deps_of(&mut deps, &callee);
 
         output.push_str(&format!(
             "({:?}, {:?}, {:?}),\n",
@@ -76,6 +85,14 @@ fn main() {
     }
 
     output.push_str("];\n");
+
+    let (caller, callee) = roundtrip.unwrap();
+    output.push_str(&format!(
+        "
+            pub const ROUNDTRIP_CALLER: &str = {caller:?};
+            pub const ROUNDTRIP_CALLEE: &str = {callee:?};
+        ",
+    ));
     std::fs::write(out_dir.join("out.rs"), &output).unwrap();
 }
 

--- a/crates/wit-dylib/test-programs/artifacts/src/lib.rs
+++ b/crates/wit-dylib/test-programs/artifacts/src/lib.rs
@@ -1,1 +1,111 @@
 include!(concat!(env!("OUT_DIR"), "/out.rs"));
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use wit_component::Linker;
+use wit_parser::{Resolve, WorldId};
+
+pub fn compose(
+    tempdir: &TempDir,
+    resolve: &Resolve,
+    caller: (&Path, WorldId),
+    callee: (&Path, WorldId),
+) -> Result<PathBuf> {
+    // First load up the `caller` and link it all together into a component.
+    let (_caller, caller_file) =
+        create_component(tempdir, &resolve, caller).context("failed to link caller together")?;
+
+    // Next do the same for the `callee`
+    let (_callee, callee_file) =
+        create_component(tempdir, &resolve, callee).context("failed to link callee together")?;
+
+    // Use `wasm-compose` to create a single component where `caller` imports
+    // the `callee`.
+    let config = wasm_compose::config::Config {
+        definitions: vec![callee_file],
+        ..Default::default()
+    };
+    let composition = wasm_compose::composer::ComponentComposer::new(&caller_file, &config)
+        .compose()
+        .context("failed to compose")?;
+
+    let composition_file = tempdir.path().join("composition.wasm");
+    std::fs::write(&composition_file, &composition)
+        .context("failed to write `composition.wasm`")?;
+
+    Ok(composition_file)
+}
+
+fn create_component(
+    tempdir: &TempDir,
+    resolve: &Resolve,
+    wasm: (&Path, WorldId),
+) -> Result<(Vec<u8>, PathBuf)> {
+    let mut adapter = wit_dylib::create(resolve, wasm.1, None);
+    let name = &resolve.worlds[wasm.1].name;
+
+    wit_component::embed_component_metadata(
+        &mut adapter,
+        resolve,
+        wasm.1,
+        wit_component::StringEncoding::UTF8,
+    )?;
+
+    let adapter_file = tempdir.path().join(format!("{name}_adapter.wasm"));
+    std::fs::write(&adapter_file, &adapter).context("failed to write `callee.wasm`")?;
+    wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+        .validate_all(&adapter)
+        .with_context(|| format!("adapter is invalid {adapter_file:?}"))?;
+
+    let mut linker = Linker::default();
+
+    // First define our caller/callee component with its own filename.
+    linker = linker
+        .library(
+            wasm.0.file_name().unwrap().to_str().unwrap(),
+            &std::fs::read(wasm.0).context("failed to read wasm")?,
+            false,
+        )
+        .context("failed to link wasm as library")?;
+
+    // Next insert the synthesized adapter that is what we're primarily testing
+    // in this file.
+    linker = linker
+        .library(&format!("{name}-interpreter-adapter.wasm"), &adapter, false)
+        .context("failed to link adapter as library")?;
+
+    // Next load up `libc.so` as we specified in the compilation of the original
+    // file that it should be linked dynamically.
+    linker = linker
+        .library(
+            "libc.so",
+            &std::fs::read(LIBC_SO).context("failed to read libc.so")?,
+            false,
+        )
+        .context("failed to link adapter as library")?;
+
+    // Rust-sourced compiles still, as of the time of this writing, require the
+    // WASIp1 adapter. Load that in here.
+    linker = linker
+        .adapter(
+            "wasi_snapshot_preview1",
+            wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,
+        )
+        .context("failed to load adapter")?;
+
+    let wasm = linker.encode().with_context(|| {
+        format!(
+            "failed to link:\n\
+original wasm: {wasm:?}\n\
+adapter:       {adapter_file:?}\n\
+libc:          {libc:?}\n\
+",
+            libc = LIBC_SO,
+        )
+    })?;
+
+    let wasm_file = tempdir.path().join(format!("{name}.wasm"));
+    std::fs::write(&wasm_file, &wasm).with_context(|| format!("failed to write {wasm_file:?}"))?;
+    Ok((wasm, wasm_file))
+}

--- a/crates/wit-dylib/test-programs/src/bin/aliases_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/aliases_callee.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::allow_attributes_without_reason)]
-#![allow(unsafe_code)]
-
 use test_programs::*;
 
 export_test!(struct MyInterpreter);
@@ -55,16 +52,12 @@ impl TestCase for MyInterpreter {
                 let Val::String(s) = args.next().unwrap() else {
                     panic!()
                 };
-                let Val::Own(r1) = args.next().unwrap() else {
+                let Val::Own(_) = args.next().unwrap() else {
                     panic!()
                 };
-                let Val::Own(r2) = args.next().unwrap() else {
+                let Val::Own(_) = args.next().unwrap() else {
                     panic!()
                 };
-                unsafe {
-                    p4.drop()(r1);
-                    p5.drop()(r2);
-                }
                 assert_eq!(s, "x");
                 None
             }
@@ -72,7 +65,7 @@ impl TestCase for MyInterpreter {
                 let Type::Own(ty) = func.result().unwrap() else {
                     panic!()
                 };
-                unsafe { Some(Val::Own(ty.new().unwrap()(100))) }
+                Some(Val::Own(Own::new(ty, 100)))
             }
             other => panic!("unknown function {other:?}"),
         }

--- a/crates/wit-dylib/test-programs/src/bin/aliases_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/aliases_caller.rs
@@ -14,13 +14,7 @@ impl TestCase for MyInterpreter {
         assert!(func.result().is_none());
         assert_eq!(args.len(), 0);
 
-        let f = wit
-            .iter_funcs()
-            .filter(|f| {
-                f.interface() == Some("a:b/x") && f.name() == "f" && f.import_impl().is_some()
-            })
-            .next()
-            .unwrap();
+        let f = wit.unwrap_import(Some("a:b/x"), "f");
 
         let mut params = f.params();
         let Type::Alias(p1) = params.next().unwrap() else {

--- a/crates/wit-dylib/test-programs/src/bin/async.wit
+++ b/crates/wit-dylib/test-programs/src/bin/async.wit
@@ -1,0 +1,50 @@
+package a:b;
+
+interface x {
+  f: async func();
+  f-scalar-param: async func(x: u32);
+  f-scalar-result: async func() -> u32;
+
+  record a {
+    a: b,
+    c: f32
+  }
+  record b {
+    a: u32,
+    c: char,
+  }
+  aggregates: async func(a: a, b: b) -> a;
+
+  record big {
+    a1: big2,
+    a2: big2,
+    a3: big2,
+    a4: big2,
+  }
+  record big2 {
+    a1: big3,
+    a2: big3,
+    a3: big3,
+    a4: big3,
+  }
+  record big3 {
+    a1: u8,
+    a2: u8,
+    a3: u8,
+    a4: u8,
+  }
+  indirect-params: async func(a: big, b: big);
+  indirect-params-and-result: async func(a: big) -> big;
+
+  echo-string: async func(a: string) -> string;
+}
+
+world caller {
+  import x;
+
+  export run: async func();
+}
+
+world callee {
+  export x;
+}

--- a/crates/wit-dylib/test-programs/src/bin/async_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/async_callee.rs
@@ -1,0 +1,103 @@
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        _wit: Wit,
+        _func: Function,
+        _args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        unreachable!()
+    }
+
+    async fn call_export_async(
+        _wit: Wit,
+        func: Function,
+        mut args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        assert_eq!(func.interface(), Some("a:b/x"));
+
+        let big3 = Val::Record(vec![Val::U8(1), Val::U8(2), Val::U8(3), Val::U8(4)]);
+        let big2 = Val::Record(vec![big3.clone(), big3.clone(), big3.clone(), big3.clone()]);
+        let big = Val::Record(vec![big2.clone(), big2.clone(), big2.clone(), big2.clone()]);
+
+        match func.name() {
+            "[async]f" => {
+                assert_eq!(func.params().len(), 0);
+                assert!(func.result().is_none());
+                assert_eq!(args.len(), 0);
+
+                for _ in 0..10 {
+                    wit_bindgen::yield_async().await;
+                }
+                None
+            }
+            "[async]f-scalar-param" => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_none());
+                assert_eq!(args.len(), 1);
+
+                assert_eq!(args.next(), Some(Val::U32(101)));
+                assert_eq!(args.next(), None);
+                None
+            }
+            "[async]f-scalar-result" => {
+                assert_eq!(func.params().len(), 0);
+                assert!(func.result().is_some());
+                assert_eq!(args.len(), 0);
+
+                Some(Val::U32(202))
+            }
+            "[async]aggregates" => {
+                assert_eq!(func.params().len(), 2);
+                assert!(func.result().is_some());
+                assert_eq!(args.len(), 2);
+
+                assert_eq!(
+                    args.next(),
+                    Some(Val::Record(vec![
+                        Val::Record(vec![Val::U32(2000), Val::Char('y')]),
+                        Val::F32(32.0),
+                    ]))
+                );
+                assert_eq!(
+                    args.next(),
+                    Some(Val::Record(vec![Val::U32(1000), Val::Char('x')]),)
+                );
+                assert_eq!(args.next(), None);
+
+                Some(Val::Record(vec![
+                    Val::Record(vec![Val::U32(3000), Val::Char('z')]),
+                    Val::F32(64.0),
+                ]))
+            }
+            "[async]indirect-params" => {
+                assert_eq!(func.params().len(), 2);
+                assert!(func.result().is_none());
+                assert_eq!(args.len(), 2);
+
+                assert_eq!(args.next(), Some(big.clone()));
+                assert_eq!(args.next(), Some(big.clone()));
+                assert_eq!(args.next(), None);
+
+                None
+            }
+            "[async]indirect-params-and-result" => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_some());
+                assert_eq!(args.len(), 1);
+                assert_eq!(args.next(), Some(big.clone()));
+                assert_eq!(args.next(), None);
+
+                Some(big.clone())
+            }
+            "[async]echo-string" => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_some());
+                args.next()
+            }
+            other => panic!("unknown function {other:?}"),
+        }
+    }
+}

--- a/crates/wit-dylib/test-programs/src/bin/async_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/async_caller.rs
@@ -1,0 +1,97 @@
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        wit: Wit,
+        func: Function,
+        args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        let _ = (wit, func, args);
+        unreachable!()
+    }
+
+    async fn call_export_async(
+        wit: Wit,
+        func: Function,
+        args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        assert_eq!(func.interface(), None);
+        assert_eq!(func.name(), "[async]run");
+        assert_eq!(func.params().len(), 0);
+        assert!(func.result().is_none());
+        assert_eq!(args.len(), 0);
+
+        let ret = Self::call_import_async(wit, Some("a:b/x"), "[async]f", &[]).await;
+        assert!(ret.is_none());
+
+        let ret = Self::call_import_async(
+            wit,
+            Some("a:b/x"),
+            "[async]f-scalar-param",
+            &[Val::U32(101)],
+        )
+        .await;
+        assert!(ret.is_none());
+
+        let ret = Self::call_import_async(wit, Some("a:b/x"), "[async]f-scalar-result", &[]).await;
+        assert_eq!(ret, Some(Val::U32(202)));
+
+        let ret = Self::call_import_async(
+            wit,
+            Some("a:b/x"),
+            "[async]aggregates",
+            &[
+                Val::Record(vec![
+                    Val::Record(vec![Val::U32(2000), Val::Char('y')]),
+                    Val::F32(32.0),
+                ]),
+                Val::Record(vec![Val::U32(1000), Val::Char('x')]),
+            ],
+        )
+        .await;
+        assert_eq!(
+            ret,
+            Some(Val::Record(vec![
+                Val::Record(vec![Val::U32(3000), Val::Char('z'),]),
+                Val::F32(64.0),
+            ]))
+        );
+
+        let big3 = Val::Record(vec![Val::U8(1), Val::U8(2), Val::U8(3), Val::U8(4)]);
+        let big2 = Val::Record(vec![big3.clone(), big3.clone(), big3.clone(), big3.clone()]);
+        let big = Val::Record(vec![big2.clone(), big2.clone(), big2.clone(), big2.clone()]);
+
+        let ret = Self::call_import_async(
+            wit,
+            Some("a:b/x"),
+            "[async]indirect-params",
+            &[big.clone(), big.clone()],
+        )
+        .await;
+        assert_eq!(ret, None);
+
+        let ret = Self::call_import_async(
+            wit,
+            Some("a:b/x"),
+            "[async]indirect-params-and-result",
+            &[big.clone()],
+        )
+        .await;
+        assert_eq!(ret, Some(big.clone()));
+
+        for s in ["", "a", "abcdefg", "hi!", ""] {
+            let ret = Self::call_import_async(
+                wit,
+                Some("a:b/x"),
+                "[async]echo-string",
+                &[Val::String(s.to_string())],
+            )
+            .await;
+            assert_eq!(ret, Some(Val::String(s.to_string())));
+        }
+
+        None
+    }
+}

--- a/crates/wit-dylib/test-programs/src/bin/lists.wit
+++ b/crates/wit-dylib/test-programs/src/bin/lists.wit
@@ -5,6 +5,10 @@ interface x {
   echo-u8: func(a: list<u8>) -> list<u8>;
   echo-u32: func(a: list<u32>) -> list<u32>;
   echo-string: func(a: list<string>) -> list<string>;
+
+  list-of-variants: func(
+    name1: list<list<option<s8>>>,
+  );
 }
 
 world caller {

--- a/crates/wit-dylib/test-programs/src/bin/lists_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/lists_callee.rs
@@ -29,6 +29,22 @@ impl TestCase for MyInterpreter {
                 let bytes = alloc::get();
                 Some(Val::U32(bytes.try_into().unwrap()))
             }
+
+            "list-of-variants" => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_none());
+                assert_eq!(args.len(), 1);
+                let arg = args.next().unwrap();
+                assert_eq!(
+                    arg,
+                    Val::GenericList(vec![
+                        Val::GenericList(vec![Val::Option(None)]),
+                        Val::GenericList(vec![Val::Option(None)]),
+                    ]),
+                );
+                None
+            }
+
             other => panic!("unknown function {other:?}"),
         }
     }

--- a/crates/wit-dylib/test-programs/src/bin/lists_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/lists_caller.rs
@@ -74,6 +74,19 @@ impl TestCase for MyInterpreter {
             );
         }
 
+        {
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "list-of-variants",
+                &[Val::GenericList(vec![
+                    Val::GenericList(vec![Val::Option(None)]),
+                    Val::GenericList(vec![Val::Option(None)]),
+                ])],
+            );
+            assert_eq!(ret, None);
+        }
+
         None
     }
 }

--- a/crates/wit-dylib/test-programs/src/bin/resources_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/resources_callee.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::allow_attributes_without_reason)]
-#![allow(unsafe_code)]
-
 use test_programs::*;
 
 export_test!(struct MyInterpreter);
@@ -21,14 +18,13 @@ impl TestCase for MyInterpreter {
                     unreachable!();
                 };
 
-                let ret = unsafe { ty.new().unwrap()(100) };
-                Some(Val::Own(ret))
+                Some(Val::Own(Own::new(ty, 100)))
             }
             "[method]a.frob" => {
                 assert_eq!(func.params().len(), 1);
                 assert!(func.result().is_none());
                 assert_eq!(args.len(), 1);
-                let Val::Borrow(handle) = args.next().unwrap() else {
+                let Val::Borrow(Borrow::Rep(handle)) = args.next().unwrap() else {
                     unreachable!();
                 };
                 assert_eq!(handle, 100);

--- a/crates/wit-dylib/test-programs/src/bin/resources_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/resources_caller.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::allow_attributes_without_reason)]
-#![allow(unsafe_code)]
-
 use test_programs::*;
 
 export_test!(struct MyInterpreter);
@@ -17,21 +14,21 @@ impl TestCase for MyInterpreter {
         assert!(func.result().is_none());
         assert_eq!(args.len(), 0);
 
-        let ty = wit.iter_resources().find(|r| r.name() == "a").unwrap();
         let Val::Own(handle) =
             Self::call_import(wit, Some("a:b/x"), "[constructor]a", &[]).unwrap()
         else {
             unreachable!()
         };
 
-        assert!(handle != 100);
+        assert!(handle.handle() != 100);
 
-        let ret = Self::call_import(wit, Some("a:b/x"), "[method]a.frob", &[Val::Borrow(handle)]);
+        let ret = Self::call_import(
+            wit,
+            Some("a:b/x"),
+            "[method]a.frob",
+            &[Val::Borrow(handle.borrow())],
+        );
         assert!(ret.is_none());
-
-        unsafe {
-            ty.drop()(handle);
-        }
 
         None
     }

--- a/crates/wit-dylib/test-programs/src/bin/roundtrip_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/roundtrip_callee.rs
@@ -1,0 +1,97 @@
+use rand::Rng;
+use std::sync::Mutex;
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+static RNG: Mutex<Option<generate::Generator>> = Mutex::new(None);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        wit: Wit,
+        func: Function,
+        mut args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        if func.interface() == Some("wit-dylib:roundtrip-test/alloc") {
+            match func.name() {
+                "set-seed" => {
+                    let Val::U64(seed) = args.next().unwrap() else {
+                        panic!()
+                    };
+                    assert_eq!(args.next(), None);
+                    dprintln!("callee: seed: {seed}");
+                    let mut rng = RNG.lock().unwrap();
+                    assert!(rng.is_none());
+                    *rng = Some(generate::Generator::new(wit, seed));
+                    None
+                }
+
+                "checkpoint" => {
+                    assert_eq!(args.next(), None);
+                    let mut rng = RNG.lock().unwrap();
+                    let rng = rng.as_mut().unwrap();
+                    Some(rng.generate(Type::U32))
+                }
+
+                "allocated-bytes" => Some(Val::U32(alloc::get().try_into().unwrap())),
+
+                other => panic!("unknown function: {other:?}"),
+            }
+        } else {
+            dprintln!("callee: invoke({:?}, {:?})", func.interface(), func.name());
+            assert_eq!(func.params().len(), args.len());
+
+            if func.name().starts_with("[constructor]") {
+                assert_eq!(func.params().len(), 1);
+                let Some(Val::U32(arg)) = args.next() else {
+                    panic!()
+                };
+                assert_eq!(args.next(), None);
+                let Some(Type::Own(ty)) = func.result() else {
+                    panic!()
+                };
+                Some(Val::Own(Own::new(ty, arg as usize)))
+            } else {
+                run_export(func, args)
+            }
+        }
+    }
+
+    async fn call_export_async(
+        _wit: Wit,
+        func: Function,
+        args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        // Conditionally yield to inject some async-ness sometimes.
+        {
+            let mut rng = RNG.lock().unwrap();
+            if rng.as_mut().unwrap().rng().clone().random() {
+                wit_bindgen::yield_async().await;
+            }
+        }
+
+        run_export(func, args)
+    }
+
+    fn resource_dtor(_: Resource, _: usize) {}
+}
+
+fn run_export(func: Function, args: impl ExactSizeIterator<Item = Val>) -> Option<Val> {
+    let mut rng = RNG.lock().unwrap();
+    let rng = rng.as_mut().unwrap();
+    rng.reset_remaining();
+    for (i, (ty, arg)) in func.params().zip(args).enumerate() {
+        dprintln!("callee: generate: {ty:?}");
+        dprintln!("callee:   expect: {arg:?}");
+        match (i, arg) {
+            (0, Val::Borrow(Borrow::Rep(arg))) => {
+                assert_eq!(rng.generate(Type::U32), Val::U32(arg as u32))
+            }
+            (_, arg) => assert_eq!(rng.generate(ty), arg),
+        }
+    }
+    func.result().map(|ty| {
+        dprintln!("callee: generate: {ty:?}");
+        rng.generate(ty)
+    })
+}

--- a/crates/wit-dylib/test-programs/src/bin/roundtrip_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/roundtrip_caller.rs
@@ -1,0 +1,150 @@
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        _wit: Wit,
+        _func: Function,
+        _args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        unreachable!()
+    }
+
+    async fn call_export_async(
+        wit: Wit,
+        func: Function,
+        mut args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        assert_eq!(func.interface(), None);
+        assert_eq!(func.name(), "[async]run");
+        assert_eq!(func.params().len(), 2);
+        assert!(func.result().is_none());
+        assert_eq!(args.len(), 2);
+
+        let Val::U32(iters) = args.next().unwrap() else {
+            panic!()
+        };
+        let Val::U64(seed) = args.next().unwrap() else {
+            panic!()
+        };
+        assert_eq!(args.next(), None);
+
+        let result = Self::call_import(
+            wit,
+            Some("wit-dylib:roundtrip-test/alloc"),
+            "set-seed",
+            &[Val::U64(seed)],
+        );
+        assert_eq!(result, None);
+
+        let callee_allocated_bytes =
+            wit.unwrap_import(Some("wit-dylib:roundtrip-test/alloc"), "allocated-bytes");
+
+        dprintln!("caller: seed: {seed}");
+
+        let mut rng = generate::Generator::new(wit, seed);
+        let mut import_rng = SmallRng::seed_from_u64(seed);
+
+        let imports = wit
+            .iter_funcs()
+            .filter(|f| f.is_import())
+            // don't test various intrinsics we use throughout this roundtrip
+            // test, aka anything from our special interface or any
+            // resource constructor/rep inspection.
+            .filter(|f| f.interface() != Some("wit-dylib:roundtrip-test/alloc"))
+            .filter(|f| !f.name().starts_with("[constructor]"))
+            .filter(|f| !(f.name().starts_with("[method]") && f.name().ends_with(".rep")))
+            .collect::<Vec<_>>();
+
+        if imports.is_empty() {
+            return None;
+        }
+
+        // Each iteration of the loop below is allows to leak at most 200 bytes
+        // (in theory). To ensure it's not 200-per-iteration also install a
+        // guard out here. This is currently because the first async call will
+        // allocate some storage space in our task but after that we shouldn't
+        // continue having any allocation. Our own task should get cleaned up
+        // properly, so it's mostly on us to ensure that we're just not slowly
+        // increasing the amount of leaked memory.
+        let slop = 200;
+        let _my_guard = alloc::Guard::sloppy(slop);
+
+        for i in 0..iters {
+            let _my_guard = alloc::Guard::sloppy(slop);
+            let _callee_guard = CalleeAllocGuard::new(callee_allocated_bytes);
+            dprintln!("caller: iter: {i}");
+            let i = import_rng.random_range(0..imports.len());
+            let import = &imports[i];
+            dprintln!("caller: calling {import:?}");
+
+            let mut args = Vec::new();
+            rng.reset_remaining();
+            let mut resource = None;
+            for (i, ty) in import.params().enumerate() {
+                dprintln!("caller: generate {ty:?}");
+                args.push(match (i, ty) {
+                    (0, Type::Borrow(ty)) => {
+                        Val::Borrow(resource.get_or_insert_with(|| rng.own(ty)).borrow())
+                    }
+                    _ => rng.generate(ty),
+                });
+            }
+            let result = if import.is_async_import() {
+                Self::call_import_func_async(*import, &args).await
+            } else {
+                Self::call_import_func(*import, &args)
+            };
+            match (import.result(), result) {
+                (Some(ty), Some(val)) => {
+                    dprintln!("caller: expect {ty:?}");
+                    dprintln!("caller:    val {val:?}");
+                    assert_eq!(rng.generate(ty), val);
+                }
+                (None, None) => {}
+                _ => unreachable!(),
+            }
+
+            dprintln!("verifying rngs still in sync after iteration");
+            let checkpoint = Self::call_import(
+                wit,
+                Some("wit-dylib:roundtrip-test/alloc"),
+                "checkpoint",
+                &[],
+            );
+            assert_eq!(checkpoint, Some(rng.generate(Type::U32)));
+        }
+
+        None
+    }
+}
+
+struct CalleeAllocGuard {
+    allocated_bytes: Function,
+    prev: u32,
+}
+
+impl CalleeAllocGuard {
+    fn new(allocated_bytes: Function) -> CalleeAllocGuard {
+        let Val::U32(prev) = MyInterpreter::call_import_func(allocated_bytes, &[]).unwrap() else {
+            panic!()
+        };
+        CalleeAllocGuard {
+            prev,
+            allocated_bytes,
+        }
+    }
+}
+
+impl Drop for CalleeAllocGuard {
+    fn drop(&mut self) {
+        let Val::U32(cur) = MyInterpreter::call_import_func(self.allocated_bytes, &[]).unwrap()
+        else {
+            panic!()
+        };
+        assert_eq!(self.prev, cur);
+    }
+}

--- a/crates/wit-dylib/test-programs/src/generate.rs
+++ b/crates/wit-dylib/test-programs/src/generate.rs
@@ -1,0 +1,190 @@
+use crate::{
+    Enum, Flags, Function, List, Own, Resource, Type, Val, Variant, Wit, WitOption, WitResult,
+};
+use rand::distr::{SampleString, StandardUniform};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::collections::HashMap;
+use std::mem;
+
+const MAX_SIZE: usize = 1 << 20;
+const MAX_LEN: usize = 100;
+
+pub struct Generator {
+    rng: SmallRng,
+    remaining: usize,
+    resource_ctors: HashMap<Resource, Function>,
+}
+
+impl Generator {
+    pub fn new(wit: Wit, seed: u64) -> Generator {
+        let mut resource_ctors = HashMap::new();
+        for f in wit
+            .iter_funcs()
+            .filter(|f| f.is_import() && f.name().starts_with("[constructor]"))
+        {
+            let Some(Type::Own(resource)) = f.result() else {
+                panic!()
+            };
+            let prev = resource_ctors.insert(resource, f);
+            assert!(prev.is_none());
+        }
+        Generator {
+            rng: SmallRng::seed_from_u64(seed),
+            remaining: MAX_SIZE,
+            resource_ctors,
+        }
+    }
+
+    pub fn reset_remaining(&mut self) {
+        self.remaining = MAX_SIZE;
+    }
+
+    pub fn generate(&mut self, ty: Type) -> Val {
+        match ty {
+            Type::U8 => Val::U8(self.primitive()),
+            Type::U16 => Val::U16(self.primitive()),
+            Type::U32 => Val::U32(self.primitive()),
+            Type::U64 => Val::U64(self.primitive()),
+            Type::S8 => Val::S8(self.primitive()),
+            Type::S16 => Val::S16(self.primitive()),
+            Type::S32 => Val::S32(self.primitive()),
+            Type::S64 => Val::S64(self.primitive()),
+            Type::F32 => Val::F32(self.primitive()),
+            Type::F64 => Val::F64(self.primitive()),
+            Type::Bool => Val::Bool(self.primitive()),
+            Type::Char => Val::Char(self.primitive()),
+            Type::String => Val::String(self.string()),
+            Type::Record(r) => Val::Record(self.record(r.fields().map(|f| f.1))),
+            Type::Tuple(t) => Val::Tuple(self.record(t.types())),
+            Type::Flags(f) => Val::Flags(self.flags(f)),
+            Type::Enum(t) => Val::Enum(self.enum_(t)),
+            Type::Variant(t) => self.variant(t),
+            Type::Option(t) => Val::Option(self.option(t)),
+            Type::Result(t) => Val::Result(self.result(t)),
+            Type::Alias(t) => self.generate(t.ty()),
+            Type::List(t) => {
+                if t.ty() == Type::U8 {
+                    Val::ByteList(self.byte_list())
+                } else {
+                    Val::GenericList(self.generic_list(t))
+                }
+            }
+
+            Type::Own(ty) => Val::Own(self.own(ty)),
+            Type::Borrow(_) => unimplemented!("should be handled at caller"),
+
+            Type::ErrorContext => todo!(),
+            Type::Stream(_) => todo!(),
+            Type::Future(_) => todo!(),
+            Type::FixedSizeList(_) => todo!(),
+        }
+    }
+
+    pub fn rng(&mut self) -> &mut SmallRng {
+        &mut self.rng
+    }
+
+    fn discount(&mut self, size: usize) {
+        self.remaining = self.remaining.saturating_sub(size);
+    }
+
+    fn primitive<T>(&mut self) -> T
+    where
+        StandardUniform: rand::distr::Distribution<T>,
+    {
+        self.discount(mem::size_of::<T>());
+        self.rng.random()
+    }
+
+    fn string(&mut self) -> String {
+        let len = self.rng.random_range(0..=self.remaining.min(MAX_LEN));
+        let ret = StandardUniform.sample_string(&mut self.rng, len);
+        self.discount(ret.len());
+        ret
+    }
+
+    fn record(&mut self, fields: impl Iterator<Item = Type>) -> Vec<Val> {
+        fields.map(|t| self.generate(t)).collect()
+    }
+
+    fn flags(&mut self, ty: Flags) -> u32 {
+        self.discount(4);
+        let flags = self.rng.random::<u32>();
+        match ty.names().len() {
+            // 32 => flags,
+            n => flags & ((1 << n) - 1),
+        }
+    }
+
+    fn enum_(&mut self, ty: Enum) -> u32 {
+        self.discount(4);
+        self.rng.random_range(0..ty.names().len() as u32)
+    }
+
+    fn variant(&mut self, ty: Variant) -> Val {
+        // count the size for the discriminant
+        self.discount(4);
+        let case = self.rng.random_range(0..ty.cases().len() as u32);
+        let payload_ty = ty.cases().nth(case as usize).unwrap().1;
+        let payload = payload_ty.map(|t| Box::new(self.generate(t)));
+        Val::Variant(case, payload)
+    }
+
+    fn option(&mut self, ty: WitOption) -> Option<Box<Val>> {
+        self.discount(1);
+        if self.rng.random() {
+            Some(Box::new(self.generate(ty.ty())))
+        } else {
+            None
+        }
+    }
+
+    fn result(&mut self, ty: WitResult) -> Result<Option<Box<Val>>, Option<Box<Val>>> {
+        self.discount(1);
+        if self.rng.random() {
+            Ok(ty.ok().map(|t| Box::new(self.generate(t))))
+        } else {
+            Err(ty.err().map(|t| Box::new(self.generate(t))))
+        }
+    }
+
+    fn byte_list(&mut self) -> Vec<u8> {
+        let len = self.rng.random_range(0..=self.remaining.min(MAX_LEN));
+        self.discount(len);
+        let mut result = vec![0; len];
+        self.rng.fill(&mut result[..]);
+        result
+    }
+
+    fn generic_list(&mut self, ty: List) -> Vec<Val> {
+        let mut result = Vec::new();
+        while self.remaining > 0 && self.rng.random_ratio(9, 10) {
+            result.push(self.generate(ty.ty()));
+        }
+        result
+    }
+
+    pub fn own(&mut self, ty: Resource) -> Own {
+        let rep = self.primitive::<u32>();
+        // If `ty` is exported by this component, meaning that we have a
+        // constructor, then use that to make an owned resource. Otherwise
+        // it must be registered in `resource_ctors` previously.
+        //
+        // This means that the caller component in roundtrip testing will use
+        // `resource_ctors`, or call into the callee, to make a resource. The
+        // callee component will use `Own::new`, and both should create
+        // distinct owned handles with the same rep internally which is what's
+        // used for equality in the callee.
+        if ty.new().is_some() {
+            Own::new(ty, rep as usize)
+        } else {
+            let Val::Own(ret) =
+                super::call_import_func(self.resource_ctors[&ty], &[Val::U32(rep)]).unwrap()
+            else {
+                panic!()
+            };
+            ret
+        }
+    }
+}

--- a/crates/wit-dylib/tests/all.rs
+++ b/crates/wit-dylib/tests/all.rs
@@ -1,10 +1,9 @@
 use anyhow::{Context, Result};
 use libtest_mimic::{Arguments, Trial};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
-use wit_component::Linker;
-use wit_parser::{Resolve, WorldId};
+use wit_parser::Resolve;
 
 fn main() {
     let mut trials = Vec::new();
@@ -18,14 +17,15 @@ fn main() {
         let test_name = wit.file_name().unwrap().to_str().unwrap();
         let trial = Trial::test(test_name.to_string(), move || {
             let mut tempdir = TempDir::new_in(caller.parent().unwrap()).unwrap();
+            tempdir.disable_cleanup(true);
             run_test(&tempdir, caller, callee, wit)
                 .with_context(|| {
-                    tempdir.disable_cleanup(true);
                     format!(
                         "failed test {test_name:?}\nartifacts are in {:?}",
                         tempdir.path(),
                     )
                 })
+                .inspect(|_| tempdir.disable_cleanup(false))
                 .map_err(|e| format!("{e:?}").into())
         })
         .with_ignored_flag(cfg!(target_family = "wasm"));
@@ -38,38 +38,15 @@ fn main() {
 fn run_test(tempdir: &TempDir, caller: &Path, callee: &Path, wit: &Path) -> Result<()> {
     let mut resolve = Resolve::default();
     let package = resolve.push_file(wit).context("failed to load WIT")?;
+    let caller_world = resolve.select_world(&[package], Some("caller"))?;
+    let callee_world = resolve.select_world(&[package], Some("callee"))?;
 
-    // First load up the `caller` and link it all together into a component.
-    let (_caller, caller_file) = create_component(
+    let composition_file = artifacts::compose(
         tempdir,
-        caller,
         &resolve,
-        resolve.select_world(&[package], Some("caller"))?,
-    )
-    .context("failed to link caller together")?;
-
-    // Next do the same for the `callee`
-    let (_callee, callee_file) = create_component(
-        tempdir,
-        callee,
-        &resolve,
-        resolve.select_world(&[package], Some("callee"))?,
-    )
-    .context("failed to link callee together")?;
-
-    // Use `wasm-compose` to create a single component where `caller` imports
-    // the `callee`.
-    let config = wasm_compose::config::Config {
-        definitions: vec![callee_file],
-        ..Default::default()
-    };
-    let composition = wasm_compose::composer::ComponentComposer::new(&caller_file, &config)
-        .compose()
-        .context("failed to compose")?;
-
-    let composition_file = tempdir.path().join("composition.wasm");
-    std::fs::write(&composition_file, &composition)
-        .context("failed to write `composition.wasm`")?;
+        (caller, caller_world),
+        (callee, callee_world),
+    )?;
 
     // And finally run this component's `run` function in Wasmtime to ensure the
     // test passes.
@@ -77,6 +54,8 @@ fn run_test(tempdir: &TempDir, caller: &Path, callee: &Path, wit: &Path) -> Resu
     cmd.arg("run")
         .arg("--invoke=run()")
         .arg("-Shttp")
+        .arg("-Wcomponent-model-async")
+        .arg("-Wcomponent-model-error-context")
         .arg(&composition_file);
     let result = cmd.output().context("failed to run wasmtime")?;
     if result.status.success() {
@@ -100,78 +79,4 @@ fn run_test(tempdir: &TempDir, caller: &Path, callee: &Path, wit: &Path) -> Resu
     }
 
     anyhow::bail!("{error}")
-}
-
-fn create_component(
-    tempdir: &TempDir,
-    wasm: &Path,
-    resolve: &Resolve,
-    world: WorldId,
-) -> Result<(Vec<u8>, PathBuf)> {
-    let mut adapter = wit_dylib::create(resolve, world, None);
-    let name = &resolve.worlds[world].name;
-
-    wit_component::embed_component_metadata(
-        &mut adapter,
-        resolve,
-        world,
-        wit_component::StringEncoding::UTF8,
-    )?;
-
-    let adapter_file = tempdir.path().join(format!("{name}_adapter.wasm"));
-    std::fs::write(&adapter_file, &adapter).context("failed to write `callee.wasm`")?;
-    wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
-        .validate_all(&adapter)
-        .with_context(|| format!("adapter is invalid {adapter_file:?}"))?;
-
-    let mut linker = Linker::default();
-
-    // First define our caller/callee component with its own filename.
-    linker = linker
-        .library(
-            wasm.file_name().unwrap().to_str().unwrap(),
-            &std::fs::read(wasm).context("failed to read wasm")?,
-            false,
-        )
-        .context("failed to link wasm as library")?;
-
-    // Next insert the synthesized adapter that is what we're primarily testing
-    // in this file.
-    linker = linker
-        .library(&format!("{name}-interpreter-adapter.wasm"), &adapter, false)
-        .context("failed to link adapter as library")?;
-
-    // Next load up `libc.so` as we specified in the compilation of the original
-    // file that it should be linked dynamically.
-    linker = linker
-        .library(
-            "libc.so",
-            &std::fs::read(artifacts::LIBC_SO).context("failed to read libc.so")?,
-            false,
-        )
-        .context("failed to link adapter as library")?;
-
-    // Rust-sourced compiles still, as of the time of this writing, require the
-    // WASIp1 adapter. Load that in here.
-    linker = linker
-        .adapter(
-            "wasi_snapshot_preview1",
-            wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,
-        )
-        .context("failed to load adapter")?;
-
-    let wasm = linker.encode().with_context(|| {
-        format!(
-            "failed to link:\n\
-original wasm: {wasm:?}\n\
-adapter:       {adapter_file:?}\n\
-libc:          {libc:?}\n\
-",
-            libc = artifacts::LIBC_SO,
-        )
-    })?;
-
-    let wasm_file = tempdir.path().join(format!("{name}.wasm"));
-    std::fs::write(&wasm_file, &wasm).with_context(|| format!("failed to write {wasm_file:?}"))?;
-    Ok((wasm, wasm_file))
 }

--- a/crates/wit-dylib/tests/roundtrip.rs
+++ b/crates/wit-dylib/tests/roundtrip.rs
@@ -1,0 +1,353 @@
+//! A test that exercises sending arbitrary WIT values across an import/export
+//! boundary and ensuring that they are transmitted succesfully.
+//!
+//! This test will use the `roundtrip_caller.rs` file to invoke functions in
+//! `roundtrip_callee.rs`. These precompiled components, provided through the
+//! `artifacts` crate, work in close conjunction with this test file to work. At
+//! a high level what happens here is:
+//!
+//! 1. An arbitrary WIT package set is generated with `wit-smith`.
+//! 2. This WIT is augmented with a custom interface for running the test
+//!    and various other intrinsics, use for the test harness.
+//! 3. Both Rust components use this augmented WIT to get turned into a
+//!    component. Notably the `caller` world is used to bind
+//!    `roundtrip_caller.rs` and similarly for `callee`. Each component is
+//!    linked with `wit_component::Linker`
+//! 4. Both components are composed together into a single component (where the
+//!    caller component imports the callee component).
+//! 5. The component is run in Wasmtime with a number of iterations and a seed.
+//! 6. The caller component uses the seed to pick an arbitrary import and then
+//!    invokes it.
+//! 7. The caller component uses the seed to generate arbitrary values to pass
+//!    to the import.
+//! 8. The callee uses the same seed as the caller to ensure that the received
+//!    values are the same as the ones that it generates.
+//! 9. The same procedure works in reverse for the result.
+//! 10. The caller double-checks that it did not leak memory, nor did the
+//!     callee, during this invocation.
+//!
+//! This provides end-to-end testing that arbitrarily shaped WIT values with
+//! arbitrarily shaped runtime values in arbitrary positions all get
+//! communicated correctly. Basically this is intended to provide a high degree
+//! of confidence that the bindings generated are actually correct and don't
+//! leak memory.
+
+use arbitrary::{Result, Unstructured};
+use indexmap::IndexMap;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+use wit_parser::decoding::DecodedWasm;
+use wit_parser::{
+    Function, FunctionKind, Handle, Interface, Package, PackageName, Resolve, Type, TypeDef,
+    TypeDefKind, TypeOwner, World, WorldItem, WorldKey,
+};
+
+#[test]
+fn run() {
+    let _ = env_logger::try_init();
+
+    arbtest::arbtest(run_one)
+        // To repro...
+        // .seed(0x573d795000000078)
+        .run();
+}
+
+fn run_one(u: &mut Unstructured<'_>) -> Result<()> {
+    println!("iter...");
+    let seed = u.arbitrary::<u64>()?;
+    let iters = 200;
+    let mut config = u.arbitrary::<wit_smith::Config>()?;
+    config.error_context = false;
+    config.fixed_size_list = false;
+    config.futures = false; // TODO
+    config.streams = false; // TODO
+    config.async_ = true;
+    let wasm = wit_smith::smith(&config, u)?;
+    std::fs::write("./hello.wasm", &wasm).unwrap();
+    let (mut resolve, _pkg) = match wit_parser::decoding::decode(&wasm).unwrap() {
+        DecodedWasm::WitPackage(resolve, pkg) => (resolve, pkg),
+        DecodedWasm::Component(..) => unreachable!(),
+    };
+    update_resources(&mut resolve);
+
+    let interfaces = resolve
+        .packages
+        .iter()
+        .flat_map(|(_, pkg)| pkg.interfaces.values().cloned())
+        .collect::<Vec<_>>();
+
+    let world_items = interfaces
+        .iter()
+        .map(|id| {
+            (
+                WorldKey::Interface(*id),
+                WorldItem::Interface {
+                    id: *id,
+                    stability: Default::default(),
+                },
+            )
+        })
+        .collect::<IndexMap<_, _>>();
+
+    // Create a new package which represents the custom intrinsics used to
+    // implement the test.
+    let package = resolve.packages.alloc(Package {
+        name: PackageName {
+            namespace: "wit-dylib".to_string(),
+            name: "roundtrip-test".to_string(),
+            version: None,
+        },
+        interfaces: Default::default(),
+        worlds: Default::default(),
+        docs: Default::default(),
+    });
+
+    // Inject an interface in this package which the caller imports and the
+    // callee exports. There are a few functions such as:
+    //
+    // * `allocated-bytes` - used to let the caller know how many bytes are
+    //   allocated in the callee to help detect leaks.
+    // * `set-seed` - at the start of the test informs the callee of the
+    //   original seed to ensure that both the callee and caller are using the
+    //   same one.
+    // * `checkpoint` - used to double-check after a call that the random state
+    //   is the same in the caller and callee.
+    let alloc = resolve.interfaces.alloc(Interface {
+        name: Some("alloc".to_string()),
+        stability: Default::default(),
+        package: Some(package),
+        docs: Default::default(),
+        types: Default::default(),
+        functions: {
+            let mut funcs = IndexMap::new();
+            funcs.insert(
+                "allocated-bytes".to_string(),
+                Function {
+                    name: "allocated-bytes".to_string(),
+                    kind: FunctionKind::Freestanding,
+                    params: Vec::new(),
+                    result: Some(Type::U32),
+                    stability: Default::default(),
+                    docs: Default::default(),
+                },
+            );
+            funcs.insert(
+                "set-seed".to_string(),
+                Function {
+                    name: "set-seed".to_string(),
+                    kind: FunctionKind::Freestanding,
+                    params: vec![("seed".to_string(), Type::U64)],
+                    result: None,
+                    stability: Default::default(),
+                    docs: Default::default(),
+                },
+            );
+            funcs.insert(
+                "checkpoint".to_string(),
+                Function {
+                    name: "checkpoint".to_string(),
+                    kind: FunctionKind::Freestanding,
+                    params: Vec::new(),
+                    result: Some(Type::U32),
+                    stability: Default::default(),
+                    docs: Default::default(),
+                },
+            );
+            funcs
+        },
+    });
+
+    // Generate two worlds in our custom package, one for the callee and one for
+    // the caller which differ only in their name and whether the interfaces are
+    // imported or exported.
+    let callee = resolve.worlds.alloc(World {
+        name: "callee".to_string(),
+        stability: Default::default(),
+        package: Some(package),
+        exports: world_items.clone(),
+        imports: Default::default(),
+        includes: Default::default(),
+        include_names: Default::default(),
+        docs: Default::default(),
+    });
+    let caller = resolve.worlds.alloc(World {
+        name: "caller".to_string(),
+        stability: Default::default(),
+        package: Some(package),
+        imports: world_items,
+        exports: Default::default(),
+        includes: Default::default(),
+        include_names: Default::default(),
+        docs: Default::default(),
+    });
+
+    // Add an extra import/export for our synthesized interfaces as well.
+    resolve.worlds[callee].exports.insert(
+        WorldKey::Interface(alloc),
+        WorldItem::Interface {
+            id: alloc,
+            stability: Default::default(),
+        },
+    );
+    resolve.worlds[caller].imports.insert(
+        WorldKey::Interface(alloc),
+        WorldItem::Interface {
+            id: alloc,
+            stability: Default::default(),
+        },
+    );
+
+    // Inject the actual entrypoint of the test.
+    resolve.worlds[caller].exports.insert(
+        WorldKey::Name("[async]run".to_string()),
+        WorldItem::Function(Function {
+            name: "[async]run".to_string(),
+            kind: FunctionKind::AsyncFreestanding,
+            params: vec![
+                ("iters".to_string(), Type::U32),
+                ("seed".to_string(), Type::U64),
+            ],
+            result: None,
+            stability: Default::default(),
+            docs: Default::default(),
+        }),
+    );
+
+    // Fixup the WIT data structures in memory.
+    resolve.packages[package]
+        .interfaces
+        .insert("alloc".to_string(), alloc);
+    resolve.packages[package]
+        .worlds
+        .insert("callee".to_string(), callee);
+    resolve.packages[package]
+        .worlds
+        .insert("caller".to_string(), caller);
+
+    // For debugging, print the WIT being used.
+    if false {
+        let mut printer = wit_component::WitPrinter::default();
+        printer
+            .print(
+                &resolve,
+                package,
+                &resolve
+                    .packages
+                    .iter()
+                    .map(|(id, _)| id)
+                    .filter(|i| *i != package)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        println!("{}", printer.output);
+    }
+
+    // Run the test by composing the caller/callee together and running the
+    // result in Wasmtime.
+    let mut tempdir =
+        TempDir::new_in(Path::new(artifacts::ROUNDTRIP_CALLER).parent().unwrap()).unwrap();
+    tempdir.disable_cleanup(true);
+
+    let composition = artifacts::compose(
+        &tempdir,
+        &resolve,
+        (artifacts::ROUNDTRIP_CALLER.as_ref(), caller),
+        (artifacts::ROUNDTRIP_CALLEE.as_ref(), callee),
+    )
+    .expect("failed to compose");
+
+    let mut cmd = Command::new("wasmtime");
+    cmd.arg("run")
+        .arg(format!("--invoke=run({iters}, {seed})"))
+        .arg("-Shttp")
+        .arg("-Wcomponent-model-async")
+        .arg("-Wcomponent-model-error-context")
+        .arg(&composition);
+    let result = cmd.output().expect("failed to run wasmtime");
+    if result.status.success() {
+        tempdir.disable_cleanup(false);
+        return Ok(());
+    }
+    let mut error = String::new();
+    error.push_str(&format!("command: {cmd:?}\n"));
+    error.push_str(&format!("status:  {}\n", result.status));
+    if !result.stdout.is_empty() {
+        error.push_str(&format!(
+            "stdout:\n  {}\n",
+            String::from_utf8_lossy(&result.stdout).replace("\n", "\n  ")
+        ));
+    }
+    if !result.stderr.is_empty() {
+        error.push_str(&format!(
+            "stderr:\n  {}\n",
+            String::from_utf8_lossy(&result.stderr).replace("\n", "\n  ")
+        ));
+    }
+
+    panic!("{error}")
+}
+
+/// Updates all resources found in `resolve` to ensure that the constructor
+/// takes a `u32` and there's a function to learn the `rep`.
+fn update_resources(resolve: &mut Resolve) {
+    let interface_resources = resolve
+        .interfaces
+        .iter()
+        .flat_map(|(id, iface)| {
+            iface
+                .types
+                .iter()
+                .filter(|(_name, id)| {
+                    let ty = &resolve.types[**id];
+                    matches!(ty.kind, TypeDefKind::Resource)
+                })
+                .map(move |(name, resource_id)| (id, *resource_id, name.clone()))
+        })
+        .collect::<Vec<_>>();
+
+    for (interface_id, resource_id, resource_name) in interface_resources {
+        let own = resolve.types.alloc(TypeDef {
+            name: None,
+            kind: TypeDefKind::Handle(Handle::Own(resource_id)),
+            owner: TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+        });
+        let borrow = resolve.types.alloc(TypeDef {
+            name: None,
+            kind: TypeDefKind::Handle(Handle::Borrow(resource_id)),
+            owner: TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+        });
+        let iface = &mut resolve.interfaces[interface_id];
+        let ctor = format!("[constructor]{resource_name}");
+        let rep = format!("[method]{resource_name}.rep");
+        iface.functions.swap_remove(&ctor);
+        iface.functions.swap_remove(&rep);
+
+        iface.functions.insert(
+            ctor.clone(),
+            Function {
+                name: ctor,
+                kind: FunctionKind::Constructor(resource_id),
+                params: vec![("rep".to_string(), Type::U32)],
+                result: Some(Type::Id(own)),
+                stability: Default::default(),
+                docs: Default::default(),
+            },
+        );
+        iface.functions.insert(
+            rep.clone(),
+            Function {
+                name: rep,
+                kind: FunctionKind::Method(resource_id),
+                params: vec![("self".to_string(), Type::Id(borrow))],
+                result: Some(Type::U32),
+                stability: Default::default(),
+                docs: Default::default(),
+            },
+        );
+    }
+}

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -132,6 +132,17 @@ pub enum AbiVariant {
     GuestExportAsyncStackful,
 }
 
+impl AbiVariant {
+    pub fn is_async(&self) -> bool {
+        match self {
+            Self::GuestImport | Self::GuestExport => false,
+            Self::GuestImportAsync | Self::GuestExportAsync | Self::GuestExportAsyncStackful => {
+                true
+            }
+        }
+    }
+}
+
 pub struct FlatTypes<'a> {
     types: &'a mut [WasmType],
     cur: usize,

--- a/crates/wit-smith/src/config.rs
+++ b/crates/wit-smith/src/config.rs
@@ -19,6 +19,18 @@ pub struct Config {
     pub max_files_per_package: usize,
     #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().max_resource_items))]
     pub max_resource_items: usize,
+    #[cfg_attr(feature = "clap", clap(long = "async", default_value_t = Config::default().async_))]
+    pub async_: bool,
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().futures))]
+    pub futures: bool,
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().streams))]
+    pub streams: bool,
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().error_context))]
+    pub error_context: bool,
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().fixed_size_list))]
+    pub fixed_size_list: bool,
+    #[cfg_attr(feature = "clap", clap(long, default_value_t = Config::default().world_include))]
+    pub world_include: bool,
 }
 
 impl Default for Config {
@@ -32,6 +44,12 @@ impl Default for Config {
             max_type_parts: 10,
             max_files_per_package: 10,
             max_resource_items: 10,
+            async_: false,
+            futures: false,
+            streams: false,
+            error_context: false,
+            fixed_size_list: false,
+            world_include: false,
         }
     }
 }
@@ -47,6 +65,12 @@ impl Arbitrary<'_> for Config {
             max_pkg_items: u.int_in_range(1..=10)?,
             max_type_parts: u.int_in_range(1..=10)?,
             max_resource_items: u.int_in_range(0..=10)?,
+            async_: u.arbitrary()?,
+            futures: u.arbitrary()?,
+            streams: u.arbitrary()?,
+            error_context: u.arbitrary()?,
+            fixed_size_list: u.arbitrary()?,
+            world_include: false,
         })
     }
 }

--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -781,6 +781,9 @@ impl<'a> InterfaceGenerator<'a> {
                 }
 
                 ItemKind::Include => {
+                    if !self.generator.config.world_include {
+                        continue;
+                    }
                     part.push_str("include ");
                     match self
                         .generator
@@ -1170,6 +1173,9 @@ impl<'a> InterfaceGenerator<'a> {
                     dst.push_str(">");
                 }
                 Kind::FixedSizeList => {
+                    if !self.generator.config.fixed_size_list {
+                        continue;
+                    }
                     *fuel = match fuel.checked_sub(1) {
                         Some(fuel) => fuel,
                         None => continue,
@@ -1210,6 +1216,9 @@ impl<'a> InterfaceGenerator<'a> {
                     }
                 }
                 Kind::Stream => {
+                    if !self.generator.config.streams {
+                        continue;
+                    }
                     *fuel = match fuel.checked_sub(1) {
                         Some(fuel) => fuel,
                         None => continue,
@@ -1219,6 +1228,9 @@ impl<'a> InterfaceGenerator<'a> {
                     dst.push_str(">");
                 }
                 Kind::Future => {
+                    if !self.generator.config.futures {
+                        continue;
+                    }
                     *fuel = match fuel.checked_sub(1) {
                         Some(fuel) => fuel,
                         None => continue,
@@ -1232,6 +1244,9 @@ impl<'a> InterfaceGenerator<'a> {
                     }
                 }
                 Kind::ErrorContext => {
+                    if !self.generator.config.error_context {
+                        continue;
+                    }
                     dst.push_str("error-context");
                 }
             };
@@ -1254,7 +1269,7 @@ impl<'a> InterfaceGenerator<'a> {
         dst: &mut String,
         method: bool,
     ) -> Result<()> {
-        if u.arbitrary()? {
+        if self.generator.config.async_ && u.arbitrary()? {
             dst.push_str("async ");
         }
         dst.push_str("func");

--- a/src/bin/wasm-tools/wit_dylib.rs
+++ b/src/bin/wasm-tools/wit_dylib.rs
@@ -52,11 +52,12 @@ impl Opts {
         self.io.general_opts()
     }
 
-    pub fn run(self) -> Result<()> {
+    pub fn run(mut self) -> Result<()> {
         let (resolve, pkg_id) = self.resolve.load()?;
         let world = resolve.select_world(&[pkg_id], self.world.as_deref())?;
 
-        let mut wasm = wit_dylib::create(&resolve, world, Some(&self.dylib_opts));
+        let mut wasm = wit_dylib::create(&resolve, world, Some(&mut self.dylib_opts));
+        self.dylib_opts.async_.ensure_all_used()?;
 
         embed_component_metadata(
             &mut wasm,


### PR DESCRIPTION
This commit starts to fill out the support for async in `wit-dylib`. In doing so this has filled out a number of pieces of functionality elsewhere and implemented more thorough testing. As a result of this some issues were discovered which are also fixed in this PR. Notable changes are:

* Naming of the `task-return` intrinsic is now in a helper in `wit-parser` to avoid needing to duplicate that elsewhere.
* A new `roundtrip` test was added to `wit-dylib` which generates arbitrary WITs and arbitrary values for the WIT and ensures that the values are communicated successfully.
* Composition code shared between the `all` and `roundtrip` tests was moved to the `artifacts` crate as a shared dependency of the two.
* In-memory data structures for `wit_func_t` are updated to reflect async support.
* Deferred deallocation of bytes is pushed as a responsibility to the embedder. Storing values on the stack was getting too tricky and felt like a too-clever-by-half implementation. To simplify the generated code the responsibility is now on the `wit_dylib_*` implementor to deallocate bytes in a deferred fashion.
* The `wit-bindgen` crate is a dependency of `wit-dylib-ffi`, the guest bindings of `wit_dylib.h`, for async support.
* The `wasm-tools wit-dylib` subcommand now has configuration, in the same manner as `wit-bindgen` for which functions should be async and which should be sync.
* The `with_temp_stack` helper was removed as that was also getting too tricky to manage and instead functions just always allocate some temporary space.
* Existing bindings were updated for async functions when that ABI is selected, and new bindings were added for various intrinsics related to the lifecycle of async imports/exports.

Perhaps the biggest feature in this commit is the addition of the `roundtrip` test which is hoped to provide a much more thorough implementation of testing this crate. Notably it generates an arbitrary WIT structure *and additionally* generates arbitrary values of this structure. This has weeded out a number of bugs in the bindings generator and necessitated various refactorings here. This is intended to be a crucial part of making this a solid dependency to build on.