### PR TITLE
Fix new warnings on nightly

### DIFF
--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -939,7 +939,7 @@ impl<'a> Module<'a> {
 macro_rules! define_visit {
     ($(@$p:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident ($($ann:tt)*))*) => {
         $(
-            #[allow(unused_variables, reason = "macro-generated")]
+            #[allow(unused_variables)]
             fn $visit(&mut self $(, $($arg: $argty),*)?)  {
                 $(
                     $(


### PR DESCRIPTION
Some unused variable warnings are cropping up on nightly now that the compiler presumably checks a bit more deeply for unused variables.