### PR TITLE
Add negative tests for compact imports

### DIFF
--- a/tests/cli/compact-imports/compact-imports-rejected.wast
+++ b/tests/cli/compact-imports/compact-imports-rejected.wast
@@ -1,0 +1,22 @@
+;; RUN: wast --assert default --snapshot tests/snapshots % -f=-compact-imports
+
+(assert_malformed
+  (module
+    (import "test"
+      (item "fi32" (func (result i32)))
+      (item "fi64" (func (result i64)))
+    )
+  )
+  "invalid leading byte 0x7F with compact imports proposal disabled")
+
+(assert_malformed
+  (module
+    (import "test"
+      (item "g1")
+      (item "g20")
+      (item "g300")
+      (item "g4000")
+      (global i32)
+    )
+  )
+  "invalid leading byte 0x7E with compact imports proposal disabled")

--- a/tests/snapshots/cli/compact-imports/compact-imports-rejected.wast.json
+++ b/tests/snapshots/cli/compact-imports/compact-imports-rejected.wast.json
@@ -1,0 +1,19 @@
+{
+  "source_filename": "tests/cli/compact-imports/compact-imports-rejected.wast",
+  "commands": [
+    {
+      "type": "assert_malformed",
+      "line": 4,
+      "filename": "compact-imports-rejected.0.wasm",
+      "module_type": "binary",
+      "text": "invalid leading byte 0x7F with compact imports proposal disabled"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 13,
+      "filename": "compact-imports-rejected.1.wasm",
+      "module_type": "binary",
+      "text": "invalid leading byte 0x7E with compact imports proposal disabled"
+    }
+  ]
+}


### PR DESCRIPTION
Assert that when the feature is disabled the new binary forms are rejected.