### PR TITLE
validator/operators.rs: refine some handling of control stack + comments

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2094,8 +2094,10 @@ where
     fn visit_end(&mut self) -> Self::Output {
         let mut frame = self.pop_ctrl()?;
 
-        // Note that this `if` isn't included in the appendix right
-        // now, but it's used to allow for `if` statements that are
+        // Note that this `if` isn't included in the appendix;
+        // the `if ... end` abbreviation for `if ... else [] end`
+        // is part of the binary and text formats.
+        // This is used to allow for `if` statements that are
         // missing an `else` block which have the same parameter/return
         // types on the block (since that's valid).
         if frame.kind == FrameKind::If {


### PR DESCRIPTION
This PR consolidates some of the validator's manipulation of the control stack into the push_ctrl/push_bare_ctrl functions, so that individual operator validator functions no longer need to directly manipulate the control stack. (It also fixes a confusing comment.)

This is preparation for an "atomic" validator feature to come in a subsequent PR (https://github.com/keithw/wasm-tools/tree/atomic). This would provide the ability to validate an operator atomically, i.e. the validator state is unchanged if the operator is invalid.