### PR TITLE
fix: duplicated words in wasm-mutate and wasm-smith comments

### DIFF
--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -50,7 +50,7 @@ use wasmparser::Operator;
 /// A mutation that can be applied to a Wasm module to produce a new, mutated
 /// Wasm module.
 pub trait Mutator {
-    /// Can this `Mutator` *probably* be applied to the the given Wasm and
+    /// Can this `Mutator` *probably* be applied to the given Wasm and
     /// configuration?
     ///
     /// When checking Wasm applicability, these checks should be implemented as

--- a/crates/wasm-smith/src/core/code_builder/no_traps.rs
+++ b/crates/wasm-smith/src/core/code_builder/no_traps.rs
@@ -457,7 +457,7 @@ fn min_input_const_for_trunc<'a>(inst: &Instruction) -> Instruction<'a> {
     let min_f64 = -9_223_372_036_854_775_000f64;
     let min_f32 = -9_223_372_000_000_000_000f32;
 
-    // This is the minimum float value that is representable as as i32
+    // This is the minimum float value that is representable as i32
     let min_f32_as_i32 = -2_147_483_500f32;
     match inst {
         Instruction::I32TruncF32S => Instruction::F32Const(min_f32_as_i32.into()),


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in source comments:
- `crates/wasm-mutate/src/mutators.rs` — `/// Can this \`Mutator\` *probably* be applied to the the given Wasm and` → `... to the given Wasm and`
- `crates/wasm-smith/src/core/code_builder/no_traps.rs` — `// This is the minimum float value that is representable as as i32` → `... representable as i32`

No code/behavior change.