### PR TITLE
Expand --help output for `parse` and `print` commands

### DIFF
--- a/src/bin/wasm-tools/parse.rs
+++ b/src/bin/wasm-tools/parse.rs
@@ -4,8 +4,29 @@ use clap::Parser;
 /// Parse the WebAssembly text format.
 ///
 /// This subcommand will parse the provided input as the WebAssembly text format
-/// and optionally write the binary form to a provided file.
+/// and optionally write the binary or text form to a provided file.
 #[derive(Parser)]
+#[clap(after_help = "
+Examples:
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to stdout:
+
+          wasm-tools parse -t input.wat
+
+   To parse the file input.wat as WebAssembly text format and write the binary
+   form to the file output.wasm, including debugging information:
+
+          wasm-tools parse input.wat -g -o output.wasm
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to the file output.wat:
+
+          wasm-tools parse -t input.wat -o output.wat
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.")]
 pub struct Opts {
     #[clap(flatten)]
     generate_dwarf: wasm_tools::GenerateDwarfArg,

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -3,6 +3,52 @@ use clap::Parser;
 
 /// Print the textual form of a WebAssembly binary.
 #[derive(Parser)]
+#[clap(after_help = "\
+Examples:
+
+    # Print the textual form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+    local.get $lhs
+    local.get $rhs
+    i32.add
+ )
+
+    # Print a \"skeleton\" form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm --skeleton
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32) ...)
+
+    # Print the textual form of `foo.wasm` to stdout, with folded instructions,
+    # binary offsets, and indented 6 spaces.
+    $ wasm-tools print foo.wasm -p -f --indent 6
+(module
+(;@b     ;)      (type (;0;) (func (param i32 i32) (result i32)))
+(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+(;@3c    ;)            (i32.add
+(;@38    ;)                  (local.get $lhs)
+(;@3a    ;)                  (local.get $rhs))
+                 )
+
+    # Print the textual form of `foo.wasm` to stdout, with synthesized names for
+    # items without a name in the `name` section. (Notice below that the type
+    # denoted by ;0; in the previous examples has been given a name.)
+    $ wasm-tools print foo.wasm --name-unnamed
+(module
+  (type $#type0 (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type $#type0) (param $lhs i32) (param $rhs i32) (result i32)
+...
+
+    # Print the textual form of `foo.wasm` to the file `foo.wat`.
+    $ wasm-tools print foo.wasm -o foo.wat
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.
+")]
 pub struct Opts {
     #[clap(flatten)]
     generate_dwarf: wasm_tools::GenerateDwarfArg,
@@ -31,6 +77,7 @@ pub struct Opts {
     name_unnamed: bool,
 
     /// Print instructions in the folded format.
+    /// (See https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions)
     #[clap(short, long)]
     fold_instructions: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,9 @@ impl InputArg {
 pub struct OutputArg {
     /// Where to place output.
     ///
-    /// If not provided then stdout is used.
+    /// Required when printing WebAssembly binary output.
+    ///
+    /// If not provided, then stdout is used.
     #[clap(short, long)]
     output: Option<PathBuf>,
 }


### PR DESCRIPTION
Add example usage sections to the --help output for these commands.