### PR TITLE
Use the 2024 edition for rustfmt in this workspace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,7 @@ jobs:
     # Note that this doesn't use `cargo fmt` because that doesn't format
     # modules-defined-in-macros which is in use in `wast` for example. This is
     # the best alternative I can come up with at this time
-    - run: find . -name '*.rs' | xargs rustfmt --check --edition 2021
+    - run: find . -name '*.rs' | xargs rustfmt --check --edition 2024
 
   fuzz:
     name: Fuzz

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,1 @@
-# This project isn't yet using the 2024 edition due to its MSRV requirement but
-# we're going ahead and opting into the 2024 style edition ahead of updating the
-# Rust edition itself.
-style_edition = '2024'
-edition = '2021'
+edition = '2024'


### PR DESCRIPTION
Possible now that MSRV is high enough