### PR TITLE
Fix foreign interface dependencies which are disabled by feature-gating

### DIFF
--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -103,7 +103,7 @@ pub struct UnresolvedPackage {
     /// interface name followed by the identifier within `self.interfaces`. The
     /// fields of `self.interfaces` describes the required types that are from
     /// each foreign interface.
-    pub foreign_deps: IndexMap<PackageName, IndexMap<String, AstItem>>,
+    pub foreign_deps: IndexMap<PackageName, IndexMap<String, (AstItem, Vec<Stability>)>>,
 
     /// Doc comments for this package.
     pub docs: Docs,

--- a/crates/wit-parser/tests/ui/foreign-interface-dep-gated.wit
+++ b/crates/wit-parser/tests/ui/foreign-interface-dep-gated.wit
@@ -1,0 +1,17 @@
+package a:b1;
+
+world the-world {
+  include a:b2/the-world;
+}
+
+package a:b2 {
+  world the-world {
+    @unstable(feature = disabled)
+    import a:b3/thing;
+  }
+}
+
+package a:b3 {
+  @unstable(feature = disabled)
+  interface thing {}
+}

--- a/crates/wit-parser/tests/ui/foreign-interface-dep-gated.wit.json
+++ b/crates/wit-parser/tests/ui/foreign-interface-dep-gated.wit.json
@@ -1,0 +1,39 @@
+{
+  "worlds": [
+    {
+      "name": "the-world",
+      "imports": {},
+      "exports": {},
+      "package": 1
+    },
+    {
+      "name": "the-world",
+      "imports": {},
+      "exports": {},
+      "package": 2
+    }
+  ],
+  "interfaces": [],
+  "types": [],
+  "packages": [
+    {
+      "name": "a:b3",
+      "interfaces": {},
+      "worlds": {}
+    },
+    {
+      "name": "a:b2",
+      "interfaces": {},
+      "worlds": {
+        "the-world": 0
+      }
+    },
+    {
+      "name": "a:b1",
+      "interfaces": {},
+      "worlds": {
+        "the-world": 1
+      }
+    }
+  ]
+}

--- a/crates/wit-parser/tests/ui/foreign-world-dep-gated.wit
+++ b/crates/wit-parser/tests/ui/foreign-world-dep-gated.wit
@@ -1,0 +1,17 @@
+package a:b1;
+
+world the-world {
+  include a:b2/the-world;
+}
+
+package a:b2 {
+  world the-world {
+    @unstable(feature = disabled)
+    import a:b3/another-world;
+  }
+}
+
+package a:b3 {
+  @unstable(feature = disabled)
+  world another-world {}
+}

--- a/crates/wit-parser/tests/ui/foreign-world-dep-gated.wit.json
+++ b/crates/wit-parser/tests/ui/foreign-world-dep-gated.wit.json
@@ -1,0 +1,39 @@
+{
+  "worlds": [
+    {
+      "name": "the-world",
+      "imports": {},
+      "exports": {},
+      "package": 1
+    },
+    {
+      "name": "the-world",
+      "imports": {},
+      "exports": {},
+      "package": 2
+    }
+  ],
+  "interfaces": [],
+  "types": [],
+  "packages": [
+    {
+      "name": "a:b3",
+      "interfaces": {},
+      "worlds": {}
+    },
+    {
+      "name": "a:b2",
+      "interfaces": {},
+      "worlds": {
+        "the-world": 0
+      }
+    },
+    {
+      "name": "a:b1",
+      "interfaces": {},
+      "worlds": {
+        "the-world": 1
+      }
+    }
+  ]
+}

--- a/tests/cli/bad-stability.wit.stderr
+++ b/tests/cli/bad-stability.wit.stderr
@@ -1,8 +1,5 @@
-error: failed to process world item in `c`
-
-Caused by:
-    0: package [a:b] contains a feature gate with a version specifier, so it must have a version
-            --> tests/cli/bad-stability.wit:7:14
-             |
-           7 |   import d:e/f-g-h@0.2.3;
-             |              ^----
+error: package [a:b] contains a feature gate with a version specifier, so it must have a version
+     --> tests/cli/bad-stability.wit:7:14
+      |
+    7 |   import d:e/f-g-h@0.2.3;
+      |              ^----


### PR DESCRIPTION
A foreign imported interface can be missing from pkg.interfaces either because it does not exist, or because it was disabled by feature-gating.

Previously, the parser failed in both cases, when it should only fail when it does not exist, and should succeed when the references to it are disabled by feature-gating.

By checking the set of unresolved worlds' imports and exports for references to this interface, it is possible to determine if they contain any references to the interface, and whether or not they were disabled by feature gating.

If they are all disabled, then it does not matter that the interface is absent from pkg.interfaces, and the code should not fail. If any references are active however, then this is an error as the code will not be able to find the interface in pkg.interfaces.

If no references exist at all, then no combination of feature enabling/disabling would satisfy the import/use statement which requires the interface, and the code should fail.

This fixes issue 2285 and a unit test was added to cover this case.