### PR TITLE
Allow long symbol names

### DIFF
--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -299,7 +299,7 @@ impl<'a> FromReader<'a> for SymbolInfo<'a> {
             SYMTAB_FUNCTION | SYMTAB_GLOBAL | SYMTAB_EVENT | SYMTAB_TABLE => {
                 let index = reader.read_var_u32()?;
                 let name = match defined || explicit_name {
-                    true => Some(reader.read_string()?),
+                    true => Some(reader.read_unlimited_string()?),
                     false => None,
                 };
                 Ok(match kind {
@@ -311,7 +311,7 @@ impl<'a> FromReader<'a> for SymbolInfo<'a> {
                 })
             }
             SYMTAB_DATA => {
-                let name = reader.read_string()?;
+                let name = reader.read_unlimited_string()?;
                 let data = match defined {
                     true => Some(reader.read()?),
                     false => None,


### PR DESCRIPTION
Read symbol names in the custom linking section without the usual `limits::MAX_WASM_STRING_SIZE`.

Internal symbols can contain the name of generated closure types and monomorphized generic arguments, leading to very long symbol names. While often not semantically meaningful to an engine, these strings are useful for debugging and not subject to any length restriction when emitted by llvm.

Fixes #2332 