### PR TITLE
wasmparser: clarify validator error message

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -988,7 +988,7 @@ where
         if memarg.align > memarg.max_align {
             bail!(
                 self.offset,
-                "malformed memop alignment: alignment must not be larger than natural"
+                "invalid memop alignment: alignment must not be larger than natural"
             );
         }
         if index_ty == ValType::I32 && memarg.offset > u64::from(u32::MAX) {


### PR DESCRIPTION
This PR changes one validator error message to clarify that it's flagging an invalid (rather than malformed) memop alignment.