### PR TITLE
Escape `map` when printing WITs

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -1229,6 +1229,7 @@ fn is_keyword(name: &str) -> bool {
             | "constructor"
             | "error-context"
             | "async"
+            | "map"
     )
 }
 


### PR DESCRIPTION
Added as a keyword recently.