### PR TITLE
Clamp down further on error-context feature gate

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -3910,13 +3910,7 @@ impl ComponentState {
     ) -> Result<ComponentDefinedType> {
         match ty {
             crate::ComponentDefinedType::Primitive(ty) => {
-                if ty == crate::PrimitiveValType::ErrorContext && !self.features.cm_error_context()
-                {
-                    bail!(
-                        offset,
-                        "`error-context` requires the component model error-context feature"
-                    )
-                }
+                self.check_primitive_type(ty, offset)?;
                 Ok(ComponentDefinedType::Primitive(ty))
             }
             crate::ComponentDefinedType::Record(fields) => {
@@ -4184,7 +4178,10 @@ impl ComponentState {
         offset: usize,
     ) -> Result<ComponentValType> {
         Ok(match ty {
-            crate::ComponentValType::Primitive(pt) => ComponentValType::Primitive(pt),
+            crate::ComponentValType::Primitive(pt) => {
+                self.check_primitive_type(pt, offset)?;
+                ComponentValType::Primitive(pt)
+            }
             crate::ComponentValType::Type(idx) => {
                 ComponentValType::Type(self.defined_type_at(idx, offset)?)
             }
@@ -4467,6 +4464,16 @@ impl ComponentState {
                 offset,
                 "support for component model `value`s is not enabled"
             );
+        }
+        Ok(())
+    }
+
+    fn check_primitive_type(&self, ty: crate::PrimitiveValType, offset: usize) -> Result<()> {
+        if ty == crate::PrimitiveValType::ErrorContext && !self.features.cm_error_context() {
+            bail!(
+                offset,
+                "`error-context` requires the component model error-context feature"
+            )
         }
         Ok(())
     }

--- a/tests/cli/missing-features/component-model/error-context.wast
+++ b/tests/cli/missing-features/component-model/error-context.wast
@@ -3,6 +3,14 @@
 ;; error-context.new
 (assert_invalid
   (component
+    (import "x" (func (param "x" error-context)))
+  )
+  "requires the component model error-context feature"
+)
+
+;; error-context.new
+(assert_invalid
+  (component
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core module $m

--- a/tests/snapshots/cli/missing-features/component-model/error-context.wast.json
+++ b/tests/snapshots/cli/missing-features/component-model/error-context.wast.json
@@ -6,26 +6,33 @@
       "line": 5,
       "filename": "error-context.0.wasm",
       "module_type": "binary",
+      "text": "requires the component model error-context feature"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 13,
+      "filename": "error-context.1.wasm",
+      "module_type": "binary",
       "text": "`error-context.new` requires the component model error-context feature"
     },
     {
       "type": "assert_invalid",
-      "line": 19,
-      "filename": "error-context.1.wasm",
+      "line": 27,
+      "filename": "error-context.2.wasm",
       "module_type": "binary",
       "text": "`error-context.debug-message` requires the component model error-context feature"
     },
     {
       "type": "assert_invalid",
-      "line": 36,
-      "filename": "error-context.2.wasm",
+      "line": 44,
+      "filename": "error-context.3.wasm",
       "module_type": "binary",
       "text": "`error-context.drop` requires the component model error-context feature"
     },
     {
       "type": "assert_invalid",
-      "line": 48,
-      "filename": "error-context.3.wasm",
+      "line": 56,
+      "filename": "error-context.4.wasm",
       "module_type": "binary",
       "text": "requires the component model error-context feature"
     }


### PR DESCRIPTION
Some usage of `error-context` was leaking past feature gates, so this plugs those holes.