### PR TITLE
Rename `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -69,7 +69,7 @@
 //! assert!(wasmparser::validate(&wasm_bytes).is_ok());
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
 

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -43,7 +43,7 @@
 //! # Ok(()) }
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs)]
 
 pub use add_metadata::{AddMetadata, AddMetadataField};

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -52,7 +52,7 @@
 //! The design and implementation strategy of wasm-smith is outlined in
 //! [this article](https://fitzgeraldnick.com/2020/08/24/writing-a-test-case-generator.html).
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs, missing_debug_implementations)]
 // Needed for the `instructions!` macro in `src/code_builder.rs`.
 #![recursion_limit = "512"]

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -28,7 +28,7 @@
 
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -7,7 +7,7 @@
 //! and debugging and such.
 
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use anyhow::{Context, Result, anyhow, bail};
 use operator::{OpPrinter, OperatorSeparator, OperatorState, PrintOperator, PrintOperatorFolded};

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`LexError`]: lexer::LexError
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// A macro to create a custom keyword parser.
 ///

--- a/crates/wat/src/lib.rs
+++ b/crates/wat/src/lib.rs
@@ -66,7 +66,7 @@
 //! [wat]: http://webassembly.github.io/spec/core/text/index.html
 
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::borrow::Cow;
 use std::fmt;

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -1,7 +1,7 @@
 //! The WebAssembly component tooling.
 
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::str::FromStr;
 use std::{borrow::Cow, fmt::Display};


### PR DESCRIPTION
Turns out this was renamed long long ago and we never caught up...