### PR TITLE
Start adding tests for -h and --help output

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -207,6 +207,7 @@ fn assert_output(bless: bool, output: &[u8], path: &Path, tempdir: &TempDir) -> 
     let mut output = String::from_utf8_lossy(output)
         .replace(tempdir, "%tmpdir")
         .replace("\\", "/")
+        .replace("wasm-tools.exe", "wasm-tools")
         .lines()
         .map(|line| {
             if let Some(start) = line.find("(processed-by \"wit-component\"") {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -156,6 +156,7 @@ fn execute(cmd: &mut Command, stdin: Option<&[u8]>, should_fail: bool) -> Result
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     let mut p = cmd
+        .env("COLUMNS", "80")
         .spawn()
         .with_context(|| format!("failed to spawn {cmd:?}"))?;
 

--- a/tests/cli/help-parse-short.wat
+++ b/tests/cli/help-parse-short.wat
@@ -1,0 +1,1 @@
+;; RUN: parse -h

--- a/tests/cli/help-parse-short.wat.stdout
+++ b/tests/cli/help-parse-short.wat.stdout
@@ -1,0 +1,39 @@
+Parse the WebAssembly text format
+
+Usage: wasm-tools parse [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
+                                     files
+  -g                                 Shorthand for `--generate-dwarf full`
+  -o, --output <OUTPUT>              Where to place output
+  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
+                                     auto]
+  -t, --wat                          Output the text format of WebAssembly instead of the binary format
+  -h, --help                         Print help (see more with '--help')
+
+
+Examples:
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to stdout:
+
+          wasm-tools parse -t input.wat
+
+   To parse the file input.wat as WebAssembly text format and write the binary
+   form to the file output.wasm, including debugging information:
+
+          wasm-tools parse input.wat -g -o output.wasm
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to the file output.wat:
+
+          wasm-tools parse -t input.wat -o output.wat
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.

--- a/tests/cli/help-parse-short.wat.stdout
+++ b/tests/cli/help-parse-short.wat.stdout
@@ -6,15 +6,22 @@ Arguments:
   [INPUT]  Input file to process
 
 Options:
-      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
-                                     files
-  -g                                 Shorthand for `--generate-dwarf full`
-  -o, --output <OUTPUT>              Where to place output
-  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
-      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
-                                     auto]
-  -t, --wat                          Output the text format of WebAssembly instead of the binary format
-  -h, --help                         Print help (see more with '--help')
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text
+          files
+  -g
+          Shorthand for `--generate-dwarf full`
+  -o, --output <OUTPUT>
+          Where to place output
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output
+          [default: auto]
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+  -h, --help
+          Print help (see more with '--help')
 
 
 Examples:

--- a/tests/cli/help-parse.wat
+++ b/tests/cli/help-parse.wat
@@ -1,0 +1,1 @@
+;; RUN: parse --help

--- a/tests/cli/help-parse.wat.stdout
+++ b/tests/cli/help-parse.wat.stdout
@@ -1,0 +1,71 @@
+Parse the WebAssembly text format.
+
+This subcommand will parse the provided input as the WebAssembly text format and optionally write the binary or
+text form to a provided file.
+
+Usage: wasm-tools parse [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
+          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text files.
+          
+          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
+          instruct the text parser to insert DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
+          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+
+  -g
+          Shorthand for `--generate-dwarf full`
+
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
+          terminal environment, for example by using `isatty`.
+          
+          [default: auto]
+
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+
+Examples:
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to stdout:
+
+          wasm-tools parse -t input.wat
+
+   To parse the file input.wat as WebAssembly text format and write the binary
+   form to the file output.wasm, including debugging information:
+
+          wasm-tools parse input.wat -g -o output.wasm
+
+   To parse the file input.wat as WebAssembly text format and write the
+   normalized text format to the file output.wat:
+
+          wasm-tools parse -t input.wat -o output.wat
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.

--- a/tests/cli/help-parse.wat.stdout
+++ b/tests/cli/help-parse.wat.stdout
@@ -1,7 +1,7 @@
 Parse the WebAssembly text format.
 
-This subcommand will parse the provided input as the WebAssembly text format and optionally write the binary or
-text form to a provided file.
+This subcommand will parse the provided input as the WebAssembly text format and
+optionally write the binary or text form to a provided file.
 
 Usage: wasm-tools parse [OPTIONS] [INPUT]
 
@@ -9,17 +9,21 @@ Arguments:
   [INPUT]
           Input file to process.
           
-          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
-          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
 
 Options:
       --generate-dwarf <lines|full>
-          Optionally generate DWARF debugging information from WebAssembly text files.
+          Optionally generate DWARF debugging information from WebAssembly text
+          files.
           
-          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
-          instruct the text parser to insert DWARF debugging information to map binary locations back to the
-          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
-          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+          When the input to this command is a WebAssembly text file, such as
+          `*.wat`, then this option will instruct the text parser to insert
+          DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has
+          no effect if the `INPUT` argument is already a WebAssembly binary or
+          if the text format uses `(module binary ...)`.
 
   -g
           Shorthand for `--generate-dwarf full`
@@ -37,8 +41,9 @@ Options:
       --color <COLOR>
           Configuration over whether terminal colors are used in output.
           
-          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
-          terminal environment, for example by using `isatty`.
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
           
           [default: auto]
 

--- a/tests/cli/help-print-short.wat
+++ b/tests/cli/help-print-short.wat
@@ -1,0 +1,1 @@
+;; RUN: print -h

--- a/tests/cli/help-print-short.wat.stdout
+++ b/tests/cli/help-print-short.wat.stdout
@@ -1,0 +1,72 @@
+Print the textual form of a WebAssembly binary
+
+Usage: wasm-tools print [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
+                                     files
+  -g                                 Shorthand for `--generate-dwarf full`
+  -o, --output <OUTPUT>              Where to place output
+  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
+                                     auto]
+  -p, --print-offsets                Whether or not to print binary offsets intermingled in the text format as
+                                     comments for debugging
+      --skeleton                     Indicates that the "skeleton" of a module should be printed
+      --name-unnamed                 Ensure all wasm items have `$`-based names, even if they don't have an
+                                     entry in the `name` section
+  -f, --fold-instructions            Print instructions in the folded format. (See
+                                     https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions)
+      --print-operand-stack          Print the contents of the operand stack within function bodies
+      --indent-text <INDENT_TEXT>    The string to use when indenting
+      --indent <INDENT>              Number of spaces used for indentation, has lower priority than
+                                     `--indent-text`
+  -h, --help                         Print help (see more with '--help')
+
+Examples:
+
+    # Print the textual form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+    local.get $lhs
+    local.get $rhs
+    i32.add
+ )
+
+    # Print a "skeleton" form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm --skeleton
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32) ...)
+
+    # Print the textual form of `foo.wasm` to stdout, with folded instructions,
+    # binary offsets, and indented 6 spaces.
+    $ wasm-tools print foo.wasm -p -f --indent 6
+(module
+(;@b     ;)      (type (;0;) (func (param i32 i32) (result i32)))
+(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+(;@3c    ;)            (i32.add
+(;@38    ;)                  (local.get $lhs)
+(;@3a    ;)                  (local.get $rhs))
+                 )
+
+    # Print the textual form of `foo.wasm` to stdout, with synthesized names for
+    # items without a name in the `name` section. (Notice below that the type
+    # denoted by ;0; in the previous examples has been given a name.)
+    $ wasm-tools print foo.wasm --name-unnamed
+(module
+  (type $#type0 (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type $#type0) (param $lhs i32) (param $rhs i32) (result i32)
+...
+
+    # Print the textual form of `foo.wasm` to the file `foo.wat`.
+    $ wasm-tools print foo.wasm -o foo.wat
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-print-short.wat.stdout
+++ b/tests/cli/help-print-short.wat.stdout
@@ -6,25 +6,38 @@ Arguments:
   [INPUT]  Input file to process
 
 Options:
-      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
-                                     files
-  -g                                 Shorthand for `--generate-dwarf full`
-  -o, --output <OUTPUT>              Where to place output
-  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
-      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
-                                     auto]
-  -p, --print-offsets                Whether or not to print binary offsets intermingled in the text format as
-                                     comments for debugging
-      --skeleton                     Indicates that the "skeleton" of a module should be printed
-      --name-unnamed                 Ensure all wasm items have `$`-based names, even if they don't have an
-                                     entry in the `name` section
-  -f, --fold-instructions            Print instructions in the folded format. (See
-                                     https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions)
-      --print-operand-stack          Print the contents of the operand stack within function bodies
-      --indent-text <INDENT_TEXT>    The string to use when indenting
-      --indent <INDENT>              Number of spaces used for indentation, has lower priority than
-                                     `--indent-text`
-  -h, --help                         Print help (see more with '--help')
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text
+          files
+  -g
+          Shorthand for `--generate-dwarf full`
+  -o, --output <OUTPUT>
+          Where to place output
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output
+          [default: auto]
+  -p, --print-offsets
+          Whether or not to print binary offsets intermingled in the text format
+          as comments for debugging
+      --skeleton
+          Indicates that the "skeleton" of a module should be printed
+      --name-unnamed
+          Ensure all wasm items have `$`-based names, even if they don't have an
+          entry in the `name` section
+  -f, --fold-instructions
+          Print instructions in the folded format. (See
+          https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions)
+      --print-operand-stack
+          Print the contents of the operand stack within function bodies
+      --indent-text <INDENT_TEXT>
+          The string to use when indenting
+      --indent <INDENT>
+          Number of spaces used for indentation, has lower priority than
+          `--indent-text`
+  -h, --help
+          Print help (see more with '--help')
 
 Examples:
 
@@ -49,7 +62,8 @@ Examples:
     $ wasm-tools print foo.wasm -p -f --indent 6
 (module
 (;@b     ;)      (type (;0;) (func (param i32 i32) (result i32)))
-(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32)
+(result i32)
 (;@3c    ;)            (i32.add
 (;@38    ;)                  (local.get $lhs)
 (;@3a    ;)                  (local.get $rhs))

--- a/tests/cli/help-print.wat
+++ b/tests/cli/help-print.wat
@@ -1,0 +1,1 @@
+;; RUN: print --help

--- a/tests/cli/help-print.wat.stdout
+++ b/tests/cli/help-print.wat.stdout
@@ -1,0 +1,115 @@
+Print the textual form of a WebAssembly binary
+
+Usage: wasm-tools print [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
+          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text files.
+          
+          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
+          instruct the text parser to insert DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
+          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+
+  -g
+          Shorthand for `--generate-dwarf full`
+
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
+          terminal environment, for example by using `isatty`.
+          
+          [default: auto]
+
+  -p, --print-offsets
+          Whether or not to print binary offsets intermingled in the text format as comments for debugging
+
+      --skeleton
+          Indicates that the "skeleton" of a module should be printed.
+          
+          Items such as function bodies, data segments, and element segments are replaced with "..." instead of
+          printing their actual contents.
+
+      --name-unnamed
+          Ensure all wasm items have `$`-based names, even if they don't have an entry in the `name` section.
+          
+          This option, when enabled, will synthesize names for any item which doesn't previously have a name.
+
+  -f, --fold-instructions
+          Print instructions in the folded format. (See
+          https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions)
+
+      --print-operand-stack
+          Print the contents of the operand stack within function bodies
+
+      --indent-text <INDENT_TEXT>
+          The string to use when indenting
+
+      --indent <INDENT>
+          Number of spaces used for indentation, has lower priority than `--indent-text`
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+    # Print the textual form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+    local.get $lhs
+    local.get $rhs
+    i32.add
+ )
+
+    # Print a "skeleton" form of `foo.wasm` to stdout.
+    $ wasm-tools print foo.wasm --skeleton
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32) ...)
+
+    # Print the textual form of `foo.wasm` to stdout, with folded instructions,
+    # binary offsets, and indented 6 spaces.
+    $ wasm-tools print foo.wasm -p -f --indent 6
+(module
+(;@b     ;)      (type (;0;) (func (param i32 i32) (result i32)))
+(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+(;@3c    ;)            (i32.add
+(;@38    ;)                  (local.get $lhs)
+(;@3a    ;)                  (local.get $rhs))
+                 )
+
+    # Print the textual form of `foo.wasm` to stdout, with synthesized names for
+    # items without a name in the `name` section. (Notice below that the type
+    # denoted by ;0; in the previous examples has been given a name.)
+    $ wasm-tools print foo.wasm --name-unnamed
+(module
+  (type $#type0 (;0;) (func (param i32 i32) (result i32)))
+  (func $add (;0;) (type $#type0) (param $lhs i32) (param $rhs i32) (result i32)
+...
+
+    # Print the textual form of `foo.wasm` to the file `foo.wat`.
+    $ wasm-tools print foo.wasm -o foo.wat
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-print.wat.stdout
+++ b/tests/cli/help-print.wat.stdout
@@ -6,17 +6,21 @@ Arguments:
   [INPUT]
           Input file to process.
           
-          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
-          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
 
 Options:
       --generate-dwarf <lines|full>
-          Optionally generate DWARF debugging information from WebAssembly text files.
+          Optionally generate DWARF debugging information from WebAssembly text
+          files.
           
-          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
-          instruct the text parser to insert DWARF debugging information to map binary locations back to the
-          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
-          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+          When the input to this command is a WebAssembly text file, such as
+          `*.wat`, then this option will instruct the text parser to insert
+          DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has
+          no effect if the `INPUT` argument is already a WebAssembly binary or
+          if the text format uses `(module binary ...)`.
 
   -g
           Shorthand for `--generate-dwarf full`
@@ -34,24 +38,28 @@ Options:
       --color <COLOR>
           Configuration over whether terminal colors are used in output.
           
-          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
-          terminal environment, for example by using `isatty`.
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
           
           [default: auto]
 
   -p, --print-offsets
-          Whether or not to print binary offsets intermingled in the text format as comments for debugging
+          Whether or not to print binary offsets intermingled in the text format
+          as comments for debugging
 
       --skeleton
           Indicates that the "skeleton" of a module should be printed.
           
-          Items such as function bodies, data segments, and element segments are replaced with "..." instead of
-          printing their actual contents.
+          Items such as function bodies, data segments, and element segments are
+          replaced with "..." instead of printing their actual contents.
 
       --name-unnamed
-          Ensure all wasm items have `$`-based names, even if they don't have an entry in the `name` section.
+          Ensure all wasm items have `$`-based names, even if they don't have an
+          entry in the `name` section.
           
-          This option, when enabled, will synthesize names for any item which doesn't previously have a name.
+          This option, when enabled, will synthesize names for any item which
+          doesn't previously have a name.
 
   -f, --fold-instructions
           Print instructions in the folded format. (See
@@ -64,7 +72,8 @@ Options:
           The string to use when indenting
 
       --indent <INDENT>
-          Number of spaces used for indentation, has lower priority than `--indent-text`
+          Number of spaces used for indentation, has lower priority than
+          `--indent-text`
 
   -h, --help
           Print help (see a summary with '-h')
@@ -92,7 +101,8 @@ Examples:
     $ wasm-tools print foo.wasm -p -f --indent 6
 (module
 (;@b     ;)      (type (;0;) (func (param i32 i32) (result i32)))
-(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32) (result i32)
+(;@37    ;)      (func $add (;0;) (type 0) (param $lhs i32) (param $rhs i32)
+(result i32)
 (;@3c    ;)            (i32.add
 (;@38    ;)                  (local.get $lhs)
 (;@3a    ;)                  (local.get $rhs))

--- a/tests/cli/help-validate-short.wat
+++ b/tests/cli/help-validate-short.wat
@@ -1,0 +1,1 @@
+;; RUN: validate -h

--- a/tests/cli/help-validate-short.wat.stdout
+++ b/tests/cli/help-validate-short.wat.stdout
@@ -1,0 +1,32 @@
+Validate a WebAssembly binary
+
+Usage: wasm-tools validate [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
+                                     files
+  -g                                 Shorthand for `--generate-dwarf full`
+  -f, --features <FEATURES>          Comma-separated list of WebAssembly features to enable during validation
+  -o, --output <OUTPUT>              Where to place output
+  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
+                                     auto]
+  -h, --help                         Print help (see more with '--help')
+
+Examples:
+
+    # Validate `foo.wasm` with the default Wasm feature proposals.
+    $ wasm-tools validate foo.wasm
+
+    # Validate `foo.wasm` with more verbose output
+    $ wasm-tools validate -vv foo.wasm
+
+    # Validate `fancy.wasm` with all Wasm feature proposals enabled.
+    $ wasm-tools validate --features all fancy.wasm
+
+    # Validate `mvp.wasm` with the original wasm feature set enabled.
+    $ wasm-tools validate --features=wasm1 mvp.wasm
+    $ wasm-tools validate --features=mvp mvp.wasm

--- a/tests/cli/help-validate-short.wat.stdout
+++ b/tests/cli/help-validate-short.wat.stdout
@@ -6,15 +6,23 @@ Arguments:
   [INPUT]  Input file to process
 
 Options:
-      --generate-dwarf <lines|full>  Optionally generate DWARF debugging information from WebAssembly text
-                                     files
-  -g                                 Shorthand for `--generate-dwarf full`
-  -f, --features <FEATURES>          Comma-separated list of WebAssembly features to enable during validation
-  -o, --output <OUTPUT>              Where to place output
-  -v, --verbose...                   Use verbose output (-v info, -vv debug, -vvv trace)
-      --color <COLOR>                Configuration over whether terminal colors are used in output [default:
-                                     auto]
-  -h, --help                         Print help (see more with '--help')
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text
+          files
+  -g
+          Shorthand for `--generate-dwarf full`
+  -f, --features <FEATURES>
+          Comma-separated list of WebAssembly features to enable during
+          validation
+  -o, --output <OUTPUT>
+          Where to place output
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output
+          [default: auto]
+  -h, --help
+          Print help (see more with '--help')
 
 Examples:
 

--- a/tests/cli/help-validate-short.wat.stdout
+++ b/tests/cli/help-validate-short.wat.stdout
@@ -14,8 +14,6 @@ Options:
   -f, --features <FEATURES>
           Comma-separated list of WebAssembly features to enable during
           validation
-  -o, --output <OUTPUT>
-          Where to place output
   -v, --verbose...
           Use verbose output (-v info, -vv debug, -vvv trace)
       --color <COLOR>
@@ -38,3 +36,7 @@ Examples:
     # Validate `mvp.wasm` with the original wasm feature set enabled.
     $ wasm-tools validate --features=wasm1 mvp.wasm
     $ wasm-tools validate --features=mvp mvp.wasm
+
+Exit status:
+    0 if the binary is valid,
+    nonzero if the binary is not valid.

--- a/tests/cli/help-validate.wat
+++ b/tests/cli/help-validate.wat
@@ -1,0 +1,1 @@
+;; RUN: validate --help

--- a/tests/cli/help-validate.wat.stdout
+++ b/tests/cli/help-validate.wat.stdout
@@ -1,9 +1,13 @@
 Validate a WebAssembly binary
 
 This subcommand will validate a WebAssembly binary to determine if it's valid or
-not. This implements the validation algorithm of the WebAssembly specification.
-The process will exit with 0 and no output if the binary is valid, or nonzero
-and an error message on stderr if the binary is not valid.
+not. This implements the validation algorithm of the WebAssembly specification
+<https://webassembly.github.io/spec/core/valid/index.html>. No output is printed
+if the binary is valid; an error message is printed to stderr if the binary is
+not valid. A WebAssembly text file can also be used.
+
+Extra information will be included in the error message if the input WebAssembly
+binary contains DWARF debugging information.
 
 Usage: wasm-tools validate [OPTIONS] [INPUT]
 
@@ -50,13 +54,6 @@ Options:
           Available feature options can be found in the wasmparser crate:
           <https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasmparser/src/features.rs>
 
-  -o, --output <OUTPUT>
-          Where to place output.
-          
-          Required when printing WebAssembly binary output.
-          
-          If not provided, then stdout is used.
-
   -v, --verbose...
           Use verbose output (-v info, -vv debug, -vvv trace)
 
@@ -86,3 +83,7 @@ Examples:
     # Validate `mvp.wasm` with the original wasm feature set enabled.
     $ wasm-tools validate --features=wasm1 mvp.wasm
     $ wasm-tools validate --features=mvp mvp.wasm
+
+Exit status:
+    0 if the binary is valid,
+    nonzero if the binary is not valid.

--- a/tests/cli/help-validate.wat.stdout
+++ b/tests/cli/help-validate.wat.stdout
@@ -1,0 +1,79 @@
+Validate a WebAssembly binary
+
+This subcommand will validate a WebAssembly binary to determine if it's valid or not. This implements the
+validation algorithm of the WebAssembly specification. The process will exit with 0 and no output if the binary
+is valid, or nonzero and an error message on stderr if the binary is not valid.
+
+Usage: wasm-tools validate [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
+          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text files.
+          
+          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
+          instruct the text parser to insert DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
+          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+
+  -g
+          Shorthand for `--generate-dwarf full`
+
+  -f, --features <FEATURES>
+          Comma-separated list of WebAssembly features to enable during validation.
+          
+          If a "-" character is present in front of a feature it will disable that feature. For example "-simd"
+          will disable the simd proposal.
+          
+          The placeholder "all" can be used to enable all wasm features and the term "-all" can be used to
+          disable all features.
+          
+          The default set of features enabled are all WebAssembly proposals that are at phase 4 or after. This
+          means that the default set of features accepted are relatively bleeding edge. Versions of the
+          WebAssembly specification can also be selected. The "wasm1" or "mvp" feature can select the original
+          WebAssembly specification and "wasm2" can be used to select the 2.0 version.
+          
+          Available feature options can be found in the wasmparser crate:
+          <https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasmparser/src/features.rs>
+
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
+          terminal environment, for example by using `isatty`.
+          
+          [default: auto]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+    # Validate `foo.wasm` with the default Wasm feature proposals.
+    $ wasm-tools validate foo.wasm
+
+    # Validate `foo.wasm` with more verbose output
+    $ wasm-tools validate -vv foo.wasm
+
+    # Validate `fancy.wasm` with all Wasm feature proposals enabled.
+    $ wasm-tools validate --features all fancy.wasm
+
+    # Validate `mvp.wasm` with the original wasm feature set enabled.
+    $ wasm-tools validate --features=wasm1 mvp.wasm
+    $ wasm-tools validate --features=mvp mvp.wasm

--- a/tests/cli/help-validate.wat.stdout
+++ b/tests/cli/help-validate.wat.stdout
@@ -1,8 +1,9 @@
 Validate a WebAssembly binary
 
-This subcommand will validate a WebAssembly binary to determine if it's valid or not. This implements the
-validation algorithm of the WebAssembly specification. The process will exit with 0 and no output if the binary
-is valid, or nonzero and an error message on stderr if the binary is not valid.
+This subcommand will validate a WebAssembly binary to determine if it's valid or
+not. This implements the validation algorithm of the WebAssembly specification.
+The process will exit with 0 and no output if the binary is valid, or nonzero
+and an error message on stderr if the binary is not valid.
 
 Usage: wasm-tools validate [OPTIONS] [INPUT]
 
@@ -10,34 +11,41 @@ Arguments:
   [INPUT]
           Input file to process.
           
-          If not provided or if this is `-` then stdin is read entirely and processed. Note that for most
-          subcommands this input can either be a binary `*.wasm` file or a textual format `*.wat` file.
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
 
 Options:
       --generate-dwarf <lines|full>
-          Optionally generate DWARF debugging information from WebAssembly text files.
+          Optionally generate DWARF debugging information from WebAssembly text
+          files.
           
-          When the input to this command is a WebAssembly text file, such as `*.wat`, then this option will
-          instruct the text parser to insert DWARF debugging information to map binary locations back to the
-          original source locations in the input `*.wat` file. This option has no effect if the `INPUT`
-          argument is already a WebAssembly binary or if the text format uses `(module binary ...)`.
+          When the input to this command is a WebAssembly text file, such as
+          `*.wat`, then this option will instruct the text parser to insert
+          DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has
+          no effect if the `INPUT` argument is already a WebAssembly binary or
+          if the text format uses `(module binary ...)`.
 
   -g
           Shorthand for `--generate-dwarf full`
 
   -f, --features <FEATURES>
-          Comma-separated list of WebAssembly features to enable during validation.
+          Comma-separated list of WebAssembly features to enable during
+          validation.
           
-          If a "-" character is present in front of a feature it will disable that feature. For example "-simd"
-          will disable the simd proposal.
+          If a "-" character is present in front of a feature it will disable
+          that feature. For example "-simd" will disable the simd proposal.
           
-          The placeholder "all" can be used to enable all wasm features and the term "-all" can be used to
-          disable all features.
+          The placeholder "all" can be used to enable all wasm features and the
+          term "-all" can be used to disable all features.
           
-          The default set of features enabled are all WebAssembly proposals that are at phase 4 or after. This
-          means that the default set of features accepted are relatively bleeding edge. Versions of the
-          WebAssembly specification can also be selected. The "wasm1" or "mvp" feature can select the original
-          WebAssembly specification and "wasm2" can be used to select the 2.0 version.
+          The default set of features enabled are all WebAssembly proposals that
+          are at phase 4 or after. This means that the default set of features
+          accepted are relatively bleeding edge. Versions of the WebAssembly
+          specification can also be selected. The "wasm1" or "mvp" feature can
+          select the original WebAssembly specification and "wasm2" can be used
+          to select the 2.0 version.
           
           Available feature options can be found in the wasmparser crate:
           <https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasmparser/src/features.rs>
@@ -55,8 +63,9 @@ Options:
       --color <COLOR>
           Configuration over whether terminal colors are used in output.
           
-          Supports one of `auto|never|always|always-ansi`. The default is to detect what to do based on the
-          terminal environment, for example by using `isatty`.
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
           
           [default: auto]
 


### PR DESCRIPTION
Add tests for the -h and --help output for the
`parse`, `print`, and `validate` commands.