### PR TITLE
Improve error message for missing wasi-sdk

### DIFF
--- a/crates/wit-dylib/test-programs/artifacts/build.rs
+++ b/crates/wit-dylib/test-programs/artifacts/build.rs
@@ -7,7 +7,7 @@ fn main() {
     let wasi_sdk_path = PathBuf::from(std::env::var("WASI_SDK_PATH").expect(
         "
 The $WASI_SDK_PATH environment variable isn't set and thus these tests can't be
-built. If you're testing the entier workspace pass `--exclude wit-dylib` to
+built. If you're testing the entire workspace pass `--exclude wit-dylib` to
 Cargo to avoid testing this crate, and otherwise you can install the sdk through
 https://github.com/webassembly/wasi-sdk
 


### PR DESCRIPTION
Be a bit more descriptive about what it means and how to work around it.