### PR TITLE
Limit the element count of fixed-length lists

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -72,6 +72,9 @@ mod component_limits {
     pub const MAX_WASM_RECORD_FIELDS: usize = 10_000;
     pub const MAX_WASM_VARIANT_CASES: usize = 10_000;
     pub const MAX_WASM_TUPLE_TYPES: usize = 10_000;
+    /// Fixed-length lists don't contribute their length to the component
+    /// type-size budget, so the element count gets a separate limit of 1 Gi.
+    pub const MAX_WASM_FIXED_LENGTH_LIST_ELEMENTS: usize = 1_073_741_824;
     pub const MAX_WASM_FLAG_NAMES: usize = 1_000;
     pub const MAX_WASM_ENUM_CASES: usize = 10_000;
     pub const MAX_WASM_INSTANTIATION_EXPORTS: usize = 100_000;

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -4069,6 +4069,13 @@ impl ComponentState {
                         "Fixed-length lists must have more than zero elements"
                     )
                 }
+                check_max(
+                    0,
+                    elements,
+                    MAX_WASM_FIXED_LENGTH_LIST_ELEMENTS,
+                    "fixed-length list element",
+                    offset,
+                )?;
                 Ok(ComponentDefinedType::FixedLengthList(
                     self.create_component_val_type(ty, offset)?,
                     elements,

--- a/tests/cli/component-model/fixed-length-lists.wast
+++ b/tests/cli/component-model/fixed-length-lists.wast
@@ -38,6 +38,21 @@
   "Fixed-length lists must have more than zero elements (at offset 0x54)"
 )
 
+(assert_invalid
+  (component
+    (core module $m
+      (memory (export "memory") 1)
+      (func (export "ret-list") (result i32) unreachable)
+    )
+    (core instance $i (instantiate $m))
+
+    (func (export "ret-list") (result (list u32 4294967295))
+      (canon lift (core func $i "ret-list") (memory $i "memory"))
+    )
+  )
+  "fixed-length list element count exceeds limit of 1073741824 (at offset 0x54)"
+)
+
 (assert_malformed
   (component quote
     "(core module $m"

--- a/tests/snapshots/cli/component-model/fixed-length-lists.wast.json
+++ b/tests/snapshots/cli/component-model/fixed-length-lists.wast.json
@@ -21,23 +21,30 @@
       "text": "Fixed-length lists must have more than zero elements (at offset 0x54)"
     },
     {
-      "type": "assert_malformed",
+      "type": "assert_invalid",
       "line": 42,
-      "filename": "fixed-length-lists.3.wat",
+      "filename": "fixed-length-lists.3.wasm",
+      "module_type": "binary",
+      "text": "fixed-length list element count exceeds limit of 1073741824 (at offset 0x54)"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 57,
+      "filename": "fixed-length-lists.4.wat",
       "module_type": "text",
       "text": "invalid u32 number: constant out of range"
     },
     {
       "type": "assert_invalid",
-      "line": 57,
-      "filename": "fixed-length-lists.4.wasm",
+      "line": 72,
+      "filename": "fixed-length-lists.5.wasm",
       "module_type": "binary",
       "text": "type mismatch for import `x`"
     },
     {
       "type": "assert_invalid",
-      "line": 70,
-      "filename": "fixed-length-lists.5.wasm",
+      "line": 85,
+      "filename": "fixed-length-lists.6.wasm",
       "module_type": "binary",
       "text": "type mismatch for import `x`"
     }


### PR DESCRIPTION
Fixed-length lists were only checked for zero elements, with no upper bound, so a list of up to 4294967295 elements passed validation. The count then flows to consumers and overflows their canonical ABI size calculations. Cap the element count at 1 Gi, the limit suggested on the issue.

Closes #2416.
