### PR TITLE
Support components with custom page sizes

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -4481,7 +4481,7 @@ impl ComponentState {
             maximum: None,
             memory64: ty.memory64,
             shared: false,
-            page_size_log2: None,
+            page_size_log2: ty.page_size_log2,
         };
         if ty.memory64 && !self.features.cm64() {
             bail!(

--- a/tests/cli/component-model/custom-page-sizes.wast
+++ b/tests/cli/component-model/custom-page-sizes.wast
@@ -10,22 +10,17 @@
   (core func (canon lower (func $f) (memory $i "m")))
 )
 
-;; currently the component model requires all memories are a subtype of
-;; `(memory 0)`, AKA no compat with custom page sizes. This has not yet been
-;; relaxed at the spec level.
-(assert_invalid
-  (component
+;; compat with custom page sizes.
+(component
     (import "f" (func $f (param "x" string)))
     (core module $m
       (memory (export "m") 1 (pagesize 1))
     )
     (core instance $i (instantiate $m))
     (core func (canon lower (func $f) (memory $i "m")))
-  )
-  "mismatch in page size for memories"
 )
 
-;; subtyping works with custom-page-sizes
+;; subtyping works with explict page sizes
 (component
   (core module $a (memory (export "m") 1 (pagesize 65536)))
   (core module $b (import "a" "m" (memory 1 (pagesize 65536))))
@@ -41,12 +36,20 @@
 )
 
 (component
+  (core module $a (memory (export "m") 1 (pagesize 1)))
+  (core module $b (import "a" "m" (memory 1 (pagesize 1))))
+  (core instance $a (instantiate $a))
+  (core instance $b (instantiate $b (with "a" (instance $a))))
+)
+
+(component
   (core module $a (memory (export "m") 1))
   (core module $b (import "a" "m" (memory 1 (pagesize 65536))))
   (core instance $a (instantiate $a))
   (core instance $b (instantiate $b (with "a" (instance $a))))
 )
 
+;; subtyping requires consistent page sizes
 (assert_invalid
   (component
     (core module $a (memory (export "m") 1 (pagesize 1)))

--- a/tests/cli/component-model/options.wast
+++ b/tests/cli/component-model/options.wast
@@ -44,16 +44,6 @@
 (assert_invalid
   (component
     (core module $m
-      (memory (export "m") 0 (pagesize 1))
-      (func (export "f"))
-    )
-    (core instance $i (instantiate $m))
-    (func (canon lift (core func $i "f") (memory $i "m")))
-  )
-  "mismatch in page size for memories")
-(assert_invalid
-  (component
-    (core module $m
       (memory (export "m") 0 1 shared)
       (func (export "f"))
     )

--- a/tests/snapshots/cli/component-model/custom-page-sizes.wast.json
+++ b/tests/snapshots/cli/component-model/custom-page-sizes.wast.json
@@ -8,55 +8,60 @@
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
-      "line": 17,
+      "type": "module",
+      "line": 14,
       "filename": "custom-page-sizes.1.wasm",
-      "module_type": "binary",
-      "text": "mismatch in page size for memories"
+      "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 29,
+      "line": 24,
       "filename": "custom-page-sizes.2.wasm",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 36,
+      "line": 31,
       "filename": "custom-page-sizes.3.wasm",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 43,
+      "line": 38,
       "filename": "custom-page-sizes.4.wasm",
       "module_type": "binary"
     },
     {
-      "type": "assert_invalid",
-      "line": 51,
+      "type": "module",
+      "line": 45,
       "filename": "custom-page-sizes.5.wasm",
-      "module_type": "binary",
-      "text": "mismatch in page size for memories"
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 60,
+      "line": 54,
       "filename": "custom-page-sizes.6.wasm",
       "module_type": "binary",
       "text": "mismatch in page size for memories"
     },
     {
       "type": "assert_invalid",
-      "line": 69,
+      "line": 63,
       "filename": "custom-page-sizes.7.wasm",
       "module_type": "binary",
       "text": "mismatch in page size for memories"
     },
     {
       "type": "assert_invalid",
-      "line": 78,
+      "line": 72,
       "filename": "custom-page-sizes.8.wasm",
+      "module_type": "binary",
+      "text": "mismatch in page size for memories"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 81,
+      "filename": "custom-page-sizes.9.wasm",
       "module_type": "binary",
       "text": "mismatch in page size for memories"
     }

--- a/tests/snapshots/cli/component-model/custom-page-sizes.wast/1.print
+++ b/tests/snapshots/cli/component-model/custom-page-sizes.wast/1.print
@@ -1,0 +1,11 @@
+(component
+  (type (;0;) (func (param "x" string)))
+  (import "f" (func $f (;0;) (type 0)))
+  (core module $m (;0;)
+    (memory (;0;) 1 (pagesize 0x1))
+    (export "m" (memory 0))
+  )
+  (core instance $i (;0;) (instantiate $m))
+  (alias core export $i "m" (core memory (;0;)))
+  (core func (;0;) (canon lower (func $f) (memory 0)))
+)

--- a/tests/snapshots/cli/component-model/custom-page-sizes.wast/5.print
+++ b/tests/snapshots/cli/component-model/custom-page-sizes.wast/5.print
@@ -1,10 +1,10 @@
 (component
   (core module $a (;0;)
-    (memory (;0;) 1 (pagesize 0x1))
+    (memory (;0;) 1)
     (export "m" (memory 0))
   )
   (core module $b (;1;)
-    (import "a" "m" (memory (;0;) 1 (pagesize 0x1)))
+    (import "a" "m" (memory (;0;) 1 (pagesize 0x10000)))
   )
   (core instance $a (;0;) (instantiate $a))
   (core instance $b (;1;) (instantiate $b

--- a/tests/snapshots/cli/component-model/options.wast.json
+++ b/tests/snapshots/cli/component-model/options.wast.json
@@ -26,19 +26,12 @@
       "line": 45,
       "filename": "options.3.wasm",
       "module_type": "binary",
-      "text": "mismatch in page size for memories"
+      "text": "mismatch in the shared flag for memories"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "options.4.wasm",
-      "module_type": "binary",
-      "text": "mismatch in the shared flag for memories"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 65,
-      "filename": "options.5.wasm",
       "module_type": "binary",
       "text": "64-bit memories require the `cm64` feature to be enabled"
     }


### PR DESCRIPTION
This PR partly reverts #2477 by allowing again but now in an explicit manner components whose inner modules have linear memories with custom page sizes.

cc @alexcrichton

See this [Zulip Topic](https://bytecodealliance.zulipchat.com/#narrow/channel/511605-wasm-tools/topic/Making.20component.20from.20modules.20with.20pagesize.200x1) for additional context. 