### PR TITLE
Enable the `CM_ASYNC` feature by default

### DIFF
--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -253,7 +253,7 @@ define_wasm_features! {
         ///
         /// Corresponds to the 🔀 character in
         /// <https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md>.
-        pub cm_async: CM_ASYNC(1 << 27) = false;
+        pub cm_async: CM_ASYNC(1 << 27) = true;
         /// Gates the "stackful ABI" in the component model async proposal.
         ///
         /// Corresponds to the 🚟 character in


### PR DESCRIPTION
Coupled with today's WASI 0.3.0 vote this ungates the `cm-async` feature by default in wasmparser which enables validating async-using components by default, for example.