### PR TITLE
wasm-mutate-stats: release worklist mutex before file I/O

### DIFF
--- a/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
+++ b/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
@@ -453,18 +453,24 @@ impl State {
             let mut counter = 0;
 
             while !finish_writing_wrap_clone.load(Relaxed) {
-                // pop from worklist
-                if let Some(wasm) = to_write_clone.lock().unwrap().pop() {
+                // Pop from the worklist while holding the mutex for as short a window
+                // as possible — the previous form `if let Some(_) = to_write_clone.lock()
+                // .unwrap().pop()` keeps the temporary MutexGuard alive for the entire
+                // body of the `if let`, blocking the producers (and shutdown) on every
+                // file write.
+                let wasm = to_write_clone.lock().unwrap().pop();
+                if let Some(wasm) = wasm {
                     let filename = artifact_folder_cp.join(format!("mutated.{counter}.wasm"));
                     std::fs::write(filename, &wasm).context("Failed to write mutated wasm")?;
                     counter += 1;
                 }
             }
             eprintln!("Writing down pending mutated binaries!");
-            // Then write pending wasms
-            while let Some(wasm) = to_write_clone.lock().unwrap().pop() {
+            // Then write pending wasms — same lock-narrowing as above.
+            loop {
+                let wasm = to_write_clone.lock().unwrap().pop();
+                let Some(wasm) = wasm else { break };
                 let filename = artifact_folder_cp.join(format!("mutated.{counter}.wasm"));
-
                 std::fs::write(filename, &wasm).context("Failed to write mutated wasm")?;
                 counter += 1;
             }


### PR DESCRIPTION
Closes #2490.

The writer thread in `crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs` popped from the worklist with the lock held for the entire body of the `if let` / `while let`:

```rust
if let Some(wasm) = to_write_clone.lock().unwrap().pop() {
    std::fs::write(filename, &wasm).context("Failed to write mutated wasm")?;
    counter += 1;
}
```

The temporary `MutexGuard` produced by `.lock()` lives for the whole scrutinee, so the queue mutex stayed held across every `std::fs::write` call. Producers and the shutdown signal blocked on each file write, hurting throughput and increasing shutdown latency.

Hoist the `.pop()` into its own statement so the guard is dropped before the I/O, and match on the resulting `Option` in a separate scope. Same fix for both the steady-state `while !finish_writing_wrap_clone.load(...)` loop and the post-shutdown drain loop.

`cargo check -p wasm-mutate-stats` clean against current `main`.