### PR TITLE
Fix merge imports based on semver

### DIFF
--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -2559,6 +2559,11 @@ package {name} is defined in two different locations:\n\
             assert!(prev.is_none());
         }
 
+        // The type-reference replacements above may have changed interface
+        // dependency edges, so re-sort interfaces topologically before
+        // elaborating worlds.
+        self.topologically_sort_interfaces(None);
+
         // Run through `elaborate_world` to reorder imports as appropriate and
         // fill anything back in if it's actually required by exports. For now
         // this doesn't tamper with exports at all. Also note that this is


### PR DESCRIPTION
#2451 introduced `topologically_sort_interfaces` and correctly calls it at the end of `Resolve::merge_packages` after modifying interface dependencies. However, `merge_world_imports_based_on_semver` was not updated with the same fix.

`merge_world_imports_based_on_semver` calls `update_interface_dep_of_type` to rewire type aliases from older semver-compatible interfaces to their newer replacements. This changes the dependency edges in the interface graph: an interface `A` that previously pointed to `B_old` (positioned before `A` in the arena) may now point to `B_new` (positioned after `A`). This violates the topological ordering invariant that `assert_topologically_sorted` checks.

The `merge` path already handled this by calling `self.topologically_sort_interfaces(...)` after modifying type references, but the semver deduplication path was missed.