### PR TITLE
Add more snapshots for feature gate paths and fix a panic on @since include

### DIFF
--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -3840,8 +3840,7 @@ impl Remap {
                 .include_stability(&include.stability, pkg_id, include.span)
                 .with_context(|| {
                     format!(
-                        "failed to process feature gate for included world [{}] in package [{}]",
-                        resolve.worlds[include.id].name.as_str(),
+                        "failed to process feature gate for an included world in package [{}]",
                         resolve.packages[*pkg_id].name
                     )
                 })?

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -3839,8 +3839,12 @@ impl Remap {
             if !resolve
                 .include_stability(&include.stability, pkg_id, include.span)
                 .with_context(|| {
+                    let world_name = match self.worlds[include.id.index()] {
+                        Some(resolved_id) => resolve.worlds[resolved_id].name.as_str(),
+                        None => "<unknown>",
+                    };
                     format!(
-                        "failed to process feature gate for an included world in package [{}]",
+                        "failed to process feature gate for included world [{world_name}] in package [{}]",
                         resolve.packages[*pkg_id].name
                     )
                 })?

--- a/crates/wit-parser/tests/ui/parse-fail/bad-gate-record-field.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-gate-record-field.wit
@@ -1,0 +1,12 @@
+package a:b;
+
+interface foo {
+  @unstable(feature = inactive)
+  type gated = u32;
+
+  record r {
+    field-a: u32,
+    field-b: gated,
+    field-c: string,
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-gate-record-field.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-gate-record-field.wit.result
@@ -1,0 +1,5 @@
+failed to update field `field-b`: found a reference to a type which is excluded due to its feature not being activated
+     --> tests/ui/parse-fail/bad-gate-record-field.wit:7:10
+      |
+    7 |   record r {
+      |          ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit
@@ -1,0 +1,8 @@
+package test:invalid@0.1.0;
+
+world a {}
+
+world b {
+  @since(version = 0.2.0)
+  include a;
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit.result
@@ -1,4 +1,4 @@
-failed to process feature gate for an included world in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+failed to process feature gate for included world [a] in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
      --> tests/ui/parse-fail/bad-since-on-include.wit:7:11
       |
     7 |   include a;

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-include.wit.result
@@ -1,0 +1,5 @@
+failed to process feature gate for an included world in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+     --> tests/ui/parse-fail/bad-since-on-include.wit:7:11
+      |
+    7 |   include a;
+      |           ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-interface.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-interface.wit
@@ -1,0 +1,4 @@
+package test:invalid@0.1.0;
+
+@since(version = 0.2.0)
+interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-interface.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-interface.wit.result
@@ -1,0 +1,5 @@
+failed to process feature gate for interface [foo] in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+     --> tests/ui/parse-fail/bad-since-on-interface.wit:4:11
+      |
+    4 | interface foo {}
+      |           ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-type.wit
@@ -1,0 +1,6 @@
+package test:invalid@0.1.0;
+
+interface foo {
+  @since(version = 0.2.0)
+  type t = u32;
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-type.wit.result
@@ -1,0 +1,5 @@
+failed to process feature gate for type [t] in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+     --> tests/ui/parse-fail/bad-since-on-type.wit:5:8
+      |
+    5 |   type t = u32;
+      |        ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world-import.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world-import.wit
@@ -1,0 +1,6 @@
+package test:invalid@0.1.0;
+
+world w {
+  @since(version = 0.2.0)
+  import x: func();
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world-import.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world-import.wit.result
@@ -1,0 +1,5 @@
+failed to process world item in `w`: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+     --> tests/ui/parse-fail/bad-since-on-world-import.wit:5:10
+      |
+    5 |   import x: func();
+      |          ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world.wit
@@ -1,0 +1,4 @@
+package test:invalid@0.1.0;
+
+@since(version = 0.2.0)
+world w {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since-on-world.wit.result
@@ -1,0 +1,5 @@
+failed to process feature gate for world [w] in package [test:invalid@0.1.0]: feature gate cannot reference unreleased version 0.2.0 of package [test:invalid@0.1.0] (current version 0.1.0)
+     --> tests/ui/parse-fail/bad-since-on-world.wit:4:7
+      |
+    4 | world w {}
+      |       ^


### PR DESCRIPTION
Adding a couple of snapshots that will be useful for making sure that the error messages don't regress in https://github.com/bytecodealliance/wasm-tools/pull/2482

In the process I discovered a panic in the new `bad-since-on-include.wit` test (coming from `process_world_includes`). We were reading from `resolve.worlds[include.id].name.as_str()` but `include.id` is an index from the unresolved package's arena, not the `Resolve`'s arena. This code path wasn't being hit before in any tests.