### PR TITLE
fix(wit-parser): validate case insensitivity

### DIFF
--- a/crates/wit-parser/tests/ui/parse-fail/case-insensitive-duplicates.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/case-insensitive-duplicates.wit
@@ -1,0 +1,9 @@
+// parse-fail
+
+package poc:demo;
+
+world example {
+  import get-data: func() -> string;
+  export get-user: func() -> string;
+  export GET-USER: func() -> string;
+}

--- a/crates/wit-parser/tests/ui/parse-fail/case-insensitive-duplicates.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/case-insensitive-duplicates.wit.result
@@ -1,0 +1,1 @@
+failed to validate exports in world `example`: export `GET-USER` conflicts with export `get-user` (kebab-case identifiers are case-insensitive)


### PR DESCRIPTION
This is intended to catch invalid WIT like the one is this report early: https://github.com/bytecodealliance/wit-bindgen/issues/1411
