### PR TITLE
Make Ieee{32,64} methods `const`

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -303,12 +303,12 @@ pub struct Ieee32(pub(crate) u32);
 
 impl Ieee32 {
     /// Creates a new Ieee32
-    pub fn new(bits: u32) -> Self {
+    pub const fn new(bits: u32) -> Self {
         Ieee32(bits)
     }
 
     /// Gets the underlying bits of the 32-bit float.
-    pub fn bits(self) -> u32 {
+    pub const fn bits(self) -> u32 {
         self.0
     }
 }
@@ -341,12 +341,12 @@ pub struct Ieee64(pub(crate) u64);
 
 impl Ieee64 {
     /// Creates a new Ieee64
-    pub fn new(bits: u64) -> Self {
+    pub const fn new(bits: u64) -> Self {
         Ieee64(bits)
     }
 
     /// Gets the underlying bits of the 64-bit float.
-    pub fn bits(self) -> u64 {
+    pub const fn bits(self) -> u64 {
         self.0
     }
 }


### PR DESCRIPTION
This is a very minor thing so I thought probably not worth making an issue for it.

This just makes the `Ieee{32,64}::{new,bits}` methods `const` - I happened to want to use `new` in a `const` context and ended up using `core::mem::transmute` instead which is less nice. I see no reason why the methods shouldn't be const.