### PR TITLE
Fix parsing named locals without an inline function type

### DIFF
--- a/crates/wast/src/core/binary/dwarf.rs
+++ b/crates/wast/src/core/binary/dwarf.rs
@@ -11,7 +11,7 @@
 //! easy/fun to play around with.
 
 use crate::core::binary::{EncodeOptions, Encoder, GenerateDwarf, Names, RecOrType};
-use crate::core::{InnerTypeKind, Local, ValType};
+use crate::core::{Local, ValType};
 use crate::token::Span;
 use gimli::write::{
     self, Address, AttributeValue, DwarfUnit, Expression, FileId, LineProgram, LineString,
@@ -216,19 +216,8 @@ impl<'a> Dwarf<'a> {
         ty: u32,
         locals: &[Local<'_>],
     ) {
-        // Iterate through `self.types` which is what was encoded into the
-        // module and find the function type which gives access to the
-        // parameters which gives access to their types.
-        let ty = self
-            .types
-            .iter()
-            .flat_map(|t| match t {
-                RecOrType::Type(t) => std::slice::from_ref(*t),
-                RecOrType::Rec(r) => &r.types,
-            })
-            .nth(ty as usize);
-        let ty = match ty.map(|t| &t.def.kind) {
-            Some(InnerTypeKind::Func(ty)) => ty,
+        let ty = match super::func_type(self.types, ty) {
+            Some(ty) => ty,
             _ => return,
         };
 

--- a/tests/cli/locals-named-correctly.wat
+++ b/tests/cli/locals-named-correctly.wat
@@ -1,0 +1,9 @@
+;; RUN: print %
+
+(module
+  (type $a (func (param i32)))
+
+  (func (type $a)
+    (local $b i32)
+  )
+)

--- a/tests/cli/locals-named-correctly.wat.stdout
+++ b/tests/cli/locals-named-correctly.wat.stdout
@@ -1,0 +1,6 @@
+(module
+  (type $a (;0;) (func (param i32)))
+  (func (;0;) (type $a) (param i32)
+    (local $b i32)
+  )
+)

--- a/tests/snapshots/cli/stack-switching/cont.wast/47.print
+++ b/tests/snapshots/cli/stack-switching/cont.wast/47.print
@@ -21,30 +21,30 @@
     i32.const 42
     return
   )
-  (func $f (;2;) (type $ft) (param $nextk (ref null $ct))
-    (local (ref null $ct))
+  (func $f (;2;) (type $ft) (param (ref null $ct))
+    (local $nextk (ref null $ct))
+    local.get 0
+    local.set $nextk
+    global.get $fi
+    call $print-i32
     local.get $nextk
-    local.set 1
-    global.get $fi
-    call $print-i32
-    local.get 1
     switch $ct $swap
-    local.set 1
+    local.set $nextk
     global.get $fi
     call $print-i32
-    local.get 1
+    local.get $nextk
     switch $ct $swap
     drop
   )
-  (func $g (;3;) (type $ft) (param $nextk (ref null $ct))
-    (local (ref null $ct))
-    local.get $nextk
-    local.set 1
+  (func $g (;3;) (type $ft) (param (ref null $ct))
+    (local $nextk (ref null $ct))
+    local.get 0
+    local.set $nextk
     global.get $gi
     call $print-i32
-    local.get 1
+    local.get $nextk
     switch $ct $swap
-    local.set 1
+    local.set $nextk
     global.get $gi
     call $print-i32
   )

--- a/tests/snapshots/cli/stack-switching/cont.wast/49.print
+++ b/tests/snapshots/cli/stack-switching/cont.wast/49.print
@@ -17,48 +17,48 @@
     cont.new $ct
     resume $ct (on $swap switch)
   )
-  (func $f (;2;) (type $ft) (param $i i32) (param $nextk (ref null $ct)) (result i32)
-    (local i32 (ref null $ct))
+  (func $f (;2;) (type $ft) (param i32 (ref null $ct)) (result i32)
+    (local $i i32) (local $nextk (ref null $ct))
+    local.get 0
+    local.set $i
+    local.get 1
+    local.set $nextk
     local.get $i
-    local.set 2
+    call $print-i32
+    i32.const 1
+    local.get $i
+    i32.add
     local.get $nextk
-    local.set 3
-    local.get 2
-    call $print-i32
-    i32.const 1
-    local.get 2
-    i32.add
-    local.get 3
     switch $ct $swap
-    local.set 3
-    local.set 2
-    local.get 2
+    local.set $nextk
+    local.set $i
+    local.get $i
     call $print-i32
     i32.const 1
-    local.get 2
+    local.get $i
     i32.add
-    local.get 3
+    local.get $nextk
     switch $ct $swap
     unreachable
   )
-  (func $g (;3;) (type $ft) (param $i i32) (param $nextk (ref null $ct)) (result i32)
-    (local i32 (ref null $ct))
+  (func $g (;3;) (type $ft) (param i32 (ref null $ct)) (result i32)
+    (local $i i32) (local $nextk (ref null $ct))
+    local.get 0
+    local.set $i
+    local.get 1
+    local.set $nextk
     local.get $i
-    local.set 2
-    local.get $nextk
-    local.set 3
-    local.get 2
     call $print-i32
     i32.const 1
-    local.get 2
+    local.get $i
     i32.add
-    local.get 3
+    local.get $nextk
     switch $ct $swap
-    local.set 3
-    local.set 2
-    local.get 2
+    local.set $nextk
+    local.set $i
+    local.get $i
     call $print-i32
-    local.get 2
+    local.get $i
     return
   )
 )

--- a/tests/snapshots/testsuite/func.wast/93.print
+++ b/tests/snapshots/testsuite/func.wast/93.print
@@ -4,13 +4,13 @@
   (export "f" (func 0))
   (export "g" (func 2))
   (export "p" (func 3))
-  (func (;0;) (type $sig) (param $var i32) (result i32)
-    (local i32)
-    local.get 1
+  (func (;0;) (type $sig) (param i32) (result i32)
+    (local $var i32)
+    local.get $var
   )
-  (func $g (;1;) (type $sig) (param $var i32) (result i32)
-    (local i32)
-    local.get 1
+  (func $g (;1;) (type $sig) (param i32) (result i32)
+    (local $var i32)
+    local.get $var
   )
   (func (;2;) (type $sig) (param i32) (result i32)
     local.get 0


### PR DESCRIPTION
This commit fixes a bug in `wast` where the generated `name` section was invalid and placed local names on the wrong location. This happened when a function type was not listed inline for a function (e.g. it was `(type $foo)`) meaning that the binary translation started with the wrong local offset. The fix here is to do a lookup of the function type to see how many parameters it has and start the indexing there, or skip emitting local names if the function type doesn't exist.