### PR TITLE
Use `read_unlimited_string` for more strings

### DIFF
--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -45,7 +45,7 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
         let offset = reader.original_position();
         Ok(match id {
             0 => {
-                let name = reader.read_string()?;
+                let name = reader.read_unlimited_string()?;
                 if !reader.eof() {
                     return Err(BinaryReaderError::new(
                         "trailing data at the end of a name",

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -29,7 +29,7 @@ impl<'a> CoreDumpSection<'a> {
         if reader.read_u8()? != 0 {
             bail!(pos, "invalid start byte for core dump name");
         }
-        let name = reader.read_string()?;
+        let name = reader.read_unlimited_string()?;
         if !reader.eof() {
             bail!(
                 reader.original_position(),
@@ -69,7 +69,7 @@ impl<'a> CoreDumpModulesSection<'a> {
             if reader.read_u8()? != 0 {
                 bail!(pos, "invalid start byte for coremodule");
             }
-            modules.push(reader.read_string()?);
+            modules.push(reader.read_unlimited_string()?);
         }
         if !reader.eof() {
             bail!(
@@ -181,7 +181,7 @@ impl<'a> CoreDumpStackSection<'a> {
         if reader.read_u8()? != 0 {
             bail!(pos, "invalid start byte for core dump stack name");
         }
-        let name = reader.read_string()?;
+        let name = reader.read_unlimited_string()?;
         let mut frames = vec![];
         for _ in 0..reader.read_var_u32()? {
             frames.push(CoreDumpStackFrame::from_reader(&mut reader)?);

--- a/crates/wasmparser/src/readers/core/dylink0.rs
+++ b/crates/wasmparser/src/readers/core/dylink0.rs
@@ -78,14 +78,14 @@ impl<'a> Subsection<'a> for Dylink0Subsection<'a> {
             }),
             WASM_DYLINK_NEEDED => Self::Needed(
                 (0..reader.read_var_u32()?)
-                    .map(|_| reader.read_string())
+                    .map(|_| reader.read_unlimited_string())
                     .collect::<Result<_, _>>()?,
             ),
             WASM_DYLINK_EXPORT_INFO => Self::ExportInfo(
                 (0..reader.read_var_u32()?)
                     .map(|_| {
                         Ok(ExportInfo {
-                            name: reader.read_string()?,
+                            name: reader.read_unlimited_string()?,
                             flags: reader.read()?,
                         })
                     })
@@ -95,8 +95,8 @@ impl<'a> Subsection<'a> for Dylink0Subsection<'a> {
                 (0..reader.read_var_u32()?)
                     .map(|_| {
                         Ok(ImportInfo {
-                            module: reader.read_string()?,
-                            field: reader.read_string()?,
+                            module: reader.read_unlimited_string()?,
+                            field: reader.read_unlimited_string()?,
                             flags: reader.read()?,
                         })
                     })
@@ -104,7 +104,7 @@ impl<'a> Subsection<'a> for Dylink0Subsection<'a> {
             ),
             WASM_DYLINK_RUNTIME_PATH => Self::RuntimePath(
                 (0..reader.read_var_u32()?)
-                    .map(|_| reader.read_string())
+                    .map(|_| reader.read_unlimited_string())
                     .collect::<Result<_, _>>()?,
             ),
             ty => Self::Unknown {

--- a/crates/wasmparser/src/readers/core/producers.rs
+++ b/crates/wasmparser/src/readers/core/producers.rs
@@ -46,7 +46,7 @@ pub struct ProducersField<'a> {
 impl<'a> FromReader<'a> for ProducersField<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let offset = reader.original_position();
-        let name = reader.read_string()?;
+        let name = reader.read_unlimited_string()?;
         match name {
             "language" | "sdk" | "processed-by" => {}
             _ => bail!(offset, "invalid producers field name: `{name}`"),
@@ -77,8 +77,8 @@ pub struct ProducersFieldValue<'a> {
 
 impl<'a> FromReader<'a> for ProducersFieldValue<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let name = reader.read_string()?;
-        let version = reader.read_string()?;
+        let name = reader.read_unlimited_string()?;
+        let version = reader.read_unlimited_string()?;
         Ok(ProducersFieldValue { name, version })
     }
 }


### PR DESCRIPTION
Effectively for anything that resides in a custom section use the `read_unlimited_string` string helper since the same restrictions for strings in the "main module" don't necessarily apply to custom sections.