### PR TITLE
Expand --help output for `metadata add` and `metadata show` commands

### DIFF
--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -33,6 +33,144 @@ impl Opts {
 
 /// Read metadata (module name, producers) from a WebAssembly file.
 #[derive(clap::Parser)]
+#[clap(after_help = "\
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $my-name
+  (core module $submodule)
+
+  (core module (@name \"another submodule\"))
+)
+
+This Wasm file represents a component containing two core modules.
+
+    # Show the metadata for foo.wasm in a tabular format.
+    $ wasm-tools metadata show foo.wasm
+
+╭───────────┬───────────────────┬──────┬───────┬───────────┬─────────╮
+│ KIND      ┆ NAME              ┆ SIZE ┆ SIZE% ┆ LANGUAGES ┆ PARENT  │
+╞═══════════╪═══════════════════╪══════╪═══════╪═══════════╪═════════╡
+│ component ┆ my-name           ┆ 136B ┆  100% ┆ -         ┆ <root>  │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ submodule         ┆  27B ┆   20% ┆ -         ┆ my-name │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ another submodule ┆  35B ┆   26% ┆ -         ┆ my-name │
+╰───────────┴───────────────────┴──────┴───────┴───────────┴─────────╯
+╭───────┬────────────────────────────╮
+│ KIND  ┆ VALUE                      │
+╞═══════╪════════════════════════════╡
+│ name  ┆ my-name                    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ component                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x0..0x88                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ submodule [module]         │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ another submodule [module] │
+╰───────┴────────────────────────────╯
+╭───────┬───────────╮
+│ KIND  ┆ VALUE     │
+╞═══════╪═══════════╡
+│ name  ┆ submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0xa..0x25 │
+╰───────┴───────────╯
+╭───────┬───────────────────╮
+│ KIND  ┆ VALUE             │
+╞═══════╪═══════════════════╡
+│ name  ┆ another submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module            │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x27..0x4a        │
+╰───────┴───────────────────╯
+
+    The first table summarizes the contents of the file: a component and two
+    core modules.
+
+    Next, one table is shown for each component and module. The first table
+    shows that a component named `my-name` is represented by the bytes in
+    foo.wasm between the offsets 0x0 and 0x88. The \"child\" rows of the table
+    show the names of each of its contained modules. The second two tables
+    show the names, kinds, and ranges of each of the modules in the file.
+
+    # Show the metadata for foo.wasm in JSON format.
+    # The output is not pretty-printed. For clarity, it has been pretty-printed
+    # here.
+    $ wasm-tools metadata show foo.wasm --json
+{
+  \"component\": {
+    \"metadata\": {
+      \"name\": \"my-name\",
+      \"producers\": null,
+      \"authors\": null,
+      \"description\": null,
+      \"licenses\": null,
+      \"source\": null,
+      \"homepage\": null,
+      \"revision\": null,
+      \"version\": null,
+      \"range\": {
+        \"start\": 0,
+        \"end\": 136
+      },
+      \"dependencies\": null
+    },
+    \"children\": [
+      {
+        \"module\": {
+          \"name\": \"submodule\",
+          \"producers\": null,
+          \"authors\": null,
+          \"description\": null,
+          \"licenses\": null,
+          \"source\": null,
+          \"homepage\": null,
+          \"revision\": null,
+          \"version\": null,
+          \"range\": {
+            \"start\": 10,
+            \"end\": 37
+          },
+          \"dependencies\": null
+        }
+      },
+      {
+        \"module\": {
+          \"name\": \"another submodule\",
+          \"producers\": null,
+          \"authors\": null,
+          \"description\": null,
+          \"licenses\": null,
+          \"source\": null,
+          \"homepage\": null,
+          \"revision\": null,
+          \"version\": null,
+          \"range\": {
+            \"start\": 39,
+            \"end\": 74
+          },
+          \"dependencies\": null
+        }
+      }
+    ]
+  }
+}
+
+    The JSON format contains some additional fields. In this example, the values of
+    those fields are set to `null` because they are not present in the input file.
+    In the tabular format, these fields were simply omitted.
+    The offset ranges are also shown in decimal instead of hexadecimal.
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.
+")]
 pub struct ShowOpts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,
@@ -64,6 +202,47 @@ impl ShowOpts {
 
 /// Add metadata (module name, producers) to a WebAssembly file
 #[derive(clap::Parser)]
+#[clap(after_help = "\
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $foo
+  (core module
+    (func $foo)
+  )
+)
+
+This Wasm file represents a component containing one core module.
+
+    # Add a programming language \"foo\" whose version is 1
+    # to the `producers` section, an \"authors\" string,
+    # and a homepage URL and print the textual representation
+    # to stdout
+    $ wasm-tools metadata add --language foo=1 \\
+          --authors \"J. Random Hacker\" \\
+          --homepage \"https://example.com/\" \\
+          foo.wasm -t
+(component $foo
+  (core module (;0;)
+    (type (;0;) (func))
+    (func $foo (;0;) (type 0))
+  )
+  (@producers
+    (language \"foo\" \"1\")
+  )
+  (@custom \"authors\" \"J. Random Hacker\")
+  (@custom \"homepage\" \"https://example.com/\")
+)
+
+   # Remove the homepage section from the file foo1.wasm
+   # and write the binary output to foo2.wasm
+   $ wasm-tools metadata add --clear-homepage foo1.wasm -o foo2.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.
+")]
 pub struct AddOpts {
     #[clap(flatten)]
     generate_dwarf: wasm_tools::GenerateDwarfArg,

--- a/tests/cli/help-metadata-add-short.wat
+++ b/tests/cli/help-metadata-add-short.wat
@@ -1,0 +1,2 @@
+;; RUN: metadata add -h
+

--- a/tests/cli/help-metadata-add-short.wat.stdout
+++ b/tests/cli/help-metadata-add-short.wat.stdout
@@ -1,0 +1,104 @@
+Add metadata (module name, producers) to a WebAssembly file
+
+Usage: wasm-tools metadata add [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text
+          files
+  -g
+          Shorthand for `--generate-dwarf full`
+  -o, --output <OUTPUT>
+          Where to place output
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output
+          [default: auto]
+      --name <NAME>
+          Add a module or component name to the names section
+      --clear-name
+          Remove a module or component name from the names section
+      --language <NAME=VERSION>
+          Add a programming language to the producers section
+      --processed-by <NAME=VERSION>
+          Add a tool and its version to the producers section
+      --sdk <NAME=VERSION>
+          Add an SDK and its version to the producers section
+      --authors <NAME>
+          Contact details of the people or organization responsible, encoded as
+          a freeform string
+      --clear-authors
+          Remove authors from the metadata
+      --description <NAME>
+          A human-readable description of the binary
+      --clear-description
+          Remove description from the metadata
+      --licenses <NAME>
+          License(s) under which contained software is distributed as an SPDX
+          License Expression
+      --clear-licenses
+          Remove licenses from the metadata
+      --source <NAME>
+          URL to get source code for building the image
+      --clear-source
+          Remove source from the metadata
+      --homepage <NAME>
+          URL to find more information on the binary
+      --clear-homepage
+          Remove homepage from the metadata
+      --revision <NAME>
+          Source control revision identifier for the packaged software
+      --clear-revision
+          Remove revision from the metadata
+      --version <NAME>
+          Version of the packaged software
+      --clear-version
+          Remove version from the metadata
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+  -h, --help
+          Print help (see more with '--help')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $foo
+  (core module
+    (func $foo)
+  )
+)
+
+This Wasm file represents a component containing one core module.
+
+    # Add a programming language "foo" whose version is 1
+    # to the `producers` section, an "authors" string,
+    # and a homepage URL and print the textual representation
+    # to stdout
+    $ wasm-tools metadata add --language foo=1 /
+          --authors "J. Random Hacker" /
+          --homepage "https://example.com/" /
+          foo.wasm -t
+(component $foo
+  (core module (;0;)
+    (type (;0;) (func))
+    (func $foo (;0;) (type 0))
+  )
+  (@producers
+    (language "foo" "1")
+  )
+  (@custom "authors" "J. Random Hacker")
+  (@custom "homepage" "https://example.com/")
+)
+
+   # Remove the homepage section from the file foo1.wasm
+   # and write the binary output to foo2.wasm
+   $ wasm-tools metadata add --clear-homepage foo1.wasm -o foo2.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-metadata-add.wat
+++ b/tests/cli/help-metadata-add.wat
@@ -1,0 +1,1 @@
+;; RUN: metadata add --help

--- a/tests/cli/help-metadata-add.wat.stdout
+++ b/tests/cli/help-metadata-add.wat.stdout
@@ -1,0 +1,150 @@
+Add metadata (module name, producers) to a WebAssembly file
+
+Usage: wasm-tools metadata add [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+      --generate-dwarf <lines|full>
+          Optionally generate DWARF debugging information from WebAssembly text
+          files.
+          
+          When the input to this command is a WebAssembly text file, such as
+          `*.wat`, then this option will instruct the text parser to insert
+          DWARF debugging information to map binary locations back to the
+          original source locations in the input `*.wat` file. This option has
+          no effect if the `INPUT` argument is already a WebAssembly binary or
+          if the text format uses `(module binary ...)`.
+
+  -g
+          Shorthand for `--generate-dwarf full`
+
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
+          
+          [default: auto]
+
+      --name <NAME>
+          Add a module or component name to the names section
+
+      --clear-name
+          Remove a module or component name from the names section
+
+      --language <NAME=VERSION>
+          Add a programming language to the producers section
+
+      --processed-by <NAME=VERSION>
+          Add a tool and its version to the producers section
+
+      --sdk <NAME=VERSION>
+          Add an SDK and its version to the producers section
+
+      --authors <NAME>
+          Contact details of the people or organization responsible, encoded as
+          a freeform string
+
+      --clear-authors
+          Remove authors from the metadata
+
+      --description <NAME>
+          A human-readable description of the binary
+
+      --clear-description
+          Remove description from the metadata
+
+      --licenses <NAME>
+          License(s) under which contained software is distributed as an SPDX
+          License Expression
+
+      --clear-licenses
+          Remove licenses from the metadata
+
+      --source <NAME>
+          URL to get source code for building the image
+
+      --clear-source
+          Remove source from the metadata
+
+      --homepage <NAME>
+          URL to find more information on the binary
+
+      --clear-homepage
+          Remove homepage from the metadata
+
+      --revision <NAME>
+          Source control revision identifier for the packaged software
+
+      --clear-revision
+          Remove revision from the metadata
+
+      --version <NAME>
+          Version of the packaged software
+
+      --clear-version
+          Remove version from the metadata
+
+  -t, --wat
+          Output the text format of WebAssembly instead of the binary format
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $foo
+  (core module
+    (func $foo)
+  )
+)
+
+This Wasm file represents a component containing one core module.
+
+    # Add a programming language "foo" whose version is 1
+    # to the `producers` section, an "authors" string,
+    # and a homepage URL and print the textual representation
+    # to stdout
+    $ wasm-tools metadata add --language foo=1 /
+          --authors "J. Random Hacker" /
+          --homepage "https://example.com/" /
+          foo.wasm -t
+(component $foo
+  (core module (;0;)
+    (type (;0;) (func))
+    (func $foo (;0;) (type 0))
+  )
+  (@producers
+    (language "foo" "1")
+  )
+  (@custom "authors" "J. Random Hacker")
+  (@custom "homepage" "https://example.com/")
+)
+
+   # Remove the homepage section from the file foo1.wasm
+   # and write the binary output to foo2.wasm
+   $ wasm-tools metadata add --clear-homepage foo1.wasm -o foo2.wasm
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-metadata-show-short.wat
+++ b/tests/cli/help-metadata-show-short.wat
@@ -1,0 +1,2 @@
+;; RUN: metadata show -h
+

--- a/tests/cli/help-metadata-show-short.wat.stdout
+++ b/tests/cli/help-metadata-show-short.wat.stdout
@@ -1,0 +1,153 @@
+Read metadata (module name, producers) from a WebAssembly file
+
+Usage: wasm-tools metadata show [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]  Input file to process
+
+Options:
+  -o, --output <OUTPUT>  Where to place output
+  -v, --verbose...       Use verbose output (-v info, -vv debug, -vvv trace)
+      --color <COLOR>    Configuration over whether terminal colors are used in
+                         output [default: auto]
+      --json             Output in JSON encoding
+  -h, --help             Print help (see more with '--help')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $my-name
+  (core module $submodule)
+
+  (core module (@name "another submodule"))
+)
+
+This Wasm file represents a component containing two core modules.
+
+    # Show the metadata for foo.wasm in a tabular format.
+    $ wasm-tools metadata show foo.wasm
+
+╭───────────┬───────────────────┬──────┬───────┬───────────┬─────────╮
+│ KIND      ┆ NAME              ┆ SIZE ┆ SIZE% ┆ LANGUAGES ┆ PARENT  │
+╞═══════════╪═══════════════════╪══════╪═══════╪═══════════╪═════════╡
+│ component ┆ my-name           ┆ 136B ┆  100% ┆ -         ┆ <root>  │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ submodule         ┆  27B ┆   20% ┆ -         ┆ my-name │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ another submodule ┆  35B ┆   26% ┆ -         ┆ my-name │
+╰───────────┴───────────────────┴──────┴───────┴───────────┴─────────╯
+╭───────┬────────────────────────────╮
+│ KIND  ┆ VALUE                      │
+╞═══════╪════════════════════════════╡
+│ name  ┆ my-name                    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ component                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x0..0x88                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ submodule [module]         │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ another submodule [module] │
+╰───────┴────────────────────────────╯
+╭───────┬───────────╮
+│ KIND  ┆ VALUE     │
+╞═══════╪═══════════╡
+│ name  ┆ submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0xa..0x25 │
+╰───────┴───────────╯
+╭───────┬───────────────────╮
+│ KIND  ┆ VALUE             │
+╞═══════╪═══════════════════╡
+│ name  ┆ another submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module            │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x27..0x4a        │
+╰───────┴───────────────────╯
+
+    The first table summarizes the contents of the file: a component and two
+    core modules.
+
+    Next, one table is shown for each component and module. The first table
+    shows that a component named `my-name` is represented by the bytes in
+    foo.wasm between the offsets 0x0 and 0x88. The "child" rows of the table
+    show the names of each of its contained modules. The second two tables
+    show the names, kinds, and ranges of each of the modules in the file.
+
+    # Show the metadata for foo.wasm in JSON format.
+    # The output is not pretty-printed. For clarity, it has been pretty-printed
+    # here.
+    $ wasm-tools metadata show foo.wasm --json
+{
+  "component": {
+    "metadata": {
+      "name": "my-name",
+      "producers": null,
+      "authors": null,
+      "description": null,
+      "licenses": null,
+      "source": null,
+      "homepage": null,
+      "revision": null,
+      "version": null,
+      "range": {
+        "start": 0,
+        "end": 136
+      },
+      "dependencies": null
+    },
+    "children": [
+      {
+        "module": {
+          "name": "submodule",
+          "producers": null,
+          "authors": null,
+          "description": null,
+          "licenses": null,
+          "source": null,
+          "homepage": null,
+          "revision": null,
+          "version": null,
+          "range": {
+            "start": 10,
+            "end": 37
+          },
+          "dependencies": null
+        }
+      },
+      {
+        "module": {
+          "name": "another submodule",
+          "producers": null,
+          "authors": null,
+          "description": null,
+          "licenses": null,
+          "source": null,
+          "homepage": null,
+          "revision": null,
+          "version": null,
+          "range": {
+            "start": 39,
+            "end": 74
+          },
+          "dependencies": null
+        }
+      }
+    ]
+  }
+}
+
+    The JSON format contains some additional fields. In this example, the values
+    of
+    those fields are set to `null` because they are not present in the input
+    file.
+    In the tabular format, these fields were simply omitted.
+    The offset ranges are also shown in decimal instead of hexadecimal.
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.

--- a/tests/cli/help-metadata-show.wat
+++ b/tests/cli/help-metadata-show.wat
@@ -1,0 +1,2 @@
+;; RUN: metadata show --help
+

--- a/tests/cli/help-metadata-show.wat.stdout
+++ b/tests/cli/help-metadata-show.wat.stdout
@@ -1,0 +1,176 @@
+Read metadata (module name, producers) from a WebAssembly file
+
+Usage: wasm-tools metadata show [OPTIONS] [INPUT]
+
+Arguments:
+  [INPUT]
+          Input file to process.
+          
+          If not provided or if this is `-` then stdin is read entirely and
+          processed. Note that for most subcommands this input can either be a
+          binary `*.wasm` file or a textual format `*.wat` file.
+
+Options:
+  -o, --output <OUTPUT>
+          Where to place output.
+          
+          Required when printing WebAssembly binary output.
+          
+          If not provided, then stdout is used.
+
+  -v, --verbose...
+          Use verbose output (-v info, -vv debug, -vvv trace)
+
+      --color <COLOR>
+          Configuration over whether terminal colors are used in output.
+          
+          Supports one of `auto|never|always|always-ansi`. The default is to
+          detect what to do based on the terminal environment, for example by
+          using `isatty`.
+          
+          [default: auto]
+
+      --json
+          Output in JSON encoding
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+
+Suppose foo.wasm has the following textual representation:
+
+(component $my-name
+  (core module $submodule)
+
+  (core module (@name "another submodule"))
+)
+
+This Wasm file represents a component containing two core modules.
+
+    # Show the metadata for foo.wasm in a tabular format.
+    $ wasm-tools metadata show foo.wasm
+
+╭───────────┬───────────────────┬──────┬───────┬───────────┬─────────╮
+│ KIND      ┆ NAME              ┆ SIZE ┆ SIZE% ┆ LANGUAGES ┆ PARENT  │
+╞═══════════╪═══════════════════╪══════╪═══════╪═══════════╪═════════╡
+│ component ┆ my-name           ┆ 136B ┆  100% ┆ -         ┆ <root>  │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ submodule         ┆  27B ┆   20% ┆ -         ┆ my-name │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+│ module    ┆ another submodule ┆  35B ┆   26% ┆ -         ┆ my-name │
+╰───────────┴───────────────────┴──────┴───────┴───────────┴─────────╯
+╭───────┬────────────────────────────╮
+│ KIND  ┆ VALUE                      │
+╞═══════╪════════════════════════════╡
+│ name  ┆ my-name                    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ component                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x0..0x88                  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ submodule [module]         │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ child ┆ another submodule [module] │
+╰───────┴────────────────────────────╯
+╭───────┬───────────╮
+│ KIND  ┆ VALUE     │
+╞═══════╪═══════════╡
+│ name  ┆ submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module    │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0xa..0x25 │
+╰───────┴───────────╯
+╭───────┬───────────────────╮
+│ KIND  ┆ VALUE             │
+╞═══════╪═══════════════════╡
+│ name  ┆ another submodule │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ kind  ┆ module            │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ range ┆ 0x27..0x4a        │
+╰───────┴───────────────────╯
+
+    The first table summarizes the contents of the file: a component and two
+    core modules.
+
+    Next, one table is shown for each component and module. The first table
+    shows that a component named `my-name` is represented by the bytes in
+    foo.wasm between the offsets 0x0 and 0x88. The "child" rows of the table
+    show the names of each of its contained modules. The second two tables
+    show the names, kinds, and ranges of each of the modules in the file.
+
+    # Show the metadata for foo.wasm in JSON format.
+    # The output is not pretty-printed. For clarity, it has been pretty-printed
+    # here.
+    $ wasm-tools metadata show foo.wasm --json
+{
+  "component": {
+    "metadata": {
+      "name": "my-name",
+      "producers": null,
+      "authors": null,
+      "description": null,
+      "licenses": null,
+      "source": null,
+      "homepage": null,
+      "revision": null,
+      "version": null,
+      "range": {
+        "start": 0,
+        "end": 136
+      },
+      "dependencies": null
+    },
+    "children": [
+      {
+        "module": {
+          "name": "submodule",
+          "producers": null,
+          "authors": null,
+          "description": null,
+          "licenses": null,
+          "source": null,
+          "homepage": null,
+          "revision": null,
+          "version": null,
+          "range": {
+            "start": 10,
+            "end": 37
+          },
+          "dependencies": null
+        }
+      },
+      {
+        "module": {
+          "name": "another submodule",
+          "producers": null,
+          "authors": null,
+          "description": null,
+          "licenses": null,
+          "source": null,
+          "homepage": null,
+          "revision": null,
+          "version": null,
+          "range": {
+            "start": 39,
+            "end": 74
+          },
+          "dependencies": null
+        }
+      }
+    ]
+  }
+}
+
+    The JSON format contains some additional fields. In this example, the values
+    of
+    those fields are set to `null` because they are not present in the input
+    file.
+    In the tabular format, these fields were simply omitted.
+    The offset ranges are also shown in decimal instead of hexadecimal.
+
+Exit status:
+    0 on success,
+    nonzero if the input file fails to parse.


### PR DESCRIPTION
Add example usage sections.