### PR TITLE
wasm-compose: Update `heck` dependency to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -957,12 +957,6 @@ dependencies = [
  "foldhash",
  "serde",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2157,7 +2151,7 @@ version = "0.240.0"
 dependencies = [
  "anyhow",
  "glob",
- "heck 0.4.1",
+ "heck",
  "im-rc",
  "indexmap 2.10.0",
  "log",
@@ -2712,7 +2706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f967f5efaaac7694e6bd0d67542a5a036830860e4adf95684260181e85a5d299"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.10.0",
  "wit-parser 0.233.0",
 ]
@@ -2954,7 +2948,7 @@ version = "0.46.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser 0.239.0",
 ]
 
@@ -2982,7 +2976,7 @@ version = "0.46.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#7208f7b39751d2ed4147bd82787a393e82f57c0c"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.10.0",
  "prettyplease",
  "syn",

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-heck = "0.4.0"
+heck = "0.5.0"
 im-rc = "15.1.0"
 indexmap = { workspace = true, features = ["serde"] }
 log = { workspace = true }


### PR DESCRIPTION
Removes duplicate versions of `heck` in the crate graph.