### PR TITLE
wit-parser: add ItemName type and parser

### DIFF
--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1988,7 +1988,10 @@ pub fn parse_use_path(s: &str) -> anyhow::Result<ParsedUsePath> {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 #[cfg_attr(feature = "serde", serde(into = "String", try_from = "String"))]
 pub struct ItemName {
     pub package: Option<crate::PackageName>,
@@ -2055,14 +2058,21 @@ impl core::convert::TryFrom<String> for ItemName {
 }
 impl fmt::Display for ItemName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(crate::PackageName { namespace, name, .. }) = &self.package {
+        if let Some(crate::PackageName {
+            namespace, name, ..
+        }) = &self.package
+        {
             write!(f, "{namespace}:{name}/")?;
         }
         if let Some(int) = &self.interface {
             write!(f, "{int}.")?;
         }
         write!(f, "{}", self.name)?;
-        if let Some(crate::PackageName { version: Some(version), .. }) = &self.package {
+        if let Some(crate::PackageName {
+            version: Some(version),
+            ..
+        }) = &self.package
+        {
             write!(f, "@{version}")?;
         }
         Ok(())
@@ -2098,9 +2108,7 @@ mod item_name_test {
         );
         assert_round_trip("bare-kebab-name");
         // Invalid to have a version without a package name
-        assert!(
-            "bare-kebab-name@0.1.0".parse::<ItemName>().is_err()
-        );
+        assert!("bare-kebab-name@0.1.0".parse::<ItemName>().is_err());
     }
     #[test]
     fn in_interface() {
@@ -2114,9 +2122,7 @@ mod item_name_test {
         );
         assert_round_trip("foo.bar");
         // Invalid to have a version without a package name
-        assert!(
-            "foo.bar@0.1.0".parse::<ItemName>().is_err()
-        );
+        assert!("foo.bar@0.1.0".parse::<ItemName>().is_err());
     }
     #[test]
     fn in_package() {

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1986,3 +1986,190 @@ pub fn parse_use_path(s: &str) -> anyhow::Result<ParsedUsePath> {
         }
     })
 }
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+#[cfg_attr(feature = "serde", serde(into = "String", try_from = "String"))]
+pub struct ItemName {
+    pub package: Option<crate::PackageName>,
+    pub interface: Option<String>,
+    pub name: String,
+}
+impl core::str::FromStr for ItemName {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> anyhow::Result<ItemName> {
+        let mut tokens = Tokenizer::new(s, 0)?;
+
+        let id = parse_id(&mut tokens)?;
+        let (package, name) = if tokens.eat(Token::Colon)? {
+            let name = parse_id(&mut tokens)?;
+            tokens.expect(Token::Slash)?;
+            (Some((id, name)), parse_id(&mut tokens)?)
+        } else {
+            (None, id)
+        };
+        let interface;
+        let name = if tokens.eat(Token::Period)? {
+            interface = Some(name.name.to_string());
+            parse_id(&mut tokens)?
+        } else {
+            interface = None;
+            name
+        };
+
+        let package = package
+            .map(|(namespace, name)| -> anyhow::Result<crate::PackageName> {
+                let version = parse_opt_version(&mut tokens)?;
+                Ok(PackageName {
+                    docs: Docs::default(),
+                    span: Span::new(
+                        namespace.span.start(),
+                        version
+                            .as_ref()
+                            .map(|(s, _)| s.end())
+                            .unwrap_or(name.span.end()),
+                    ),
+                    namespace,
+                    name,
+                    version,
+                }
+                .package_name())
+            })
+            .transpose()?;
+
+        if tokens.next()?.is_some() {
+            anyhow::bail!("trailing tokens in item name specifier");
+        }
+        Ok(ItemName {
+            package,
+            interface,
+            name: name.name.to_string(),
+        })
+    }
+}
+impl core::convert::TryFrom<String> for ItemName {
+    type Error = anyhow::Error;
+    fn try_from(s: String) -> anyhow::Result<ItemName> {
+        s.parse()
+    }
+}
+impl fmt::Display for ItemName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(crate::PackageName { namespace, name, .. }) = &self.package {
+            write!(f, "{namespace}:{name}/")?;
+        }
+        if let Some(int) = &self.interface {
+            write!(f, "{int}.")?;
+        }
+        write!(f, "{}", self.name)?;
+        if let Some(crate::PackageName { version: Some(version), .. }) = &self.package {
+            write!(f, "@{version}")?;
+        }
+        Ok(())
+    }
+}
+impl From<ItemName> for String {
+    fn from(m: ItemName) -> String {
+        m.to_string()
+    }
+}
+
+#[cfg(test)]
+mod item_name_test {
+    use super::{ItemName, Version};
+    use crate::PackageName;
+    use alloc::borrow::ToOwned;
+
+    fn assert_round_trip(s: &str) {
+        use alloc::string::ToString;
+        let i = s.parse::<ItemName>().unwrap();
+        assert_eq!(i.to_string(), s);
+    }
+
+    #[test]
+    fn bare() {
+        assert_eq!(
+            "bare-kebab-name".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: None,
+                interface: None,
+                name: "bare-kebab-name".to_owned()
+            }
+        );
+        assert_round_trip("bare-kebab-name");
+        // Invalid to have a version without a package name
+        assert!(
+            "bare-kebab-name@0.1.0".parse::<ItemName>().is_err()
+        );
+    }
+    #[test]
+    fn in_interface() {
+        assert_eq!(
+            "foo.bar".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: None,
+                interface: Some("foo".to_owned()),
+                name: "bar".to_owned()
+            }
+        );
+        assert_round_trip("foo.bar");
+        // Invalid to have a version without a package name
+        assert!(
+            "foo.bar@0.1.0".parse::<ItemName>().is_err()
+        );
+    }
+    #[test]
+    fn in_package() {
+        assert_eq!(
+            "foo:bar/baz.bat".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: None
+                }),
+                interface: Some("baz".to_owned()),
+                name: "bat".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz.bat");
+        assert_eq!(
+            "foo:bar/baz.bat@0.1.0".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: Some(Version::parse("0.1.0").unwrap()),
+                }),
+                interface: Some("baz".to_owned()),
+                name: "bat".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz.bat@0.1.0");
+        assert_eq!(
+            "foo:bar/baz".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: None
+                }),
+                interface: None,
+                name: "baz".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz@0.1.0");
+        assert_eq!(
+            "foo:bar/baz@0.1.0".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: Some(Version::parse("0.1.0").unwrap()),
+                }),
+                interface: None,
+                name: "baz".to_owned()
+            }
+        );
+    }
+}

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -44,9 +44,9 @@ pub use metadata::PackageMetadata;
 
 pub mod abi;
 mod ast;
-pub use ast::{SourceMap, ItemName};
 pub use ast::error::*;
 pub use ast::lex::Span;
+pub use ast::{ItemName, SourceMap};
 pub use ast::{ParsedUsePath, parse_use_path};
 mod sizealign;
 pub use sizealign::*;

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -44,7 +44,7 @@ pub use metadata::PackageMetadata;
 
 pub mod abi;
 mod ast;
-pub use ast::SourceMap;
+pub use ast::{SourceMap, ItemName};
 pub use ast::error::*;
 pub use ast::lex::Span;
 pub use ast::{ParsedUsePath, parse_use_path};


### PR DESCRIPTION
This adds a new type and parser to the wit-parser crate for `ItemName`.

The intent is to define a single place where an optionally-qualified path to an item's name is parsed. At its core an item name is:
```
pub struct ItemName {
    pub package: Option<crate::PackageName>,
    pub interface: Option<String>,
    pub name: String,
}
```
and the only nontrivial details is that, if the package is provided and that package has a version, the version is the suffix of the entire item name, e.g. `namespace:packagename/interface.funcname@0.1.0`.

This PR does not add any integration of this type to the `Resolve` struct. That is left for a future PR.

My goal in adding this type without yet integrating it with `Resolve` is to use this type in other crates that already depend on wit-parser:
1. in #2530 this parser is useful in extracting structured information from a wave function call
1. in Wasmtime, this type could impl the https://docs.rs/wasmtime/latest/wasmtime/component/trait.InstanceExportLookup.html trait, so that e.g. the export `wasi:cli/run.run` can be looked up without chaining API calls to perform a lookup of wasi:cli/run -> run.
1. and, together, those two mechanisms leaning on this common type can solve the problem in `wasmtime run --invoke` where, if there happen to be more than one function exported across all interfaces named `run`, its impossible to disambiguate, https://github.com/bytecodealliance/wasmtime/blob/main/src/commands/run.rs#L799-L808