### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           os: ubuntu-latest
           target: wasm32-wasip1
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -74,7 +74,7 @@ jobs:
     name: Test (no-hash-maps)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/install-rust
@@ -115,7 +115,7 @@ jobs:
               RUST_BACKTRACE: 1
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -127,7 +127,7 @@ jobs:
     name: Test with extra Cargo features
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -147,7 +147,7 @@ jobs:
           - os: macos-latest
           - os: windows-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -158,7 +158,7 @@ jobs:
     name: Test libdl.so
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -171,7 +171,7 @@ jobs:
     name: Test on WebAssembly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -195,7 +195,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/install-rust
     - run: rustup component add rustfmt
     - run: printf "\n" > playground/component/src/bindings.rs
@@ -208,7 +208,7 @@ jobs:
     name: Fuzz
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -221,7 +221,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-rust
       - run: rustup target add x86_64-unknown-none
       - run: cargo check --benches -p wasm-smith
@@ -298,7 +298,7 @@ jobs:
     name: Check generated files are up-to-date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/install-rust
@@ -311,14 +311,14 @@ jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-rust
       - run: RUSTDOCFLAGS="-Dwarnings" cargo doc --all
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-rust
       - run: rustup component add clippy
       - run: cargo clippy --workspace --all-targets --exclude dl --exclude component
@@ -327,7 +327,7 @@ jobs:
     if: github.repository_owner == 'bytecodealliance'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
@@ -380,7 +380,7 @@ jobs:
       && github.event_name == 'push'
       && startsWith(github.ref, 'refs/heads/release-')
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build playground deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -25,7 +25,7 @@ jobs:
     name: Run the release process
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Setup


### PR DESCRIPTION
Update checkout action to v6. Better credential handling in containers.

https://github.com/actions/checkout/releases/tag/v6.0.0