### PR TITLE
Remove support for `float{32,64}`

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -6,9 +6,6 @@ use std::mem;
 use std::ops::Deref;
 use wit_parser::*;
 
-// NB: keep in sync with `crates/wit-parser/src/ast/lex.rs`
-const PRINT_F32_F64_DEFAULT: bool = true;
-
 /// A utility for printing WebAssembly interface definitions to a string.
 pub struct WitPrinter<O: Output = OutputToString> {
     /// Visitor that holds the WIT document being printed.
@@ -20,8 +17,6 @@ pub struct WitPrinter<O: Output = OutputToString> {
 
     // Whether to print doc comments.
     emit_docs: bool,
-
-    print_f32_f64: bool,
 }
 
 impl Default for WitPrinter {
@@ -37,10 +32,6 @@ impl<O: Output> WitPrinter<O> {
             output,
             any_items: false,
             emit_docs: true,
-            print_f32_f64: match std::env::var("WIT_REQUIRE_F32_F64") {
-                Ok(s) => s == "1",
-                Err(_) => PRINT_F32_F64_DEFAULT,
-            },
         }
     }
 
@@ -543,20 +534,8 @@ impl<O: Output> WitPrinter<O> {
             Type::S16 => self.output.ty("s16", TypeKind::BuiltIn),
             Type::S32 => self.output.ty("s32", TypeKind::BuiltIn),
             Type::S64 => self.output.ty("s64", TypeKind::BuiltIn),
-            Type::F32 => {
-                if self.print_f32_f64 {
-                    self.output.ty("f32", TypeKind::BuiltIn)
-                } else {
-                    self.output.ty("f32", TypeKind::BuiltIn)
-                }
-            }
-            Type::F64 => {
-                if self.print_f32_f64 {
-                    self.output.ty("f64", TypeKind::BuiltIn)
-                } else {
-                    self.output.ty("f64", TypeKind::BuiltIn)
-                }
-            }
+            Type::F32 => self.output.ty("f32", TypeKind::BuiltIn),
+            Type::F64 => self.output.ty("f64", TypeKind::BuiltIn),
             Type::Char => self.output.ty("char", TypeKind::BuiltIn),
             Type::String => self.output.ty("string", TypeKind::BuiltIn),
             Type::ErrorContext => self.output.ty("error-context", TypeKind::BuiltIn),

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1693,7 +1693,6 @@ fn eat_id(tokens: &mut Tokenizer<'_>, expected: &str) -> Result<Span> {
 pub struct SourceMap {
     sources: Vec<Source>,
     offset: u32,
-    require_f32_f64: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -1707,11 +1706,6 @@ impl SourceMap {
     /// Creates a new empty source map.
     pub fn new() -> SourceMap {
         SourceMap::default()
-    }
-
-    #[doc(hidden)] // NB: only here for a transitionary period
-    pub fn set_require_f32_f64(&mut self, enable: bool) {
-        self.require_f32_f64 = Some(enable);
     }
 
     /// Reads the file `path` on the filesystem and appends its contents to this
@@ -1778,7 +1772,6 @@ impl SourceMap {
                     // passing through the source to get tokenized.
                     &src.contents[..src.contents.len() - 1],
                     src.offset,
-                    self.require_f32_f64,
                 )
                 .with_context(|| format!("failed to tokenize path: {}", src.path))?;
                 let mut file = PackageFile::parse(&mut tokens)?;
@@ -1965,7 +1958,7 @@ pub enum ParsedUsePath {
 }
 
 pub fn parse_use_path(s: &str) -> Result<ParsedUsePath> {
-    let mut tokens = Tokenizer::new(s, 0, None)?;
+    let mut tokens = Tokenizer::new(s, 0)?;
     let path = UsePath::parse(&mut tokens)?;
     if tokens.next()?.is_some() {
         bail!("trailing tokens in path specifier");


### PR DESCRIPTION
This was transitioned long ago at this point, so no need to keep around the old compat code.