### PR TITLE
wasm-wave: parse wit ItemNames as UntypedFuncCall names

### DIFF
--- a/crates/wasm-wave/Cargo.toml
+++ b/crates/wasm-wave/Cargo.toml
@@ -17,12 +17,13 @@ workspace = true
 [features]
 default = ["std", "wit"]
 std = []
-wit = ["dep:wit-parser", "std"]
+wit = ["dep:wit-parser", "dep:anyhow", "std"]
 
 [dependencies]
 logos = { version = "0.14.2", default-features = false, features = ["export_derive", "forbid_unsafe"] }
 thiserror = { workspace = true }
 wit-parser = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/wasm-wave/src/lex.rs
+++ b/crates/wasm-wave/src/lex.rs
@@ -154,4 +154,3 @@ pub enum FuncNameToken {
     #[regex(r"((?&package_label)\/)?(?&label)(\.(?&label))?(\@(?&semver))?")]
     FunctionName,
 }
-

--- a/crates/wasm-wave/src/lex.rs
+++ b/crates/wasm-wave/src/lex.rs
@@ -136,3 +136,22 @@ impl Display for Keyword {
         })
     }
 }
+
+/// A lexer for function names. Different token type from WAVE values, because
+/// this is not part of the same context-free grammar.
+pub type FuncNameLexer<'source> = logos::Lexer<'source, FuncNameToken>;
+/// A function name token
+#[derive(Clone, Copy, Debug, PartialEq, Eq, logos::Logos)]
+#[logos(error = Option<logos::Span>)]
+#[logos(subpattern first_label_word = r"[a-z][a-z0-9]*|[A-Z][A-Z0-9]*")]
+#[logos(subpattern label_word = r"[a-z0-9]+|[A-Z0-9]+")]
+#[logos(subpattern label = r"(?&first_label_word)(\-(?&label_word))*")]
+#[logos(subpattern package_label = r"(?&label)\:(?&label)")]
+#[logos(subpattern semver = r"(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))")]
+pub enum FuncNameToken {
+    /// A function inside an optional interface, with an optional package qualifier and
+    /// package version suffix
+    #[regex(r"((?&package_label)\/)?(?&label)(\.(?&label))?(\@(?&semver))?")]
+    FunctionName,
+}
+

--- a/crates/wasm-wave/src/parser.rs
+++ b/crates/wasm-wave/src/parser.rs
@@ -13,7 +13,7 @@ use alloc::{
 use crate::{
     WasmValue,
     ast::{Node, NodeType},
-    lex::{Keyword, Lexer, Span, Token},
+    lex::{FuncNameLexer, FuncNameToken, Keyword, Lexer, Span, Token},
     untyped::{UntypedFuncCall, UntypedValue},
 };
 
@@ -48,23 +48,6 @@ impl<'source> Parser<'source> {
     pub fn parse_raw_value(&mut self) -> Result<UntypedValue<'source>, ParserError> {
         let node = self.parse_node()?;
         Ok(UntypedValue::new(self.lex.source(), node))
-    }
-
-    /// Parses a function name followed by a WAVE-encoded, parenthesized,
-    /// comma-separated sequence of values into an [`UntypedFuncCall`].
-    pub fn parse_raw_func_call(&mut self) -> Result<UntypedFuncCall<'source>, ParserError> {
-        self.advance()?;
-        let name = self.parse_label()?;
-        self.advance()?;
-        self.expect_token(Token::ParenOpen)?;
-
-        let params = if self.next_is(Token::ParenClose) {
-            self.advance()?;
-            None
-        } else {
-            Some(self.parse_tuple()?)
-        };
-        Ok(UntypedFuncCall::new(self.lex.source(), name, params))
     }
 
     /// Returns an error if any significant input remains unparsed.
@@ -415,6 +398,55 @@ impl Error for ParserError {
     }
 }
 
+/// Parses a function name followed by a WAVE-encoded, parenthesized,
+/// comma-separated sequence of values into an [`UntypedFuncCall`].
+pub fn parse_raw_func_call<'source>(
+    source: &'source str,
+) -> Result<UntypedFuncCall<'source>, ParserError> {
+    let mut name_parser = FuncNameParser::with_lexer(FuncNameLexer::new(source));
+    let _func_name = name_parser.advance()?;
+    let name = name_parser.lex.span();
+
+    let mut params_parser = Parser::with_lexer(name_parser.lex.morph());
+    params_parser.advance()?;
+    params_parser.expect_token(Token::ParenOpen)?;
+
+    let params = if params_parser.next_is(Token::ParenClose) {
+        params_parser.advance()?;
+        None
+    } else {
+        Some(params_parser.parse_tuple()?)
+    };
+    params_parser.finish()?;
+    Ok(UntypedFuncCall::new(source, name, params))
+}
+
+struct FuncNameParser<'source> {
+    lex: FuncNameLexer<'source>,
+    curr: Option<FuncNameToken>,
+}
+impl<'source> FuncNameParser<'source> {
+    fn with_lexer(lex: FuncNameLexer<'source>) -> Self {
+        Self { lex, curr: None }
+    }
+    fn advance(&mut self) -> Result<FuncNameToken, ParserError> {
+        let token = match self.lex.next() {
+            Some(Ok(token)) => token,
+            Some(Err(span)) => {
+                let span = span.unwrap_or_else(|| self.lex.span());
+                return Err(ParserError::new(ParserErrorKind::InvalidToken, span));
+            }
+            None => {
+                return Err(ParserError::new(
+                    ParserErrorKind::UnexpectedEnd,
+                    self.lex.span(),
+                ));
+            }
+        };
+        self.curr = Some(token);
+        Ok(token)
+    }
+}
 /// The kind of a WAVE parsing error.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]

--- a/crates/wasm-wave/src/untyped.rs
+++ b/crates/wasm-wave/src/untyped.rs
@@ -134,7 +134,7 @@ impl<'source> UntypedFuncCall<'source> {
                 if num_params > 0 {
                     return Err(ParserError::with_detail(
                         ParserErrorKind::InvalidParams,
-                        self.name.span(),
+                        self.name.clone(),
                         alloc::format!("no params provided, but {num_params} required"),
                     ));
                 }

--- a/crates/wasm-wave/src/untyped.rs
+++ b/crates/wasm-wave/src/untyped.rs
@@ -64,14 +64,14 @@ impl core::fmt::Display for UntypedValue<'_> {
 /// WAVE function calls have the form `<name>(<params...>)`.
 pub struct UntypedFuncCall<'source> {
     source: Cow<'source, str>,
-    name: Node,
+    name: logos::Span,
     params: Option<Node>,
 }
 
 impl<'source> UntypedFuncCall<'source> {
     pub(crate) fn new(
         source: impl Into<Cow<'source, str>>,
-        name: Node,
+        name: logos::Span,
         params: Option<Node>,
     ) -> Self {
         Self {
@@ -83,10 +83,7 @@ impl<'source> UntypedFuncCall<'source> {
 
     /// Parses an untyped function call from WAVE.
     pub fn parse(source: &'source str) -> Result<Self, ParserError> {
-        let mut parser = Parser::new(source);
-        let call = parser.parse_raw_func_call()?;
-        parser.finish()?;
-        Ok(call)
+        crate::parser::parse_raw_func_call(source)
     }
 
     /// Creates an owned function call, copying the entire source string if necessary.
@@ -103,11 +100,6 @@ impl<'source> UntypedFuncCall<'source> {
         &self.source
     }
 
-    /// Returns the function name node.
-    pub fn name_node(&self) -> &Node {
-        &self.name
-    }
-
     /// Returns the function parameters node.
     ///
     /// Returns `None` if the function call has no parameters.
@@ -117,7 +109,14 @@ impl<'source> UntypedFuncCall<'source> {
 
     /// Returns the function name.
     pub fn name(&self) -> &str {
-        self.name.slice(&self.source)
+        &self.source[self.name.clone()]
+    }
+
+    /// Returns the function name, as parsed by wit-parser.
+    #[cfg(feature = "wit")]
+    pub fn item_name(&self) -> Result<wit_parser::ItemName, anyhow::Error> {
+        use core::str::FromStr;
+        wit_parser::ItemName::from_str(self.name())
     }
 
     /// Converts the untyped parameters into the given types.
@@ -147,7 +146,7 @@ impl<'source> UntypedFuncCall<'source> {
 
 impl core::fmt::Display for UntypedFuncCall<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(self.name.slice(&self.source))?;
+        f.write_str(&self.source[self.name.clone()])?;
         match &self.params {
             Some(params) => fmt_node(f, params, &self.source),
             None => f.write_str("()"),

--- a/crates/wasm-wave/tests/ui.rs
+++ b/crates/wasm-wave/tests/ui.rs
@@ -32,9 +32,8 @@ fn test(path: &Path) -> Result<String> {
         ) -> Result<(String, &'static FuncType, Vec<Value>), anyhow::Error> {
             let untyped_call = UntypedFuncCall::parse(input)?;
             let func_name = untyped_call.name().to_string();
-            let func_type = get_func_type(&func_name).ok_or_else(|| {
-                anyhow::anyhow!("unknown test func {func_name:?}")
-            })?;
+            let func_type = get_func_type(&func_name)
+                .ok_or_else(|| anyhow::anyhow!("unknown test func {func_name:?}"))?;
             let param_types = func_type.params().collect::<Vec<_>>();
             let values = untyped_call.to_wasm_params::<Value>(&param_types)?;
             Ok((func_name, func_type, values))
@@ -84,19 +83,22 @@ fn get_func_type(func_name: &str) -> Option<&'static FuncType> {
                     let func_type = resolve_wit_func_type(&resolve, func).unwrap();
                     let mut entries = vec![(func_name.clone(), func_type.clone())];
                     if let Some(interface_name) = &interface.name {
-                        entries.push((
-                            format!("{interface_name}.{func_name}"),
-                            func_type.clone(),
-                        ));
+                        entries.push((format!("{interface_name}.{func_name}"), func_type.clone()));
                         if let Some(package_id) = &interface.package {
                             let package_name = &resolve.packages[*package_id].name;
                             entries.push((
-                                format!("{}:{}/{interface_name}.{func_name}", package_name.namespace, package_name.name),
+                                format!(
+                                    "{}:{}/{interface_name}.{func_name}",
+                                    package_name.namespace, package_name.name
+                                ),
                                 func_type.clone(),
                             ));
                             if let Some(version) = &package_name.version {
                                 entries.push((
-                                    format!("{}:{}/{interface_name}.{func_name}@{version}", package_name.namespace, package_name.name),
+                                    format!(
+                                        "{}:{}/{interface_name}.{func_name}@{version}",
+                                        package_name.namespace, package_name.name
+                                    ),
                                     func_type.clone(),
                                 ));
                             }

--- a/crates/wasm-wave/tests/ui.rs
+++ b/crates/wasm-wave/tests/ui.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result};
 use std::{collections::HashMap, fmt::Write, fs, path::Path, sync::OnceLock};
 
 use wasm_wave::{
-    parser::ParserError,
     untyped::UntypedFuncCall,
     value::{FuncType, Value, resolve_wit_func_type},
     wasm::{DisplayValue, WasmFunc},
@@ -30,12 +29,12 @@ fn test(path: &Path) -> Result<String> {
 
         fn parse_func_call(
             input: &str,
-        ) -> Result<(String, &'static FuncType, Vec<Value>), ParserError> {
+        ) -> Result<(String, &'static FuncType, Vec<Value>), anyhow::Error> {
             let untyped_call = UntypedFuncCall::parse(input)?;
             let func_name = untyped_call.name().to_string();
-            let func_type = get_func_type(&func_name).unwrap_or_else(|| {
-                panic!("unknown test func {func_name:?}");
-            });
+            let func_type = get_func_type(&func_name).ok_or_else(|| {
+                anyhow::anyhow!("unknown test func {func_name:?}")
+            })?;
             let param_types = func_type.params().collect::<Vec<_>>();
             let values = untyped_call.to_wasm_params::<Value>(&param_types)?;
             Ok((func_name, func_type, values))
@@ -45,7 +44,7 @@ fn test(path: &Path) -> Result<String> {
             Ok((func_name, func_type, values)) => {
                 assert!(
                     !filename.starts_with("reject-"),
-                    "accepted input {input:?} in {filename}"
+                    "accepted input {input:?} in {filename}: {func_name} {func_type} {values:?}"
                 );
                 write!(out, "{func_name}(")?;
                 let mut first = true;
@@ -80,8 +79,32 @@ fn get_func_type(func_name: &str) -> Option<&'static FuncType> {
             resolve
                 .interfaces
                 .iter()
-                .flat_map(|(_, i)| &i.functions)
-                .map(|(name, func)| (name.clone(), resolve_wit_func_type(&resolve, func).unwrap()))
+                .flat_map(|(_, i)| i.functions.iter().map(move |(name, func)| (i, name, func)))
+                .flat_map(|(interface, func_name, func)| {
+                    let func_type = resolve_wit_func_type(&resolve, func).unwrap();
+                    let mut entries = vec![(func_name.clone(), func_type.clone())];
+                    if let Some(interface_name) = &interface.name {
+                        entries.push((
+                            format!("{interface_name}.{func_name}"),
+                            func_type.clone(),
+                        ));
+                        if let Some(package_id) = &interface.package {
+                            let package_name = &resolve.packages[*package_id].name;
+                            entries.push((
+                                format!("{}:{}/{interface_name}.{func_name}", package_name.namespace, package_name.name),
+                                func_type.clone(),
+                            ));
+                            if let Some(version) = &package_name.version {
+                                entries.push((
+                                    format!("{}:{}/{interface_name}.{func_name}@{version}", package_name.namespace, package_name.name),
+                                    func_type.clone(),
+                                ));
+                            }
+                        }
+                    }
+
+                    entries
+                })
                 .collect::<HashMap<_, _>>()
         })
         .get(func_name)

--- a/crates/wasm-wave/tests/ui/accept-funcs.out
+++ b/crates/wasm-wave/tests/ui/accept-funcs.out
@@ -1,0 +1,5 @@
+nullary()
+string(val: "")
+ui.string(val: "")
+ui:tests/ui.nullary()
+ui:tests/ui.string@0.1.0(val: "")

--- a/crates/wasm-wave/tests/ui/accept-funcs.waves
+++ b/crates/wasm-wave/tests/ui/accept-funcs.waves
@@ -1,0 +1,5 @@
+nullary();
+string("");
+ui.string("");
+ui:tests/ui.nullary();
+ui:tests/ui.string@0.1.0("");

--- a/crates/wasm-wave/tests/ui/reject-funcs.out
+++ b/crates/wasm-wave/tests/ui/reject-funcs.out
@@ -1,0 +1,11 @@
+// Reject wrong type
+invalid params: no params provided, but 1 required at 0..6
+invalid params: more param(s) than expected at 8..10
+invalid params: more param(s) than expected at 11..13
+// Reject wrong interface
+unknown test func "wrong.nullary"
+// Reject wrong package
+unknown test func "ui:another/ui.nullary"
+unknown test func "other:tests/ui.nullary"
+// Reject wrong version
+unknown test func "ui:tests/ui.string@0.0.0"

--- a/crates/wasm-wave/tests/ui/reject-funcs.waves
+++ b/crates/wasm-wave/tests/ui/reject-funcs.waves
@@ -1,0 +1,11 @@
+// Reject wrong type
+string();
+nullary("");
+ui.nullary("");
+// Reject wrong interface
+wrong.nullary();
+// Reject wrong package
+ui:another/ui.nullary();
+other:tests/ui.nullary();
+// Reject wrong version
+ui:tests/ui.string@0.0.0("");

--- a/crates/wasm-wave/tests/ui/ui.wit
+++ b/crates/wasm-wave/tests/ui/ui.wit
@@ -1,4 +1,4 @@
-package ui:tests;
+package ui:tests@0.1.0;
 
 interface ui {
     nullary: func();

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1988,7 +1988,10 @@ pub fn parse_use_path(s: &str) -> anyhow::Result<ParsedUsePath> {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 #[cfg_attr(feature = "serde", serde(into = "String", try_from = "String"))]
 pub struct ItemName {
     pub package: Option<crate::PackageName>,
@@ -2055,14 +2058,21 @@ impl core::convert::TryFrom<String> for ItemName {
 }
 impl fmt::Display for ItemName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(crate::PackageName { namespace, name, .. }) = &self.package {
+        if let Some(crate::PackageName {
+            namespace, name, ..
+        }) = &self.package
+        {
             write!(f, "{namespace}:{name}/")?;
         }
         if let Some(int) = &self.interface {
             write!(f, "{int}.")?;
         }
         write!(f, "{}", self.name)?;
-        if let Some(crate::PackageName { version: Some(version), .. }) = &self.package {
+        if let Some(crate::PackageName {
+            version: Some(version),
+            ..
+        }) = &self.package
+        {
             write!(f, "@{version}")?;
         }
         Ok(())
@@ -2098,9 +2108,7 @@ mod item_name_test {
         );
         assert_round_trip("bare-kebab-name");
         // Invalid to have a version without a package name
-        assert!(
-            "bare-kebab-name@0.1.0".parse::<ItemName>().is_err()
-        );
+        assert!("bare-kebab-name@0.1.0".parse::<ItemName>().is_err());
     }
     #[test]
     fn in_interface() {
@@ -2114,9 +2122,7 @@ mod item_name_test {
         );
         assert_round_trip("foo.bar");
         // Invalid to have a version without a package name
-        assert!(
-            "foo.bar@0.1.0".parse::<ItemName>().is_err()
-        );
+        assert!("foo.bar@0.1.0".parse::<ItemName>().is_err());
     }
     #[test]
     fn in_package() {

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1986,3 +1986,190 @@ pub fn parse_use_path(s: &str) -> anyhow::Result<ParsedUsePath> {
         }
     })
 }
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+#[cfg_attr(feature = "serde", serde(into = "String", try_from = "String"))]
+pub struct ItemName {
+    pub package: Option<crate::PackageName>,
+    pub interface: Option<String>,
+    pub name: String,
+}
+impl core::str::FromStr for ItemName {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> anyhow::Result<ItemName> {
+        let mut tokens = Tokenizer::new(s, 0)?;
+
+        let id = parse_id(&mut tokens)?;
+        let (package, name) = if tokens.eat(Token::Colon)? {
+            let name = parse_id(&mut tokens)?;
+            tokens.expect(Token::Slash)?;
+            (Some((id, name)), parse_id(&mut tokens)?)
+        } else {
+            (None, id)
+        };
+        let interface;
+        let name = if tokens.eat(Token::Period)? {
+            interface = Some(name.name.to_string());
+            parse_id(&mut tokens)?
+        } else {
+            interface = None;
+            name
+        };
+
+        let package = package
+            .map(|(namespace, name)| -> anyhow::Result<crate::PackageName> {
+                let version = parse_opt_version(&mut tokens)?;
+                Ok(PackageName {
+                    docs: Docs::default(),
+                    span: Span::new(
+                        namespace.span.start(),
+                        version
+                            .as_ref()
+                            .map(|(s, _)| s.end())
+                            .unwrap_or(name.span.end()),
+                    ),
+                    namespace,
+                    name,
+                    version,
+                }
+                .package_name())
+            })
+            .transpose()?;
+
+        if tokens.next()?.is_some() {
+            anyhow::bail!("trailing tokens in item name specifier");
+        }
+        Ok(ItemName {
+            package,
+            interface,
+            name: name.name.to_string(),
+        })
+    }
+}
+impl core::convert::TryFrom<String> for ItemName {
+    type Error = anyhow::Error;
+    fn try_from(s: String) -> anyhow::Result<ItemName> {
+        s.parse()
+    }
+}
+impl fmt::Display for ItemName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(crate::PackageName { namespace, name, .. }) = &self.package {
+            write!(f, "{namespace}:{name}/")?;
+        }
+        if let Some(int) = &self.interface {
+            write!(f, "{int}.")?;
+        }
+        write!(f, "{}", self.name)?;
+        if let Some(crate::PackageName { version: Some(version), .. }) = &self.package {
+            write!(f, "@{version}")?;
+        }
+        Ok(())
+    }
+}
+impl From<ItemName> for String {
+    fn from(m: ItemName) -> String {
+        m.to_string()
+    }
+}
+
+#[cfg(test)]
+mod item_name_test {
+    use super::{ItemName, Version};
+    use crate::PackageName;
+    use alloc::borrow::ToOwned;
+
+    fn assert_round_trip(s: &str) {
+        use alloc::string::ToString;
+        let i = s.parse::<ItemName>().unwrap();
+        assert_eq!(i.to_string(), s);
+    }
+
+    #[test]
+    fn bare() {
+        assert_eq!(
+            "bare-kebab-name".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: None,
+                interface: None,
+                name: "bare-kebab-name".to_owned()
+            }
+        );
+        assert_round_trip("bare-kebab-name");
+        // Invalid to have a version without a package name
+        assert!(
+            "bare-kebab-name@0.1.0".parse::<ItemName>().is_err()
+        );
+    }
+    #[test]
+    fn in_interface() {
+        assert_eq!(
+            "foo.bar".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: None,
+                interface: Some("foo".to_owned()),
+                name: "bar".to_owned()
+            }
+        );
+        assert_round_trip("foo.bar");
+        // Invalid to have a version without a package name
+        assert!(
+            "foo.bar@0.1.0".parse::<ItemName>().is_err()
+        );
+    }
+    #[test]
+    fn in_package() {
+        assert_eq!(
+            "foo:bar/baz.bat".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: None
+                }),
+                interface: Some("baz".to_owned()),
+                name: "bat".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz.bat");
+        assert_eq!(
+            "foo:bar/baz.bat@0.1.0".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: Some(Version::parse("0.1.0").unwrap()),
+                }),
+                interface: Some("baz".to_owned()),
+                name: "bat".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz.bat@0.1.0");
+        assert_eq!(
+            "foo:bar/baz".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: None
+                }),
+                interface: None,
+                name: "baz".to_owned()
+            }
+        );
+        assert_round_trip("foo:bar/baz@0.1.0");
+        assert_eq!(
+            "foo:bar/baz@0.1.0".parse::<ItemName>().unwrap(),
+            ItemName {
+                package: Some(PackageName {
+                    namespace: "foo".to_owned(),
+                    name: "bar".to_owned(),
+                    version: Some(Version::parse("0.1.0").unwrap()),
+                }),
+                interface: None,
+                name: "baz".to_owned()
+            }
+        );
+    }
+}

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -44,9 +44,9 @@ pub use metadata::PackageMetadata;
 
 pub mod abi;
 mod ast;
-pub use ast::{SourceMap, ItemName};
 pub use ast::error::*;
 pub use ast::lex::Span;
+pub use ast::{ItemName, SourceMap};
 pub use ast::{ParsedUsePath, parse_use_path};
 mod sizealign;
 pub use sizealign::*;

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -44,7 +44,7 @@ pub use metadata::PackageMetadata;
 
 pub mod abi;
 mod ast;
-pub use ast::SourceMap;
+pub use ast::{SourceMap, ItemName};
 pub use ast::error::*;
 pub use ast::lex::Span;
 pub use ast::{ParsedUsePath, parse_use_path};


### PR DESCRIPTION
Based on #2529 

Prior to this PR, wasm-wave defined a complete grammar for values, and additionally it provided a `UntypedFuncCall::parse` parser, which extends the grammar to include function calls. `UntypedFuncCall` was not described in the ebnf grammar, but instead is just tacked on as a special entrypoint to the Parser [`Parser::parse_raw_func_call`](https://docs.rs/wasm-wave/latest/wasm_wave/parser/struct.Parser.html#method.parse_raw_func_call). In short, the implementation was "a label, followed by parenthesis, which are empty or contain a tuple value".

The parenthesis and values are unambigiously the right choice for the syntax, but representing the function name as a single label is limiting: functions can exist anonymously (in no package, and in no interface), at the root of a package (in a package but not in an interface), or inside a package's interface. The parser gave us no way to parse or represent these cases, and it led to problems in implementations where a bare label might be ambigious, for example in the implementation of [`wasmtime run --invoke`](https://github.com/bytecodealliance/wasmtime/blob/d40cdc2ca3a522eccd0f4e9477daa66691cdc959/src/commands/run.rs#L799-L808), which is the use case that led us to move wasm-wave into wasm-tools and take a dependency on wasmtime in the first case.

So, drawing on the work to define a parser in wit-parser for `ItemName` (which accepts strings like `namespace:packagename/interface.funcname@0.1.0`), which is capable of representing all of the above cases unambiguously, this PR reworks the `UntypedFuncCall` parser to be able to parse those cases as well.

The new parser is no longer a special entrypoint for `Parser` but instead a standalone function `parse_raw_func_call` in the same module. It re-uses the `Parser` machinery for parsing all wave values, but for the parsing the function name portion of the parse, it actually uses a totally separate `logos::Lexer` that accepts an `ItemName`-shaped string using a single regex. This approach was required because adding an `ItemName`-shaped token to the lexer conflicts with the parser which already accept a sequence of label, colon, label productions in several real cases, e.g. the record `{a:none}` would get rejected at the `}` for expecting a token `/` since the lexer would try to consume it as a package namespace and name.

Because wit-parser is an optional dependency on wasm-wave, finally parsing the `UntypedFuncCall`'s name into a `ItemName` is done with an accessor method instead of in the parsing stage. Users who don't want to depend on wasm-wave can still consume the parsed function name as a `&str`, but don't get any help parsing it into a structure, in order to prevent duplicated code and the possibility of a confused deputy. (The alternative to this is making use of the entire `untyped` mod always depend on `wit-parser`, which seemed like it was too heavyweight for this particular case.)