### PR TITLE
Simplify serde for wit-encoder func

### DIFF
--- a/crates/wit-encoder/src/function.rs
+++ b/crates/wit-encoder/src/function.rs
@@ -74,6 +74,8 @@ pub struct StandaloneFunc {
     pub(crate) params: Params,
     pub(crate) result: Option<Type>,
     pub(crate) docs: Option<Docs>,
+    #[serde(default)]
+    #[serde(rename = "async")]
     pub(crate) async_: bool,
 }
 


### PR DESCRIPTION
Simplify serde for wit-encoder func:
- Use `async` rather than `async-`.
- Default to false if not specified.


