### PR TITLE
wasm-wave: catch error in UntypedFuncCall::to_wasm_params

### DIFF
--- a/crates/wasm-wave/src/untyped.rs
+++ b/crates/wasm-wave/src/untyped.rs
@@ -2,7 +2,12 @@
 
 use alloc::{borrow::Cow, vec::Vec};
 
-use crate::{Parser, WasmValue, ast::Node, lex::Keyword, parser::ParserError};
+use crate::{
+    Parser, WasmValue,
+    ast::Node,
+    lex::Keyword,
+    parser::{ParserError, ParserErrorKind},
+};
 
 /// An UntypedValue is a parsed but not type-checked WAVE value.
 #[derive(Clone, Debug)]
@@ -121,11 +126,21 @@ impl<'source> UntypedFuncCall<'source> {
     /// be returned as `none` values.
     pub fn to_wasm_params<'types, V: WasmValue + 'static>(
         &self,
-        types: impl IntoIterator<Item = &'types V::Type>,
+        types: impl IntoIterator<Item = &'types V::Type, IntoIter: ExactSizeIterator>,
     ) -> Result<Vec<V>, ParserError> {
         match &self.params {
             Some(params) => params.to_wasm_params(types, self.source()),
-            None => Ok(Vec::new()),
+            None => {
+                let num_params = types.into_iter().len();
+                if num_params > 0 {
+                    return Err(ParserError::with_detail(
+                        ParserErrorKind::InvalidParams,
+                        self.name.span(),
+                        alloc::format!("no params provided, but {num_params} required"),
+                    ));
+                }
+                Ok(Vec::new())
+            }
         }
     }
 }

--- a/crates/wasm-wave/tests/ui/reject-strings.out
+++ b/crates/wasm-wave/tests/ui/reject-strings.out
@@ -30,3 +30,5 @@ unexpected token: LabelOrKeyword at 25..30
 // Multiline invalid escapes
 invalid character escape at 30..31
 invalid character escape at 27..28
+// Missing argument
+invalid params: no params provided, but 1 required at 0..6

--- a/crates/wasm-wave/tests/ui/reject-strings.waves
+++ b/crates/wasm-wave/tests/ui/reject-strings.waves
@@ -44,3 +44,5 @@ Invalid surrogate: \u{d800}
 string("""
 Invalid escape: \j
 """);
+// Missing argument
+string();


### PR DESCRIPTION
There was a bug in `wasm_wave::UntypedFuncCall::to_wasm_params`: when to_wasm_params was called on a function which was parsed with no arguments, the length of the types is never checked to compare it to the arguments.

This change required the iterator accepted by that function to be an ExactSizeIterator so that the length may be checked, and catches the case where an empty list of parameters is applied to a non-empty list of types.