### PR TITLE
Report adapter type errors with a dedicated type

### DIFF
--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -21,6 +21,7 @@ pub use encoding::{ComponentEncoder, LibraryInfo, encode};
 pub use linking::Linker;
 pub use printing::*;
 pub use targets::*;
+pub use validation::AdapterModuleDidNotExport;
 pub use wit_parser::decoding::{DecodedWasm, decode, decode_reader};
 
 pub mod metadata;


### PR DESCRIPTION
Instead of using `bail!` with a string, report adapter type errors using a dedicated `AdapterModuleDidNotExport` type, so that users can downcast errors to it, rather than checking the error message string.