### PR TITLE
Converge to unicode-ident and remove unicode-xid dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,9 +2025,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3307,7 +3307,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
+ "unicode-ident",
  "wasmparser 0.251.0",
  "wat",
  "wit-parser 0.251.0",

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -26,7 +26,7 @@ semver = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-unicode-xid = "0.2.2"
+unicode-ident = "1.0.24"
 wasmparser = { workspace = true, optional = true, features = ['std', 'validate', 'component-model', 'features'] }
 wat = { workspace = true, optional = true, features = ['component-model'] }
 

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -4,7 +4,6 @@ use core::char;
 use core::fmt;
 use core::result::Result;
 use core::str;
-use unicode_xid::UnicodeXID;
 
 use self::Token::*;
 
@@ -504,12 +503,12 @@ fn detect_invalid_input(input: &str) -> Result<(), Error> {
 fn is_keylike_start(ch: char) -> bool {
     // Lex any XID start, `_`, or '-'. These aren't all valid identifier chars,
     // but we'll diagnose that after we've lexed the full string.
-    UnicodeXID::is_xid_start(ch) || ch == '_' || ch == '-'
+    unicode_ident::is_xid_start(ch) || ch == '_' || ch == '-'
 }
 
 fn is_keylike_continue(ch: char) -> bool {
     // Lex any XID continue (which includes `_`) or '-'.
-    UnicodeXID::is_xid_continue(ch) || ch == '-'
+    unicode_ident::is_xid_continue(ch) || ch == '-'
 }
 
 pub fn validate_id(start: u32, id: &str) -> Result<(), Error> {


### PR DESCRIPTION
Hello,

`unicode-xid` and `unicode-ident` do the exact same thing and they are both in the dependency tree.
`unicode-xid` is imported directly while `unicode-ident` is brought in by `serde`.

Converge over the more performant `unicode-ident`.
Ideally this will slightly reduce binary size and slightly reduce compile time.

This PR does not introduce any functional change.

Thanks!