### PR TITLE
Install a pinned version of Wasmtime

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -70,4 +70,4 @@ runs:
     - name: Setup `wasmtime`
       uses: bytecodealliance/actions/wasmtime/setup@v1
       with:
-        version: "dev"
+        version: "v40.0.0"


### PR DESCRIPTION
Try to resolve the CI errors coming from the latest version of wasmtime related to `async` and tests for `wit-dylib`.