### PR TITLE
ci: attest build for releases

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -65,6 +65,13 @@ runs:
         generate_release_notes: true
         tag_name: v${{ steps.tag.outputs.version }}
 
+    # Generate attestations for release artifacts
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v3
+      if: steps.tag.outputs.push_tag == 'yes'
+      with:
+        subject-path: 'dist/*'
+
     # Conditionally run crate publishes if the token is present.
     - run: rustup update stable && rustup default stable
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   create_tag:


### PR DESCRIPTION
Adds [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance) to the publish workflow.

This will allow downstream consumers to verify the provenance of release artifacts downstream.

```bash
artifact_path=wasm-tools-1.239.0-aarch64-linux.tar.gz

gh attestation verify "$artifact_path" --repo bytecodealliance/wasm-tools
```
