### PR TITLE
Change “author” to “authors” (plural) in `wasm-metadata`

### DIFF
--- a/crates/wasm-metadata/src/oci_annotations/authors.rs
+++ b/crates/wasm-metadata/src/oci_annotations/authors.rs
@@ -13,7 +13,7 @@ use wasmparser::CustomSectionReader;
 pub struct Authors(CustomSection<'static>);
 
 impl Authors {
-    /// Create a new instance of `Author`.
+    /// Create a new instance of `Authors`.
     pub fn new<S: Into<Cow<'static, str>>>(s: S) -> Self {
         Self(CustomSection {
             name: "authors".into(),
@@ -24,7 +24,7 @@ impl Authors {
         })
     }
 
-    /// Parse an `author` custom section from a wasm binary.
+    /// Parse an `authors` custom section from a wasm binary.
     pub(crate) fn parse_custom_section(reader: &CustomSectionReader<'_>) -> Result<Self> {
         ensure!(
             reader.name() == "authors",
@@ -94,8 +94,8 @@ mod test {
         let mut parsed = false;
         for section in wasmparser::Parser::new(0).parse_all(&component) {
             if let Payload::CustomSection(reader) = section.unwrap() {
-                let author = Authors::parse_custom_section(&reader).unwrap();
-                assert_eq!(author.to_string(), "Nori Cat");
+                let authors = Authors::parse_custom_section(&reader).unwrap();
+                assert_eq!(authors.to_string(), "Nori Cat");
                 parsed = true;
             }
         }
@@ -104,8 +104,8 @@ mod test {
 
     #[test]
     fn serialize() {
-        let author = Authors::new("Chashu Cat");
-        let json = serde_json::to_string(&author).unwrap();
+        let authors = Authors::new("Chashu Cat");
+        let json = serde_json::to_string(&authors).unwrap();
         assert_eq!(r#""Chashu Cat""#, json);
     }
 }

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -96,13 +96,11 @@ impl Payload {
                     #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "authors" => {
                         let a = Authors::parse_custom_section(&c)?;
-                        let Metadata {
-                            authors: author, ..
-                        } = output
+                        let Metadata { authors, .. } = output
                             .last_mut()
                             .expect("non-empty metadata stack")
                             .metadata_mut();
-                        *author = Some(a);
+                        *authors = Some(a);
                     }
                     #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "description" => {

--- a/crates/wasm-metadata/src/rewrite.rs
+++ b/crates/wasm-metadata/src/rewrite.rs
@@ -92,10 +92,10 @@ pub(crate) fn rewrite_wasm(
                         continue;
                     }
                     #[cfg(feature = "oci")]
-                    KnownCustom::Unknown if c.name() == "author" => {
+                    KnownCustom::Unknown if c.name() == "authors" => {
                         if metadata.authors.is_keep() {
-                            let author = crate::Authors::parse_custom_section(c)?;
-                            author.append_to(&mut output);
+                            let authors = crate::Authors::parse_custom_section(c)?;
+                            authors.append_to(&mut output);
                             continue;
                         } else if metadata.authors.is_clear() {
                             continue;
@@ -193,8 +193,8 @@ pub(crate) fn rewrite_wasm(
         producers.section().append_to(&mut output);
     }
     #[cfg(feature = "oci")]
-    if let AddMetadataField::Set(author) = &metadata.authors {
-        author.append_to(&mut output);
+    if let AddMetadataField::Set(authors) = &metadata.authors {
+        authors.append_to(&mut output);
     }
     #[cfg(feature = "oci")]
     if let AddMetadataField::Set(description) = &metadata.description {

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -39,7 +39,7 @@ fn add_to_empty_component() {
                 Metadata {
                     name,
                     producers,
-                    authors: author,
+                    authors,
                     description,
                     licenses,
                     source,
@@ -62,7 +62,7 @@ fn add_to_empty_component() {
                 "1.0"
             );
 
-            assert_eq!(author.unwrap(), Authors::new("Chashu Cat"));
+            assert_eq!(authors.unwrap(), Authors::new("Chashu Cat"));
             assert_eq!(description.unwrap(), Description::new("Chashu likes tuna"));
             assert_eq!(
                 licenses.unwrap(),
@@ -155,7 +155,7 @@ fn add_to_nested_component() {
                 Payload::Module(Metadata {
                     name,
                     producers,
-                    authors: author,
+                    authors,
                     licenses,
                     source,
                     range,
@@ -176,7 +176,7 @@ fn add_to_nested_component() {
                         "1.0"
                     );
 
-                    assert_eq!(author, &Some(Authors::new("Chashu Cat")));
+                    assert_eq!(authors, &Some(Authors::new("Chashu Cat")));
                     assert_eq!(description, &Some(Description::new("Chashu likes tuna")));
                     assert_eq!(
                         licenses,
@@ -258,7 +258,7 @@ fn add_then_clear_fields() {
                 Metadata {
                     name,
                     producers,
-                    authors: author,
+                    authors,
                     description,
                     licenses,
                     source,
@@ -281,7 +281,7 @@ fn add_then_clear_fields() {
                 "1.0"
             );
 
-            assert_eq!(author.unwrap(), Authors::new("Chashu Cat"));
+            assert_eq!(authors.unwrap(), Authors::new("Chashu Cat"));
             assert_eq!(
                 description.unwrap(),
                 Description::new("Chashu likes something else")

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -36,7 +36,7 @@ fn add_to_empty_module() {
         Payload::Module(Metadata {
             name,
             producers,
-            authors: author,
+            authors,
             licenses,
             source,
             range,
@@ -57,7 +57,7 @@ fn add_to_empty_module() {
                 "1.0"
             );
 
-            assert_eq!(author.unwrap(), Authors::new("Chashu Cat"));
+            assert_eq!(authors.unwrap(), Authors::new("Chashu Cat"));
             assert_eq!(description.unwrap(), Description::new("Chashu likes tuna"));
             assert_eq!(
                 licenses.unwrap(),


### PR DESCRIPTION
Closes #2326
