### PR TITLE
extend wave label to take number segments

### DIFF
--- a/crates/wasm-wave/src/lex.rs
+++ b/crates/wasm-wave/src/lex.rs
@@ -12,7 +12,8 @@ pub type Lexer<'source> = logos::Lexer<'source, Token>;
 #[logos(error = Option<Span>)]
 #[logos(skip r"[ \t\n\r]+")]
 #[logos(skip r"//[^\n]*")]
-#[logos(subpattern label_word = r"[a-z][a-z0-9]*|[A-Z][A-Z0-9]*")]
+#[logos(subpattern first_label_word = r"[a-z][a-z0-9]*|[A-Z][A-Z0-9]*")]
+#[logos(subpattern label_word = r"[a-z0-9]+|[A-Z0-9]+")]
 #[logos(subpattern char_escape = r#"\\['"tnr\\]|\\u\{[0-9a-fA-F]{1,6}\}"#)]
 pub enum Token {
     /// The `{` symbol
@@ -50,7 +51,7 @@ pub enum Token {
     Number,
 
     /// A label or keyword
-    #[regex(r"%?(?&label_word)(-(?&label_word))*")]
+    #[regex(r"%?(?&first_label_word)(-(?&label_word))*")]
     LabelOrKeyword,
 
     /// A char literal

--- a/crates/wasm-wave/src/parser.rs
+++ b/crates/wasm-wave/src/parser.rs
@@ -591,15 +591,21 @@ mod tests {
 
     #[test]
     fn parse_percent_identifiers() {
-        let ty = Type::record([("red", Type::S32), ("green", Type::CHAR)]).unwrap();
+        let ty = Type::record([
+            ("red", Type::S32),
+            ("green", Type::CHAR),
+            ("color-42-2A-5d", Type::BOOL),
+        ])
+        .unwrap();
         // Test identifiers with '%' prefixes.
         assert_eq!(
-            parse_value("{ %red: 0, %green: 'a' }", &ty),
+            parse_value("{ %red: 0, %green: 'a', %color-42-2A-5d: true }", &ty),
             Value::make_record(
                 &ty,
                 [
                     ("red", Value::make_s32(0)),
-                    ("green", Value::make_char('a'))
+                    ("green", Value::make_char('a')),
+                    ("color-42-2A-5d", Value::make_bool(true))
                 ]
             )
             .unwrap()


### PR DESCRIPTION
Follow up with https://github.com/bytecodealliance/wasm-tools/pull/2355.

Also need to extend wave parser to handle numbered identifiers.