### PR TITLE
Expand --help output for `demangle`, `objdump`, and `strip` commands

### DIFF
--- a/src/bin/wasm-tools/demangle.rs
+++ b/src/bin/wasm-tools/demangle.rs
@@ -9,6 +9,37 @@ use wasmparser::{KnownCustom, Name, NameSectionReader, Parser, Payload::*};
 /// module which otherwise uses the `name` section but doesn't run a demangler
 /// will use the demangled names since the `name` section will be replaced.
 #[derive(clap::Parser)]
+#[clap(after_help = "\
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (func $do_not_demangle_me)
+  (func $_ZN4rustE)
+  (func $_Z3food)
+)
+
+The second two functions are mangled Rust symbol names.
+
+    # Demangle symbol names in foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools demangle -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func $do_not_demangle_me (;0;) (type 0))
+  (func $rust (;1;) (type 0))
+  (func $\"foo(double)\" (;2;) (type 0))
+)
+
+    # Demangle symbol names in foo.wasm and save the binary output
+    # to foo-demangled.wasm.
+    $ wasm-tools demangle foo.wasm -o foo-demangled.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.
+")]
 pub struct Opts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -9,6 +9,30 @@ use wasmparser::{Encoding, Parser, Payload::*};
 /// This is a relatively incomplete subcommand and is generally intended to just
 /// help poke around an object file.
 #[derive(clap::Parser)]
+#[clap(after_help = "
+Examples:
+
+       # Dump the contents of the file `add.wasm`:
+       $ wasm-tools objdump add.wasm
+       types                                  |        0xa -       0x11 |         7 bytes | 1 count
+       functions                              |       0x13 -       0x15 |         2 bytes | 1 count
+       exports                                |       0x17 -       0x33 |        28 bytes | 1 count
+       code                                   |       0x35 -       0x3e |         9 bytes | 1 count
+       custom \"name\"                          |       0x45 -       0x5c |        23 bytes | 1 count
+
+   One line is printed per section. The columns indicate:
+       * The name of the section (for example, \"types\")
+       * The offsets within the file for the start and end of the section (for example, \"0xa - 0x11\")
+       * The size of the section (for example, \"7 bytes\")
+       * The number of items within the section (for example, \"1 count\")
+
+       # Dump the contents of the file `add.wasm` and store the text-based output in a file
+       # named `add.txt`:
+       $ wasm-tools objdump add.wasm -o add.txt
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.")]
 pub struct Opts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,

--- a/src/bin/wasm-tools/strip.rs
+++ b/src/bin/wasm-tools/strip.rs
@@ -6,9 +6,56 @@ use wasmparser::{Parser, Payload::*};
 /// Removes custom sections from an input WebAssembly file.
 ///
 /// This command will by default strip all custom sections such as DWARF
-/// debugging information from a wasm file. It will not strip the `name` section
-/// by default unless the `--all` flag is passed.
+/// debugging information from a wasm file. It will not strip the `name`, `component-type`,
+/// or `dylink.0` sections by default unless the `--all` flag is passed.
 #[derive(clap::Parser)]
+#[clap(after_help = "\
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (type (;0;) (func))
+  (func (;2;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom \"linking\" (after code) \"\")
+  (@custom \"reloc.CODE\" (after code) \"\")
+  (@custom \"target_features\" (after code) \"\")
+)
+
+    # Remove all custom sections from foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools strip -a -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+)
+    # Remove only the custom sections whose names match the regexp `linking`
+    # and print the textual form of the output to stdout.
+    $ wasm-tools strip -d linking foo.wasm -t
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom \"reloc.CODE\" (after code) \"\")
+  (@custom \"target_features\" (after code) \"\")
+)
+
+   # Remove all custom sections from foo.wasm and save the binary output to
+   # the file out.wasm.
+   $ wasm-tools strip -a foo.wasm -o out.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.
+")]
 pub struct Opts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,

--- a/tests/cli/help-demangle-short.wat
+++ b/tests/cli/help-demangle-short.wat
@@ -1,0 +1,2 @@
+;; RUN: demangle -h
+

--- a/tests/cli/help-demangle-short.wat.stdout
+++ b/tests/cli/help-demangle-short.wat.stdout
@@ -1,0 +1,45 @@
+Demangle Rust and C++ symbol names in the `name` section
+
+Usage: wasm-tools demangle [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+  -o, --output <OUTPUT>  Where to place output
+  -v, --verbose...       Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>    Configuration over whether terminal colors are used in
+                         output [default: auto]
+  -t, --wat              Output the text format of WebAssembly instead of the
+                         binary format
+  -h, --help             Print help (see more with '--help')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (func $do_not_demangle_me)
+  (func $_ZN4rustE)
+  (func $_Z3food)
+)
+
+The second two functions are mangled Rust symbol names.
+
+    # Demangle symbol names in foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools demangle -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func $do_not_demangle_me (;0;) (type 0))
+  (func $rust (;1;) (type 0))
+  (func $"foo(double)" (;2;) (type 0))
+)
+
+    # Demangle symbol names in foo.wasm and save the binary output
+    # to foo-demangled.wasm.
+    $ wasm-tools demangle foo.wasm -o foo-demangled.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-demangle.wat
+++ b/tests/cli/help-demangle.wat
@@ -1,0 +1,1 @@
+;; RUN: demangle --help

--- a/tests/cli/help-demangle.wat.stdout
+++ b/tests/cli/help-demangle.wat.stdout
@@ -1,0 +1,72 @@
+Demangle Rust and C++ symbol names in the `name` section.
+
+This command will detect a `name` section in a wasm executable and demangle any
+Rust and C++ symbol names found within it. Tooling for debugging a wasm module
+which otherwise uses the `name` section but doesn't run a demangler will use the
+demangled names since the `name` section will be replaced.
+
+Usage: wasm-tools demangle [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
+          
+          [default: auto]
+
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (func $do_not_demangle_me)
+  (func $_ZN4rustE)
+  (func $_Z3food)
+)
+
+The second two functions are mangled Rust symbol names.
+
+    # Demangle symbol names in foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools demangle -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func $do_not_demangle_me (;0;) (type 0))
+  (func $rust (;1;) (type 0))
+  (func $"foo(double)" (;2;) (type 0))
+)
+
+    # Demangle symbol names in foo.wasm and save the binary output
+    # to foo-demangled.wasm.
+    $ wasm-tools demangle foo.wasm -o foo-demangled.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-objdump-short.wat
+++ b/tests/cli/help-objdump-short.wat
@@ -1,0 +1,1 @@
+;; RUN: objdump -h

--- a/tests/cli/help-objdump-short.wat.stdout
+++ b/tests/cli/help-objdump-short.wat.stdout
@@ -1,0 +1,45 @@
+Dumps information about sections in a WebAssembly file
+
+Usage: wasm-tools objdump [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+  -o, --output <OUTPUT>  Where to place output
+  -v, --verbose...       Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>    Configuration over whether terminal colors are used in
+                         output [default: auto]
+  -h, --help             Print help (see more with '--help')
+
+
+Examples:
+
+       # Dump the contents of the file `add.wasm`:
+       $ wasm-tools objdump add.wasm
+       types                                  |        0xa -       0x11 |
+       7 bytes | 1 count
+       functions                              |       0x13 -       0x15 |
+       2 bytes | 1 count
+       exports                                |       0x17 -       0x33 |
+       28 bytes | 1 count
+       code                                   |       0x35 -       0x3e |
+       9 bytes | 1 count
+       custom "name"                          |       0x45 -       0x5c |
+       23 bytes | 1 count
+
+   One line is printed per section. The columns indicate:
+       * The name of the section (for example, "types")
+       * The offsets within the file for the start and end of the section (for
+       example, "0xa - 0x11")
+       * The size of the section (for example, "7 bytes")
+       * The number of items within the section (for example, "1 count")
+
+       # Dump the contents of the file `add.wasm` and store the text-based
+       output in a file
+       # named `add.txt`:
+       $ wasm-tools objdump add.wasm -o add.txt
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.

--- a/tests/cli/help-objdump.wat
+++ b/tests/cli/help-objdump.wat
@@ -1,0 +1,2 @@
+;; RUN: objdump --help
+

--- a/tests/cli/help-objdump.wat.stdout
+++ b/tests/cli/help-objdump.wat.stdout
@@ -1,0 +1,69 @@
+Dumps information about sections in a WebAssembly file.
+
+This is a relatively incomplete subcommand and is generally intended to just
+help poke around an object file.
+
+Usage: wasm-tools objdump [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
+          
+          [default: auto]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+
+Examples:
+
+       # Dump the contents of the file `add.wasm`:
+       $ wasm-tools objdump add.wasm
+       types                                  |        0xa -       0x11 |
+       7 bytes | 1 count
+       functions                              |       0x13 -       0x15 |
+       2 bytes | 1 count
+       exports                                |       0x17 -       0x33 |
+       28 bytes | 1 count
+       code                                   |       0x35 -       0x3e |
+       9 bytes | 1 count
+       custom "name"                          |       0x45 -       0x5c |
+       23 bytes | 1 count
+
+   One line is printed per section. The columns indicate:
+       * The name of the section (for example, "types")
+       * The offsets within the file for the start and end of the section (for
+       example, "0xa - 0x11")
+       * The size of the section (for example, "7 bytes")
+       * The number of items within the section (for example, "1 count")
+
+       # Dump the contents of the file `add.wasm` and store the text-based
+       output in a file
+       # named `add.txt`:
+       $ wasm-tools objdump add.wasm -o add.txt
+
+Exit status:
+    0 if OK,
+    nonzero to indicate a parse error.

--- a/tests/cli/help-strip-short.wat
+++ b/tests/cli/help-strip-short.wat
@@ -1,0 +1,2 @@
+;; RUN: strip -h
+

--- a/tests/cli/help-strip-short.wat.stdout
+++ b/tests/cli/help-strip-short.wat.stdout
@@ -1,0 +1,63 @@
+Removes custom sections from an input WebAssembly file
+
+Usage: wasm-tools strip [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+  -o, --output <OUTPUT>  Where to place output
+  -v, --verbose...       Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>    Configuration over whether terminal colors are used in
+                         output [default: auto]
+  -a, --all              Remove all custom sections, regardless of name
+  -d, --delete <REGEX>   Remove custom sections matching the specified regex
+  -t, --wat              Output the text format of WebAssembly instead of the
+                         binary format
+  -h, --help             Print help (see more with '--help')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (type (;0;) (func))
+  (func (;2;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom "linking" (after code) "")
+  (@custom "reloc.CODE" (after code) "")
+  (@custom "target_features" (after code) "")
+)
+
+    # Remove all custom sections from foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools strip -a -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+)
+    # Remove only the custom sections whose names match the regexp `linking`
+    # and print the textual form of the output to stdout.
+    $ wasm-tools strip -d linking foo.wasm -t
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom "reloc.CODE" (after code) "")
+  (@custom "target_features" (after code) "")
+)
+
+   # Remove all custom sections from foo.wasm and save the binary output to
+   # the file out.wasm.
+   $ wasm-tools strip -a foo.wasm -o out.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-strip.wat
+++ b/tests/cli/help-strip.wat
@@ -1,0 +1,2 @@
+;; RUN: strip --help
+

--- a/tests/cli/help-strip.wat.stdout
+++ b/tests/cli/help-strip.wat.stdout
@@ -1,0 +1,93 @@
+Removes custom sections from an input WebAssembly file.
+
+This command will by default strip all custom sections such as DWARF debugging
+information from a wasm file. It will not strip the `name`, `component-type`, or
+`dylink.0` sections by default unless the `--all` flag is passed.
+
+Usage: wasm-tools strip [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
+          
+          [default: auto]
+
+  -a, --all
+          Remove all custom sections, regardless of name
+
+  -d, --delete <REGEX>
+          Remove custom sections matching the specified regex
+
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(module
+  (type (;0;) (func))
+  (func (;2;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom "linking" (after code) "")
+  (@custom "reloc.CODE" (after code) "")
+  (@custom "target_features" (after code) "")
+)
+
+    # Remove all custom sections from foo.wasm and print the textual form of
+    # the output to stdout.
+    $ wasm-tools strip -a -t foo.wasm
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+)
+    # Remove only the custom sections whose names match the regexp `linking`
+    # and print the textual form of the output to stdout.
+    $ wasm-tools strip -d linking foo.wasm -t
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32)
+    global.get 0
+  )
+  (@custom "reloc.CODE" (after code) "")
+  (@custom "target_features" (after code) "")
+)
+
+   # Remove all custom sections from foo.wasm and save the binary output to
+   # the file out.wasm.
+   $ wasm-tools strip -a foo.wasm -o out.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.


### PR DESCRIPTION
Add example usage sections.