### PR TITLE
Initial support for futures/streams in wit-dylib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,95 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "fuzz-stats"
 version = "0.0.0"
 dependencies = [
@@ -1484,18 +1395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,12 +1754,6 @@ dependencies = [
  "bitmaps",
  "typenum",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2941,17 +2834,15 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 [[package]]
 name = "wit-bindgen"
 version = "0.46.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#6f67b5c2fe63e2e417b552f9f7bb6edc26e4955c"
 dependencies = [
- "futures",
- "once_cell",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
 version = "0.46.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#6f67b5c2fe63e2e417b552f9f7bb6edc26e4955c"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -2979,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.46.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#6f67b5c2fe63e2e417b552f9f7bb6edc26e4955c"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -2994,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.46.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#6f67b5c2fe63e2e417b552f9f7bb6edc26e4955c"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/crates/wit-dylib/ffi/src/ffi.rs
+++ b/crates/wit-dylib/ffi/src/ffi.rs
@@ -166,20 +166,70 @@ pub struct wit_fixed_size_list {
     pub ty: wit_type_t,
 }
 pub type wit_fixed_size_list_t = wit_fixed_size_list;
+pub type wit_async_type_lift_t = ::std::option::Option<
+    unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void, ptr: *const ::std::os::raw::c_void),
+>;
+pub type wit_async_type_lower_t = ::std::option::Option<
+    unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void, ptr: *mut ::std::os::raw::c_void),
+>;
+pub type wit_future_new_t = ::std::option::Option<unsafe extern "C" fn() -> u64>;
+pub type wit_future_read_t = ::std::option::Option<
+    unsafe extern "C" fn(handle: u32, ptr: *mut ::std::os::raw::c_void) -> u32,
+>;
+pub type wit_future_write_t = ::std::option::Option<
+    unsafe extern "C" fn(handle: u32, ptr: *const ::std::os::raw::c_void) -> u32,
+>;
+pub type wit_future_cancel_t = ::std::option::Option<unsafe extern "C" fn(handle: u32) -> u32>;
+pub type wit_future_drop_t = ::std::option::Option<unsafe extern "C" fn(handle: u32)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wit_future {
     pub interface: *const ::std::os::raw::c_char,
     pub name: *const ::std::os::raw::c_char,
     pub ty: wit_type_t,
+    pub new: wit_future_new_t,
+    pub read_async: wit_future_read_t,
+    pub write_async: wit_future_write_t,
+    pub read_sync: wit_future_read_t,
+    pub write_sync: wit_future_write_t,
+    pub cancel_read: wit_future_cancel_t,
+    pub cancel_write: wit_future_cancel_t,
+    pub drop_read: wit_future_drop_t,
+    pub drop_write: wit_future_drop_t,
+    pub lift: wit_async_type_lift_t,
+    pub lower: wit_async_type_lower_t,
+    pub elem_size: usize,
+    pub elem_align: usize,
 }
 pub type wit_future_t = wit_future;
+pub type wit_stream_new_t = ::std::option::Option<unsafe extern "C" fn() -> u64>;
+pub type wit_stream_read_t = ::std::option::Option<
+    unsafe extern "C" fn(handle: u32, ptr: *mut ::std::os::raw::c_void, len: usize) -> u32,
+>;
+pub type wit_stream_write_t = ::std::option::Option<
+    unsafe extern "C" fn(handle: u32, ptr: *const ::std::os::raw::c_void, len: usize) -> u32,
+>;
+pub type wit_stream_cancel_t = ::std::option::Option<unsafe extern "C" fn(handle: u32) -> u32>;
+pub type wit_stream_drop_t = ::std::option::Option<unsafe extern "C" fn(handle: u32)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct wit_stream {
     pub interface: *const ::std::os::raw::c_char,
     pub name: *const ::std::os::raw::c_char,
     pub ty: wit_type_t,
+    pub new: wit_stream_new_t,
+    pub read_async: wit_stream_read_t,
+    pub write_async: wit_stream_write_t,
+    pub read_sync: wit_stream_read_t,
+    pub write_sync: wit_stream_write_t,
+    pub cancel_read: wit_stream_cancel_t,
+    pub cancel_write: wit_stream_cancel_t,
+    pub drop_read: wit_stream_drop_t,
+    pub drop_write: wit_stream_drop_t,
+    pub lift: wit_async_type_lift_t,
+    pub lower: wit_async_type_lower_t,
+    pub elem_size: usize,
+    pub elem_align: usize,
 }
 pub type wit_stream_t = wit_stream;
 #[repr(C)]

--- a/crates/wit-dylib/src/bindgen.rs
+++ b/crates/wit-dylib/src/bindgen.rs
@@ -425,6 +425,30 @@ pub fn task_return(
     )
 }
 
+pub fn lift_from_memory(adapter: &mut Adapter, resolve: &Resolve, ty: Type) -> Function {
+    let mut c = FunctionCompiler::new(adapter, resolve, 2);
+    c.ctx = Some(TempLocal::new(0, ValType::I32));
+    let src = AbiLoc::Memory(Memory {
+        addr: TempLocal::new(1, ValType::I32),
+        offset: 0,
+    });
+
+    c.lift(&src, ty);
+    c.finish()
+}
+
+pub fn lower_to_memory(adapter: &mut Adapter, resolve: &Resolve, ty: Type) -> Function {
+    let mut c = FunctionCompiler::new(adapter, resolve, 2);
+    c.ctx = Some(TempLocal::new(0, ValType::I32));
+    let dst = AbiLoc::Memory(Memory {
+        addr: TempLocal::new(1, ValType::I32),
+        offset: 0,
+    });
+
+    c.lower(ty, &dst);
+    c.finish()
+}
+
 struct FunctionCompiler<'a> {
     adapter: &'a mut Adapter,
     resolve: &'a Resolve,

--- a/crates/wit-dylib/src/metadata.rs
+++ b/crates/wit-dylib/src/metadata.rs
@@ -102,12 +102,36 @@ pub struct Future {
     pub interface: Option<String>,
     pub name: Option<String>,
     pub ty: Option<Type>,
+    pub new_elem_index: u32,
+    pub read_async_elem_index: u32,
+    pub write_async_elem_index: u32,
+    pub read_sync_elem_index: u32,
+    pub write_sync_elem_index: u32,
+    pub cancel_read_elem_index: u32,
+    pub cancel_write_elem_index: u32,
+    pub drop_read_elem_index: u32,
+    pub drop_write_elem_index: u32,
+    pub lift_lower_elem_indexes: Option<(u32, u32)>,
+    pub elem_size: usize,
+    pub elem_align: usize,
 }
 
 pub struct Stream {
     pub interface: Option<String>,
     pub name: Option<String>,
     pub ty: Option<Type>,
+    pub new_elem_index: u32,
+    pub read_async_elem_index: u32,
+    pub write_async_elem_index: u32,
+    pub read_sync_elem_index: u32,
+    pub write_sync_elem_index: u32,
+    pub cancel_read_elem_index: u32,
+    pub cancel_write_elem_index: u32,
+    pub drop_read_elem_index: u32,
+    pub drop_write_elem_index: u32,
+    pub lift_lower_elem_indexes: Option<(u32, u32)>,
+    pub elem_size: usize,
+    pub elem_align: usize,
 }
 
 pub struct Alias {
@@ -481,10 +505,43 @@ impl Encoder {
                 interface,
                 name,
                 ty,
+                new_elem_index,
+                read_async_elem_index,
+                write_async_elem_index,
+                read_sync_elem_index,
+                write_sync_elem_index,
+                cancel_read_elem_index,
+                cancel_write_elem_index,
+                drop_read_elem_index,
+                drop_write_elem_index,
+                lift_lower_elem_indexes,
+                elem_size,
+                elem_align,
             } = future;
             self.opt_string_ptr(interface.as_deref());
             self.opt_string_ptr(name.as_deref());
             self.opt_ty(ty.as_ref());
+            self.elem_index(*new_elem_index);
+            self.elem_index(*read_async_elem_index);
+            self.elem_index(*write_async_elem_index);
+            self.elem_index(*read_sync_elem_index);
+            self.elem_index(*write_sync_elem_index);
+            self.elem_index(*cancel_read_elem_index);
+            self.elem_index(*cancel_write_elem_index);
+            self.elem_index(*drop_read_elem_index);
+            self.elem_index(*drop_write_elem_index);
+            match lift_lower_elem_indexes {
+                Some((lift, lower)) => {
+                    self.elem_index(*lift);
+                    self.elem_index(*lower);
+                }
+                None => {
+                    self.put_usize(0);
+                    self.put_usize(0);
+                }
+            }
+            self.put_usize(*elem_size);
+            self.put_usize(*elem_align);
         }
     }
 
@@ -494,10 +551,43 @@ impl Encoder {
                 interface,
                 name,
                 ty,
+                new_elem_index,
+                read_async_elem_index,
+                write_async_elem_index,
+                read_sync_elem_index,
+                write_sync_elem_index,
+                cancel_read_elem_index,
+                cancel_write_elem_index,
+                drop_read_elem_index,
+                drop_write_elem_index,
+                lift_lower_elem_indexes,
+                elem_size,
+                elem_align,
             } = stream;
             self.opt_string_ptr(interface.as_deref());
             self.opt_string_ptr(name.as_deref());
             self.opt_ty(ty.as_ref());
+            self.elem_index(*new_elem_index);
+            self.elem_index(*read_async_elem_index);
+            self.elem_index(*write_async_elem_index);
+            self.elem_index(*read_sync_elem_index);
+            self.elem_index(*write_sync_elem_index);
+            self.elem_index(*cancel_read_elem_index);
+            self.elem_index(*cancel_write_elem_index);
+            self.elem_index(*drop_read_elem_index);
+            self.elem_index(*drop_write_elem_index);
+            match lift_lower_elem_indexes {
+                Some((lift, lower)) => {
+                    self.elem_index(*lift);
+                    self.elem_index(*lower);
+                }
+                None => {
+                    self.put_usize(0);
+                    self.put_usize(0);
+                }
+            }
+            self.put_usize(*elem_size);
+            self.put_usize(*elem_align);
         }
     }
 

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -1236,8 +1236,6 @@ impl Function {
         let sig = resolve.wasm_signature(AbiVariant::GuestImport, &func_tmp);
         (module, name, sig)
     }
-
-    // push_imported_future_and_stream_intrinsics(wat, resolve, "[export]", interface, func);
 }
 
 fn find_futures_and_streams(resolve: &Resolve, ty: Type, results: &mut Vec<TypeId>) {


### PR DESCRIPTION
This needs some cleaning up and primarily needs tests. I wanted to open this up for now to at least have this here, however. Much of the remaining work will be in `wit-bindgen` to massage the future/stream implementation to work with the data structures in wit-dylib.