### PR TITLE
wit-parser: don't panic on a re-exported imported resource

### DIFF
--- a/crates/wit-parser/src/decoding.rs
+++ b/crates/wit-parser/src/decoding.rs
@@ -1090,8 +1090,17 @@ impl WitPackageDecoder<'_> {
             assert!(prev.is_none());
         }
 
+        // A duplicate mapping here comes from a valid component that WIT cannot
+        // represent (for example an imported resource re-exported under a new
+        // name), not an internal invariant, so report it instead of asserting.
         let prev = self.type_map.insert(created, ty);
-        assert!(prev.is_none());
+        if prev.is_some() {
+            bail!(
+                "cannot represent this component in WIT: the type `{name}` appears \
+                 more than once (for example, when an imported instance is \
+                 re-exported under a new name)"
+            );
+        }
         Ok(ty)
     }
 

--- a/tests/cli/component-wit-imported-resource-no-reexport.wat
+++ b/tests/cli/component-wit-imported-resource-no-reexport.wat
@@ -1,0 +1,6 @@
+;; RUN: component wit %
+
+(component
+    (type (;0;) (instance (export "request" (type (sub resource)))))
+    (import "impl:test/handler" (instance (;0;) (type 0)))
+)

--- a/tests/cli/component-wit-imported-resource-no-reexport.wat.stdout
+++ b/tests/cli/component-wit-imported-resource-no-reexport.wat.stdout
@@ -1,0 +1,10 @@
+package root:component;
+
+world root {
+  import impl:test/handler;
+}
+package impl:test {
+  interface handler {
+    resource request;
+  }
+}

--- a/tests/cli/component-wit-reexport-imported-resource.wat
+++ b/tests/cli/component-wit-reexport-imported-resource.wat
@@ -1,0 +1,7 @@
+;; FAIL: component wit %
+
+(component
+    (type (;0;) (instance (export "request" (type (sub resource)))))
+    (import "impl:test/handler" (instance (;0;) (type 0)))
+    (export "wasi:http/handler@0.3.0" (instance 0))
+)

--- a/tests/cli/component-wit-reexport-imported-resource.wat.stderr
+++ b/tests/cli/component-wit-reexport-imported-resource.wat.stderr
@@ -1,0 +1,4 @@
+error: failed to decode WIT from export `wasi:http/handler@0.3.0`
+
+Caused by:
+    0: cannot represent this component in WIT: the type `request` appears more than once (for example, when an imported instance is re-exported under a new name)


### PR DESCRIPTION
`validate` accepts a component that imports a resource-bearing instance and re-exports it under a new name, but `component wit` panicked on an `assert!` while decoding it. WIT can't represent a re-exported imported resource. Return a structured error instead of panicking, and add a cli test for the panic plus one for the same import without the re-export, which still decodes.

Closes #2506
