### PR TITLE
Add aarch64-windows release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,41 +30,60 @@ jobs:
         include:
         - build: x86_64-linux
           os: ubuntu-latest
+          env:
+            CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
+            DOCKER_IMAGE: ./ci/docker/x86_64-linux/Dockerfile
         - build: x86_64-musl
           os: ubuntu-latest
-          target: x86_64-unknown-linux-musl
-        - build: x86_64-macos
-          os: macos-latest
-          target: x86_64-apple-darwin
-        - build: aarch64-macos
-          os: macos-latest
-          target: aarch64-apple-darwin
-        - build: x86_64-windows
-          os: windows-latest
+          env:
+            CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
+            DOCKER_IMAGE: ./ci/docker/x86_64-musl/Dockerfile
         - build: aarch64-linux
           os: ubuntu-latest
-          target: aarch64-unknown-linux-gnu
+          env:
+            CARGO_BUILD_TARGET: aarch64-unknown-linux-gnu
+            DOCKER_IMAGE: ./ci/docker/aarch64-linux/Dockerfile
         - build: aarch64-musl
           os: ubuntu-latest
-          target: aarch64-unknown-linux-musl
+          env:
+            CARGO_BUILD_TARGET: aarch64-unknown-linux-musl
+            DOCKER_IMAGE: ./ci/docker/aarch64-musl/Dockerfile
+
+        - build: x86_64-macos
+          os: macos-latest
+          env:
+            CARGO_BUILD_TARGET: x86_64-apple-darwin
+            MACOSX_DEPLOYMENT_TARGET: 10.12
+        - build: aarch64-macos
+          os: macos-latest
+          env:
+            CARGO_BUILD_TARGET: aarch64-apple-darwin
+            MACOSX_DEPLOYMENT_TARGET: 10.12
+
+        - build: x86_64-windows
+          os: windows-latest
+          env:
+            CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
+            RUSTFLAGS: -Ctarget-feature=+crt-static
+        - build: aarch64-windows
+          os: windows-11-arm
+          env:
+            CARGO_BUILD_TARGET: aarch64-pc-windows-msvc
+            RUSTFLAGS: -Ctarget-feature=+crt-static
+
         - build: wasm32-wasip1
           os: ubuntu-latest
-          target: wasm32-wasip1
+          env:
+            CARGO_BUILD_TARGET: wasm32-wasip1
+    env: ${{ matrix.env }}
     steps:
     - uses: actions/checkout@v6
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@release-28.0.0
-      with:
-        name: ${{ matrix.build }}
-      if: matrix.build != 'wasm32-wasip1'
-    - run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-    - run: $CENTOS cargo build --release
-    - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}"
+    - run: rustup target add $CARGO_BUILD_TARGET
+    - run: ./ci/build-release-artifacts.sh
+    - run: ./ci/build-tarballs.sh "${{ matrix.build }}"
     - uses: actions/upload-artifact@v4
       with:
         name: bins-${{ matrix.build }}

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# A script to build the release artifacts of this repository into the `target`
+# directory. Note that this script only produces the artifacts through Cargo and
+# doesn't package things up. That's intended for the `build-tarballs.sh` script.
+
+set -ex
+
+# If `$DOCKER_IMAGE` is set then run the build inside of that docker container
+# instead of on the host machine. In CI this uses `./ci/docker/*/Dockerfile` to
+# have precise glibc requirements for Linux platforms for example.
+if [ "$DOCKER_IMAGE" != "" ]; then
+  if [ -f "$DOCKER_IMAGE" ]; then
+    docker build --tag build-image --file $DOCKER_IMAGE ci/docker
+    DOCKER_IMAGE=build-image
+  fi
+
+  # Inherit the environment's rustc and env vars related to cargo/rust, and then
+  # otherwise re-execute ourselves and we'll be missing `$DOCKER_IMAGE` in the
+  # container so we'll continue below.
+  exec docker run --interactive \
+    --volume `pwd`:`pwd` \
+    --volume `rustc --print sysroot`:/rust:ro \
+    --workdir `pwd` \
+    --interactive \
+    --env-file <(env | grep 'CARGO\|RUST') \
+    $DOCKER_IMAGE \
+    bash -c "PATH=\$PATH:/rust/bin RUSTFLAGS=\"\$RUSTFLAGS \$EXTRA_RUSTFLAGS\" `pwd`/$0 $*"
+fi
+
+# Default build flags for release artifacts. Leave debugging for
+# builds-from-source which have richer information anyway, and additionally the
+# CLI won't benefit from catching unwinds.
+export CARGO_PROFILE_RELEASE_STRIP=debuginfo
+export CARGO_PROFILE_RELEASE_PANIC=abort
+
+exec cargo build --release

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -3,7 +3,7 @@
 set -ex
 
 platform=$1
-target=$2
+target=$CARGO_BUILD_TARGET
 
 rm -rf tmp
 mkdir tmp
@@ -15,17 +15,20 @@ bin_pkgname=wasm-tools-$tag-$platform
 mkdir tmp/$bin_pkgname
 cp LICENSE-* README.md tmp/$bin_pkgname
 
-fmt=tar
-if [ "$platform" = "x86_64-windows" ]; then
-  cp target/release/wasm-tools.exe tmp/$bin_pkgname
-  fmt=zip
-elif [ "$target" = "wasm32-wasip1" ]; then
-  cp target/wasm32-wasip1/release/wasm-tools.wasm tmp/$bin_pkgname
-elif [ "$target" = "" ]; then
-  cp target/release/wasm-tools tmp/$bin_pkgname
-else
-  cp target/$target/release/wasm-tools tmp/$bin_pkgname
-fi
+case $platform in
+  *-windows)
+    fmt=zip
+    cp target/$target/release/wasm-tools.exe tmp/$bin_pkgname
+    ;;
+  wasm*)
+    fmt=tar
+    cp target/$target/release/wasm-tools.wasm tmp/$bin_pkgname
+    ;;
+  *)
+    fmt=tar
+    cp target/$target/release/wasm-tools tmp/$bin_pkgname
+    ;;
+esac
 
 
 mktarball() {


### PR DESCRIPTION
Also includes refactorings to mirror changes in
bytecodealliance/wasm-component-ld#87 (also mirrored in bytecodealliance/wit-bindgen#1488). Change here include making the build more self-contained instead of relying on a github action from a historical release of Wasmtime.