### PR TITLE
wasmparser: Rename BinaryReaderError to Error

### DIFF
--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -592,13 +592,13 @@ pub enum Error<E = Infallible> {
     /// A core type definition was found in a component that's not supported.
     UnsupportedCoreTypeInComponent,
     /// There was an error when parsing.
-    ParseError(wasmparser::BinaryReaderError),
+    ParseError(wasmparser::Error),
     /// There was a user-defined error when re-encoding.
     UserError(E),
 }
 
-impl<E> From<wasmparser::BinaryReaderError> for Error<E> {
-    fn from(err: wasmparser::BinaryReaderError) -> Self {
+impl<E> From<wasmparser::Error> for Error<E> {
+    fn from(err: wasmparser::Error) -> Self {
         Self::ParseError(err)
     }
 }
@@ -1726,7 +1726,7 @@ pub mod utils {
             (map $arg:ident targets) => ((
                 $arg
                     .targets()
-                    .collect::<Result<Vec<_>, wasmparser::BinaryReaderError>>()?
+                    .collect::<Result<Vec<_>, wasmparser::Error>>()?
                     .into(),
                 $arg.default(),
             ));

--- a/crates/wasm-mutate/src/error.rs
+++ b/crates/wasm-mutate/src/error.rs
@@ -12,7 +12,7 @@ impl Error {
     }
 
     /// Construct a new parse error.
-    pub fn parse(err: wasmparser::BinaryReaderError) -> Self {
+    pub fn parse(err: wasmparser::Error) -> Self {
         err.into()
     }
 
@@ -50,8 +50,8 @@ impl From<ErrorKind> for Error {
     }
 }
 
-impl From<wasmparser::BinaryReaderError> for Error {
-    fn from(e: wasmparser::BinaryReaderError) -> Self {
+impl From<wasmparser::Error> for Error {
+    fn from(e: wasmparser::Error) -> Self {
         ErrorKind::Parse(e).into()
     }
 }
@@ -80,7 +80,7 @@ impl From<std::convert::Infallible> for Error {
 pub enum ErrorKind {
     /// Failed to parse the input Wasm module.
     #[error("Failed to parse the input Wasm module.")]
-    Parse(#[from] wasmparser::BinaryReaderError),
+    Parse(#[from] wasmparser::Error),
 
     /// None of the available mutators are applicable to the input Wasm module
     #[error("There are not applicable mutations for the input Wasm module.")]

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -15,109 +15,11 @@
 
 use crate::prelude::*;
 use crate::{limits::*, *};
-use core::fmt;
 use core::marker;
 use core::ops::Range;
 use core::str;
 
 pub(crate) const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
-
-/// A binary reader for WebAssembly modules.
-#[derive(Debug, Clone)]
-pub struct BinaryReaderError {
-    // Wrap the actual error data in a `Box` so that the error is just one
-    // word. This means that we can continue returning small `Result`s in
-    // registers.
-    pub(crate) inner: Box<BinaryReaderErrorInner>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct BinaryReaderErrorInner {
-    pub(crate) message: String,
-    pub(crate) kind: BinaryReaderErrorKind,
-    pub(crate) offset: usize,
-    pub(crate) needed_hint: Option<usize>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum BinaryReaderErrorKind {
-    Custom,
-    Invalid,
-}
-
-/// The result for `BinaryReader` operations.
-pub type Result<T, E = BinaryReaderError> = core::result::Result<T, E>;
-
-impl core::error::Error for BinaryReaderError {}
-
-impl fmt::Display for BinaryReaderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{} (at offset 0x{:x})",
-            self.inner.message, self.inner.offset
-        )
-    }
-}
-
-impl BinaryReaderError {
-    #[cold]
-    pub(crate) fn _new(kind: BinaryReaderErrorKind, message: String, offset: usize) -> Self {
-        BinaryReaderError {
-            inner: Box::new(BinaryReaderErrorInner {
-                kind,
-                message,
-                offset,
-                needed_hint: None,
-            }),
-        }
-    }
-
-    #[cold]
-    pub(crate) fn new(message: impl Into<String>, offset: usize) -> Self {
-        Self::_new(BinaryReaderErrorKind::Custom, message.into(), offset)
-    }
-
-    #[cold]
-    pub(crate) fn invalid(msg: &'static str, offset: usize) -> Self {
-        Self::_new(BinaryReaderErrorKind::Invalid, msg.into(), offset)
-    }
-
-    #[cold]
-    pub(crate) fn fmt(args: fmt::Arguments<'_>, offset: usize) -> Self {
-        BinaryReaderError::new(args.to_string(), offset)
-    }
-
-    #[cold]
-    pub(crate) fn eof(offset: usize, needed_hint: usize) -> Self {
-        let mut err = BinaryReaderError::new("unexpected end-of-file", offset);
-        err.inner.needed_hint = Some(needed_hint);
-        err
-    }
-
-    pub(crate) fn kind(&mut self) -> BinaryReaderErrorKind {
-        self.inner.kind
-    }
-
-    /// Get this error's message.
-    pub fn message(&self) -> &str {
-        &self.inner.message
-    }
-
-    /// Get the offset within the Wasm binary where the error occurred.
-    pub fn offset(&self) -> usize {
-        self.inner.offset
-    }
-
-    #[cfg(all(feature = "validate", feature = "component-model"))]
-    pub(crate) fn add_context(&mut self, context: String) {
-        self.inner.message = format!("{context}\n{}", self.inner.message);
-    }
-
-    pub(crate) fn set_message(&mut self, message: &str) {
-        self.inner.message = message.to_string();
-    }
-}
 
 /// A binary reader of the WebAssembly structures and types.
 #[derive(Clone, Debug, Hash)]
@@ -262,7 +164,7 @@ impl<'a> BinaryReader<'a> {
         if self.position < self.buffer.len() {
             Ok(())
         } else {
-            Err(BinaryReaderError::eof(self.original_position(), 1))
+            Err(Error::eof(self.original_position(), 1))
         }
     }
 
@@ -271,7 +173,7 @@ impl<'a> BinaryReader<'a> {
             Ok(())
         } else {
             let hint = self.position + len - self.buffer.len();
-            Err(BinaryReaderError::eof(self.original_position(), hint))
+            Err(Error::eof(self.original_position(), hint))
         }
     }
 
@@ -288,7 +190,7 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_u7(&mut self) -> Result<u8> {
         let b = self.read_u8()?;
         if (b & 0x80) != 0 {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "invalid u7",
                 self.original_position() - 1,
             ));
@@ -426,8 +328,8 @@ impl<'a> BinaryReader<'a> {
     }
 
     #[cold]
-    fn eof_err(&self) -> BinaryReaderError {
-        BinaryReaderError::eof(self.original_position(), 1)
+    fn eof_err(&self) -> Error {
+        Error::eof(self.original_position(), 1)
     }
 
     /// Advances the `BinaryReader` up to four bytes to parse a variable
@@ -461,7 +363,7 @@ impl<'a> BinaryReader<'a> {
                     "invalid var_u32: integer too large"
                 };
                 // The continuation bit or unused bits are set.
-                return Err(BinaryReaderError::new(msg, self.original_position() - 1));
+                return Err(Error::new(msg, self.original_position() - 1));
             }
             shift += 7;
             if (byte & 0x80) == 0 {
@@ -502,7 +404,7 @@ impl<'a> BinaryReader<'a> {
                     "invalid var_u64: integer too large"
                 };
                 // The continuation bit or unused bits are set.
-                return Err(BinaryReaderError::new(msg, self.original_position() - 1));
+                return Err(Error::new(msg, self.original_position() - 1));
             }
             shift += 7;
             if (byte & 0x80) == 0 {
@@ -533,7 +435,7 @@ impl<'a> BinaryReader<'a> {
     pub fn skip_string(&mut self) -> Result<()> {
         let len = self.read_var_u32()? as usize;
         if len > MAX_WASM_STRING_SIZE {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "string size out of bounds",
                 self.original_position() - 1,
             ));
@@ -574,7 +476,7 @@ impl<'a> BinaryReader<'a> {
                     } else {
                         "invalid var_i32: integer too large"
                     };
-                    return Err(BinaryReaderError::new(msg, self.original_position() - 1));
+                    return Err(Error::new(msg, self.original_position() - 1));
                 }
                 return Ok(result);
             }
@@ -608,7 +510,7 @@ impl<'a> BinaryReader<'a> {
                 let continuation_bit = (byte & 0x80) != 0;
                 let sign_and_unused_bit = (byte << 1) as i8 >> (33 - shift);
                 if continuation_bit || (sign_and_unused_bit != 0 && sign_and_unused_bit != -1) {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "invalid var_s33: integer representation too long",
                         self.original_position() - 1,
                     ));
@@ -644,7 +546,7 @@ impl<'a> BinaryReader<'a> {
                     } else {
                         "invalid var_i64: integer too large"
                     };
-                    return Err(BinaryReaderError::new(msg, self.original_position() - 1));
+                    return Err(Error::new(msg, self.original_position() - 1));
                 }
                 return Ok(result);
             }
@@ -679,7 +581,7 @@ impl<'a> BinaryReader<'a> {
     fn internal_read_string(&mut self, len: usize) -> Result<&'a str> {
         let bytes = self.read_bytes(len)?;
         str::from_utf8(bytes).map_err(|_| {
-            BinaryReaderError::new("malformed UTF-8 encoding", self.original_position() - 1)
+            Error::new("malformed UTF-8 encoding", self.original_position() - 1)
         })
     }
 
@@ -693,7 +595,7 @@ impl<'a> BinaryReader<'a> {
     pub fn read_string(&mut self) -> Result<&'a str> {
         let len = self.read_var_u32()? as usize;
         if len > MAX_WASM_STRING_SIZE {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "string size out of bounds",
                 self.original_position() - 1,
             ));
@@ -724,7 +626,7 @@ impl<'a> BinaryReader<'a> {
         byte: u8,
         desc: &str,
         offset: usize,
-    ) -> BinaryReaderError {
+    ) -> Error {
         format_err!(offset, "invalid leading byte (0x{byte:x}) for {desc}")
     }
 
@@ -770,7 +672,7 @@ impl<'a> BinaryReader<'a> {
         match u32::try_from(idx) {
             Ok(idx) => Ok(BlockType::FuncType(idx)),
             Err(_) => {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "invalid function type",
                     self.original_position(),
                 ));
@@ -787,7 +689,7 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_header_version(&mut self) -> Result<u32> {
         let magic_number = self.read_bytes(4)?;
         if magic_number != WASM_MAGIC_NUMBER {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 format!(
                     "magic header not detected: bad magic number - expected={WASM_MAGIC_NUMBER:#x?} actual={magic_number:#x?}"
                 ),
@@ -2020,7 +1922,7 @@ impl<'a> BinaryReader<'a> {
         };
         let max_flag_bits = if self.multi_memory() { 6 } else { 5 };
         if flags >= (1 << max_flag_bits) {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "malformed memop alignment: alignment too large",
                 flags_pos,
             ));
@@ -2044,7 +1946,7 @@ impl<'a> BinaryReader<'a> {
         match byte {
             0 => Ok(Ordering::SeqCst),
             1 => Ok(Ordering::AcqRel),
-            x => Err(BinaryReaderError::new(
+            x => Err(Error::new(
                 &format!("invalid atomic consistency ordering {x}"),
                 self.original_position() - 1,
             )),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -190,10 +190,7 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_u7(&mut self) -> Result<u8> {
         let b = self.read_u8()?;
         if (b & 0x80) != 0 {
-            return Err(Error::new(
-                "invalid u7",
-                self.original_position() - 1,
-            ));
+            return Err(Error::new("invalid u7", self.original_position() - 1));
         }
         Ok(b)
     }
@@ -580,9 +577,8 @@ impl<'a> BinaryReader<'a> {
     /// (internal) Reads a fixed-size WebAssembly string from the module.
     fn internal_read_string(&mut self, len: usize) -> Result<&'a str> {
         let bytes = self.read_bytes(len)?;
-        str::from_utf8(bytes).map_err(|_| {
-            Error::new("malformed UTF-8 encoding", self.original_position() - 1)
-        })
+        str::from_utf8(bytes)
+            .map_err(|_| Error::new("malformed UTF-8 encoding", self.original_position() - 1))
     }
 
     /// Reads a WebAssembly string from the module.
@@ -622,11 +618,7 @@ impl<'a> BinaryReader<'a> {
         ))
     }
 
-    pub(crate) fn invalid_leading_byte_error(
-        byte: u8,
-        desc: &str,
-        offset: usize,
-    ) -> Error {
+    pub(crate) fn invalid_leading_byte_error(byte: u8, desc: &str, offset: usize) -> Error {
         format_err!(offset, "invalid leading byte (0x{byte:x}) for {desc}")
     }
 

--- a/crates/wasmparser/src/error.rs
+++ b/crates/wasmparser/src/error.rs
@@ -1,0 +1,100 @@
+use core::fmt;
+
+use crate::prelude::*;
+
+/// A binary reader for WebAssembly modules.
+#[derive(Debug, Clone)]
+pub struct Error {
+    // Wrap the actual error data in a `Box` so that the error is just one
+    // word. This means that we can continue returning small `Result`s in
+    // registers.
+    pub(crate) inner: Box<ErrorInner>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ErrorInner {
+    pub(crate) message: String,
+    pub(crate) kind: ErrorKind,
+    pub(crate) offset: usize,
+    pub(crate) needed_hint: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ErrorKind {
+    Custom,
+    Invalid,
+}
+
+/// The result for `BinaryReader` operations.
+pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+impl core::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} (at offset 0x{:x})",
+            self.inner.message, self.inner.offset
+        )
+    }
+}
+
+impl Error {
+    #[cold]
+    pub(crate) fn _new(kind: ErrorKind, message: String, offset: usize) -> Self {
+        Error {
+            inner: Box::new(ErrorInner {
+                kind,
+                message,
+                offset,
+                needed_hint: None,
+            }),
+        }
+    }
+
+    #[cold]
+    pub(crate) fn new(message: impl Into<String>, offset: usize) -> Self {
+        Self::_new(ErrorKind::Custom, message.into(), offset)
+    }
+
+    #[cold]
+    pub(crate) fn invalid(msg: &'static str, offset: usize) -> Self {
+        Self::_new(ErrorKind::Invalid, msg.into(), offset)
+    }
+
+    #[cold]
+    pub(crate) fn fmt(args: fmt::Arguments<'_>, offset: usize) -> Self {
+        Error::new(args.to_string(), offset)
+    }
+
+    #[cold]
+    pub(crate) fn eof(offset: usize, needed_hint: usize) -> Self {
+        let mut err = Error::new("unexpected end-of-file", offset);
+        err.inner.needed_hint = Some(needed_hint);
+        err
+    }
+
+    pub(crate) fn kind(&mut self) -> ErrorKind {
+        self.inner.kind
+    }
+
+    /// Get this error's message.
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
+    /// Get the offset within the Wasm binary where the error occurred.
+    pub fn offset(&self) -> usize {
+        self.inner.offset
+    }
+
+    #[cfg(all(feature = "validate", feature = "component-model"))]
+    pub(crate) fn add_context(&mut self, context: String) {
+        self.inner.message = format!("{context}\n{}", self.inner.message);
+    }
+
+    pub(crate) fn set_message(&mut self, message: &str) {
+        self.inner.message = message.to_string();
+    }
+}

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -1298,7 +1298,7 @@ pub use _for_each_visit_simd_operator_impl as for_each_visit_simd_operator;
 
 macro_rules! format_err {
     ($offset:expr, $($arg:tt)*) => {
-        crate::BinaryReaderError::fmt(format_args!($($arg)*), $offset)
+        crate::Error::fmt(format_args!($($arg)*), $offset)
     }
 }
 
@@ -1316,13 +1316,18 @@ macro_rules! ensure {
 }
 
 pub use crate::arity::*;
-pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Result};
+pub use crate::binary_reader::BinaryReader;
+pub use crate::error::{Error, Result};
 pub use crate::features::*;
 pub use crate::parser::*;
 pub use crate::readers::*;
 
+/// Aliases [`Error`] for backward compatibility.
+pub type BinaryReaderError = Error;
+
 mod arity;
 mod binary_reader;
+mod error;
 mod features;
 mod limits;
 mod parser;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -3,7 +3,7 @@ use crate::WasmFeatures;
 use crate::binary_reader::WASM_MAGIC_NUMBER;
 use crate::prelude::*;
 use crate::{
-    BinaryReader, Error, CustomSectionReader, DataSectionReader, ElementSectionReader,
+    BinaryReader, CustomSectionReader, DataSectionReader, ElementSectionReader, Error,
     ExportSectionReader, FromReader, FunctionBody, FunctionSectionReader, GlobalSectionReader,
     ImportSectionReader, MemorySectionReader, Result, TableSectionReader, TagSectionReader,
     TypeSectionReader,
@@ -963,10 +963,7 @@ impl Parser {
             State::FunctionBody { remaining: 0, len } => {
                 debug_assert!(len > 0);
                 let offset = reader.original_position();
-                Err(Error::new(
-                    "trailing bytes at end of section",
-                    offset,
-                ))
+                Err(Error::new("trailing bytes at end of section", offset))
             }
 
             // Functions are relatively easy to parse when we know there's at

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -3,7 +3,7 @@ use crate::WasmFeatures;
 use crate::binary_reader::WASM_MAGIC_NUMBER;
 use crate::prelude::*;
 use crate::{
-    BinaryReader, BinaryReaderError, CustomSectionReader, DataSectionReader, ElementSectionReader,
+    BinaryReader, Error, CustomSectionReader, DataSectionReader, ElementSectionReader,
     ExportSectionReader, FromReader, FunctionBody, FunctionSectionReader, GlobalSectionReader,
     ImportSectionReader, MemorySectionReader, Result, TableSectionReader, TagSectionReader,
     TypeSectionReader,
@@ -722,7 +722,7 @@ impl Parser {
                 // than section. Report a better error instead:
                 match reader.peek_bytes(4) {
                     Ok(peek) if peek == WASM_MAGIC_NUMBER => {
-                        return Err(BinaryReaderError::new(
+                        return Err(Error::new(
                             "expected section, got wasm magic number",
                             reader.original_position(),
                         ));
@@ -733,7 +733,7 @@ impl Parser {
                 let id_pos = reader.original_position();
                 let id = reader.read_u8()?;
                 if id & 0x80 != 0 {
-                    return Err(BinaryReaderError::new("malformed section id", id_pos));
+                    return Err(Error::new("malformed section id", id_pos));
                 }
                 let len_pos = reader.original_position();
                 let mut len = reader.read_var_u32()?;
@@ -750,7 +750,7 @@ impl Parser {
                     .and_then(|s| s.checked_sub(len.into()))
                     .is_none();
                 if section_overflow {
-                    return Err(BinaryReaderError::new("section too large", len_pos));
+                    return Err(Error::new("section too large", len_pos));
                 }
 
                 match (self.encoding, id) {
@@ -963,7 +963,7 @@ impl Parser {
             State::FunctionBody { remaining: 0, len } => {
                 debug_assert!(len > 0);
                 let offset = reader.original_position();
-                Err(BinaryReaderError::new(
+                Err(Error::new(
                     "trailing bytes at end of section",
                     offset,
                 ))
@@ -1290,7 +1290,7 @@ fn delimited<'a, T>(
         .and_then(|i| len.checked_sub(i))
     {
         Some(i) => i,
-        None => return Err(BinaryReaderError::new("unexpected end-of-file", start)),
+        None => return Err(Error::new("unexpected end-of-file", start)),
     };
     Ok(ret)
 }
@@ -1485,7 +1485,7 @@ impl fmt::Debug for Payload<'_> {
     }
 }
 
-fn clear_hint(mut err: BinaryReaderError) -> BinaryReaderError {
+fn clear_hint(mut err: Error) -> Error {
     err.inner.needed_hint = None;
     err
 }

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-use crate::{BinaryReader, BinaryReaderError, Result};
+use crate::{BinaryReader, Error, Result};
 use ::core::fmt;
 use ::core::marker;
 use ::core::ops::Range;
@@ -42,7 +42,7 @@ impl<'a> FromReader<'a> for bool {
         match reader.read_u8()? {
             0 => Ok(false),
             1 => Ok(true),
-            _ => Err(BinaryReaderError::new(
+            _ => Err(Error::new(
                 "invalid boolean value",
                 reader.original_position() - 1,
             )),
@@ -202,7 +202,7 @@ where
             if self.section.reader.eof() {
                 return None;
             }
-            return Some(Err(BinaryReaderError::new(
+            return Some(Err(Error::new(
                 "section size mismatch: unexpected data at the end of the section",
                 self.section.reader.original_position(),
             )));

--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -1,4 +1,4 @@
-use crate::{BinaryReader, BinaryReaderError, NameMap, Result, Subsection, Subsections};
+use crate::{BinaryReader, Error, NameMap, Result, Subsection, Subsections};
 use core::ops::Range;
 
 /// Type used to iterate and parse the contents of the `component-name` custom
@@ -47,7 +47,7 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
             0 => {
                 let name = reader.read_unlimited_string()?;
                 if !reader.eof() {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "trailing data at the end of a name",
                         reader.original_position(),
                     ));

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-use crate::{BinaryReader, BinaryReaderError, ConstExpr, FromReader, Result, SectionLimited};
+use crate::{BinaryReader, Error, ConstExpr, FromReader, Result, SectionLimited};
 use core::ops::Range;
 
 /// Represents a data segment in a core WebAssembly module.
@@ -77,7 +77,7 @@ impl<'a> FromReader<'a> for Data<'a> {
                 }
             }
             _ => {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "invalid flags byte in data segment",
                     segment_start,
                 ));

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-use crate::{BinaryReader, Error, ConstExpr, FromReader, Result, SectionLimited};
+use crate::{BinaryReader, ConstExpr, Error, FromReader, Result, SectionLimited};
 use core::ops::Range;
 
 /// Represents a data segment in a core WebAssembly module.

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, ConstExpr, ExternalKind, FromReader, OperatorsReader,
+    BinaryReader, Error, ConstExpr, ExternalKind, FromReader, OperatorsReader,
     OperatorsReaderAllocations, RefType, Result, SectionLimited,
 };
 use core::ops::Range;
@@ -76,7 +76,7 @@ impl<'a> FromReader<'a> for Element<'a> {
         // See also https://github.com/WebAssembly/spec/issues/1439
         let flags = reader.read_var_u32()?;
         if (flags & !0b111) != 0 {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "invalid flags byte in element segment",
                 reader.original_position() - 1,
             ));
@@ -107,7 +107,7 @@ impl<'a> FromReader<'a> for Element<'a> {
                 match reader.read()? {
                     ExternalKind::Func => None,
                     _ => {
-                        return Err(BinaryReaderError::new(
+                        return Err(Error::new(
                             "only the function external type is supported in elem segment",
                             reader.original_position() - 1,
                         ));

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{
-    BinaryReader, Error, ConstExpr, ExternalKind, FromReader, OperatorsReader,
+    BinaryReader, ConstExpr, Error, ExternalKind, FromReader, OperatorsReader,
     OperatorsReaderAllocations, RefType, Result, SectionLimited,
 };
 use core::ops::Range;

--- a/crates/wasmparser/src/readers/core/imports.rs
+++ b/crates/wasmparser/src/readers/core/imports.rs
@@ -16,7 +16,7 @@
 use core::mem;
 
 use crate::{
-    BinaryReader, BinaryReaderError, ExternalKind, FromReader, GlobalType, MemoryType, Result,
+    BinaryReader, Error, ExternalKind, FromReader, GlobalType, MemoryType, Result,
     SectionLimited, SectionLimitedIntoIterWithOffsets, TableType, TagType,
 };
 
@@ -243,7 +243,7 @@ pub struct ImportsIter<'a> {
 
 enum ImportsIterState<'a> {
     Done,
-    Error(BinaryReaderError),
+    Error(Error),
     Single(usize, Import<'a>),
     Compact1 {
         module: &'a str,

--- a/crates/wasmparser/src/readers/core/imports.rs
+++ b/crates/wasmparser/src/readers/core/imports.rs
@@ -16,8 +16,8 @@
 use core::mem;
 
 use crate::{
-    BinaryReader, Error, ExternalKind, FromReader, GlobalType, MemoryType, Result,
-    SectionLimited, SectionLimitedIntoIterWithOffsets, TableType, TagType,
+    BinaryReader, Error, ExternalKind, FromReader, GlobalType, MemoryType, Result, SectionLimited,
+    SectionLimitedIntoIterWithOffsets, TableType, TagType,
 };
 
 /// Represents a reference to a type definition in a WebAssembly module.

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{
-    BinaryReader, BinaryReaderError, FromReader, Result, SectionLimited, Subsection, Subsections,
+    BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections,
 };
 use core::ops::Range;
 
@@ -409,7 +409,7 @@ impl<'a> LinkingSectionReader<'a> {
 
         let version = reader.read_var_u32()?;
         if version != 2 {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 format!("unsupported linking section version: {version}"),
                 offset,
             ));

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
-use crate::{
-    BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections,
-};
+use crate::{BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections};
 use core::ops::Range;
 
 bitflags::bitflags! {

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, FromReader, Result, SectionLimited, Subsection, Subsections,
+    BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections,
 };
 use core::ops::Range;
 
@@ -131,7 +131,7 @@ impl<'a> Subsection<'a> for Name<'a> {
             0 => {
                 let name = reader.read_string()?;
                 if !reader.eof() {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "trailing data at the end of a name",
                         reader.original_position(),
                     ));

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections,
-};
+use crate::{BinaryReader, Error, FromReader, Result, SectionLimited, Subsection, Subsections};
 use core::ops::Range;
 
 /// Represents a name map from the names custom section.

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -15,7 +15,7 @@
 
 use crate::limits::{MAX_WASM_CATCHES, MAX_WASM_HANDLERS};
 use crate::prelude::*;
-use crate::{BinaryReader, BinaryReaderError, FromReader, Result, ValType};
+use crate::{BinaryReader, Error, FromReader, Result, ValType};
 use core::{fmt, mem};
 
 /// Represents a block type.
@@ -182,7 +182,7 @@ impl<'a> Iterator for BrTableTargets<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
             if !self.reader.eof() {
-                return Some(Err(BinaryReaderError::new(
+                return Some(Err(Error::new(
                     "trailing data in br_table",
                     self.reader.original_position(),
                 )));

--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -246,7 +246,7 @@ impl RelocationEntry {
         let start = self.offset as usize;
         let end = start
             .checked_add(self.ty.extent())
-            .ok_or_else(|| crate::BinaryReaderError::new("relocation range end overflow", start))?;
+            .ok_or_else(|| crate::Error::new("relocation range end overflow", start))?;
         Ok(start..end)
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-use crate::binary_reader::BinaryReaderErrorKind;
+use crate::error::ErrorKind;
 use crate::limits::{
     MAX_WASM_FUNCTION_PARAMS, MAX_WASM_FUNCTION_RETURNS, MAX_WASM_STRUCT_FIELDS,
     MAX_WASM_SUPERTYPES, MAX_WASM_TYPES,
@@ -21,7 +21,7 @@ use crate::limits::{
 use crate::prelude::*;
 #[cfg(feature = "validate")]
 use crate::types::CoreTypeId;
-use crate::{BinaryReader, BinaryReaderError, FromReader, Result, SectionLimited};
+use crate::{BinaryReader, Error, FromReader, Result, SectionLimited};
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
@@ -1798,7 +1798,7 @@ impl<'a> FromReader<'a> for ValType {
                 // that's the "root" of what was being parsed rather than
                 // reference types.
                 let refty = reader.read().map_err(|mut e| {
-                    if let BinaryReaderErrorKind::Invalid = e.kind() {
+                    if let ErrorKind::Invalid = e.kind() {
                         e.set_message("invalid value type");
                     }
                     e
@@ -1818,21 +1818,21 @@ impl<'a> FromReader<'a> for RefType {
             0x63 | 0x64 => {
                 let nullable = reader.read_u8()? == 0x63;
                 RefType::new(nullable, reader.read()?)
-                    .ok_or_else(|| crate::BinaryReaderError::new("type index too large", pos))
+                    .ok_or_else(|| crate::Error::new("type index too large", pos))
             }
-            0x62 => Err(crate::BinaryReaderError::new("unexpected exact type", pos)),
+            0x62 => Err(crate::Error::new("unexpected exact type", pos)),
             _ => {
                 // Reclassify errors as invalid reference types here because
                 // that's the "root" of what was being parsed rather than
                 // heap types.
                 let hty = reader.read().map_err(|mut e| {
-                    if let BinaryReaderErrorKind::Invalid = e.kind() {
+                    if let ErrorKind::Invalid = e.kind() {
                         e.set_message("malformed reference type");
                     }
                     e
                 })?;
                 RefType::new(true, hty)
-                    .ok_or_else(|| crate::BinaryReaderError::new("type index too large", pos))
+                    .ok_or_else(|| crate::Error::new("type index too large", pos))
             }
         }
     }
@@ -1854,7 +1854,7 @@ impl<'a> FromReader<'a> for HeapType {
                 // read.
                 *reader = clone;
                 let idx = PackedIndex::from_module_index(idx).ok_or_else(|| {
-                    BinaryReaderError::new(
+                    Error::new(
                         "type index greater than implementation limits",
                         reader.original_position(),
                     )
@@ -1877,7 +1877,7 @@ impl<'a> FromReader<'a> for HeapType {
                     // that's the "root" of what was being parsed rather than
                     // abstract heap types.
                     let ty = reader.read().map_err(|mut e| {
-                        if let BinaryReaderErrorKind::Invalid = e.kind() {
+                        if let ErrorKind::Invalid = e.kind() {
                             e.set_message("invalid heap type");
                         }
                         e
@@ -1908,7 +1908,7 @@ impl<'a> FromReader<'a> for AbstractHeapType {
             0x68 => Ok(Cont),
             0x75 => Ok(NoCont),
             _ => {
-                return Err(BinaryReaderError::invalid(
+                return Err(Error::invalid(
                     "invalid abstract heap type",
                     reader.original_position() - 1,
                 ));
@@ -2083,10 +2083,7 @@ impl<'a> FromReader<'a> for CompositeType {
     }
 }
 
-fn read_composite_type(
-    opcode: u8,
-    reader: &mut BinaryReader,
-) -> Result<CompositeType, BinaryReaderError> {
+fn read_composite_type(opcode: u8, reader: &mut BinaryReader) -> Result<CompositeType, Error> {
     // NB: See `FromReader<'a> for ValType` for a table of how this
     // interacts with other value encodings.
     let (shared, opcode) = if opcode == 0x65 {
@@ -2096,7 +2093,7 @@ fn read_composite_type(
     };
     let (describes_idx, opcode) = if opcode == 0x4c {
         let idx = PackedIndex::from_module_index(reader.read_var_u32()?).ok_or_else(|| {
-            BinaryReaderError::new(
+            Error::new(
                 "type index greater than implementation limits",
                 reader.original_position(),
             )
@@ -2107,7 +2104,7 @@ fn read_composite_type(
     };
     let (descriptor_idx, opcode) = if opcode == 0x4d {
         let idx = PackedIndex::from_module_index(reader.read_var_u32()?).ok_or_else(|| {
-            BinaryReaderError::new(
+            Error::new(
                 "type index greater than implementation limits",
                 reader.original_position(),
             )
@@ -2165,17 +2162,14 @@ impl<'a> FromReader<'a> for SubType {
                 let idx_iter = reader.read_iter(MAX_WASM_SUPERTYPES, "supertype idxs")?;
                 let idxs = idx_iter.collect::<Result<Vec<u32>>>()?;
                 if idxs.len() > 1 {
-                    return Err(BinaryReaderError::new(
-                        "multiple supertypes not supported",
-                        pos,
-                    ));
+                    return Err(Error::new("multiple supertypes not supported", pos));
                 }
                 let supertype_idx = idxs
                     .first()
                     .copied()
                     .map(|idx| {
                         PackedIndex::from_module_index(idx).ok_or_else(|| {
-                            BinaryReaderError::new(
+                            Error::new(
                                 "type index greater than implementation limits",
                                 reader.original_position(),
                             )
@@ -2254,7 +2248,7 @@ impl<'a> FromReader<'a> for ContType {
             }
         };
         let idx = PackedIndex::from_module_index(idx).ok_or_else(|| {
-            BinaryReaderError::new(
+            Error::new(
                 "type index greater than implementation limits",
                 reader.original_position(),
             )

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -14,8 +14,8 @@
  */
 
 use crate::{
-    Error, FuncType, GlobalType, HeapType, MemoryType, RefType, SubType, TableType,
-    ValType, WasmFeatures, types::CoreTypeId,
+    Error, FuncType, GlobalType, HeapType, MemoryType, RefType, SubType, TableType, ValType,
+    WasmFeatures, types::CoreTypeId,
 };
 
 /// Types that qualify as Wasm validation database.
@@ -95,11 +95,7 @@ pub trait WasmModuleResources {
     }
 
     /// Check and canonicalize a reference type.
-    fn check_ref_type(
-        &self,
-        ref_type: &mut RefType,
-        offset: usize,
-    ) -> Result<(), Error> {
+    fn check_ref_type(&self, ref_type: &mut RefType, offset: usize) -> Result<(), Error> {
         let is_nullable = ref_type.is_nullable();
         let mut heap_ty = ref_type.heap_type();
         self.check_heap_type(&mut heap_ty, offset)?;
@@ -111,11 +107,7 @@ pub trait WasmModuleResources {
     /// canonical form.
     ///
     /// Similar to `check_value_type` but for heap types.
-    fn check_heap_type(
-        &self,
-        heap_type: &mut HeapType,
-        offset: usize,
-    ) -> Result<(), Error>;
+    fn check_heap_type(&self, heap_type: &mut HeapType, offset: usize) -> Result<(), Error>;
 
     /// Get the top type for the given heap type.
     fn top_type(&self, heap_type: &HeapType) -> HeapType;

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{
-    BinaryReaderError, FuncType, GlobalType, HeapType, MemoryType, RefType, SubType, TableType,
+    Error, FuncType, GlobalType, HeapType, MemoryType, RefType, SubType, TableType,
     ValType, WasmFeatures, types::CoreTypeId,
 };
 
@@ -84,10 +84,10 @@ pub trait WasmModuleResources {
         t: &mut ValType,
         features: &WasmFeatures,
         offset: usize,
-    ) -> Result<(), BinaryReaderError> {
+    ) -> Result<(), Error> {
         features
             .check_value_type(*t)
-            .map_err(|s| BinaryReaderError::new(s, offset))?;
+            .map_err(|s| Error::new(s, offset))?;
         match t {
             ValType::Ref(r) => self.check_ref_type(r, offset),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => Ok(()),
@@ -99,7 +99,7 @@ pub trait WasmModuleResources {
         &self,
         ref_type: &mut RefType,
         offset: usize,
-    ) -> Result<(), BinaryReaderError> {
+    ) -> Result<(), Error> {
         let is_nullable = ref_type.is_nullable();
         let mut heap_ty = ref_type.heap_type();
         self.check_heap_type(&mut heap_ty, offset)?;
@@ -115,7 +115,7 @@ pub trait WasmModuleResources {
         &self,
         heap_type: &mut HeapType,
         offset: usize,
-    ) -> Result<(), BinaryReaderError>;
+    ) -> Result<(), Error>;
 
     /// Get the top type for the given heap type.
     fn top_type(&self, heap_type: &HeapType) -> HeapType;
@@ -162,7 +162,7 @@ where
     fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
         T::type_index_of_function(self, func_idx)
     }
-    fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
+    fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), Error> {
         T::check_heap_type(self, t, offset)
     }
     fn top_type(&self, heap_type: &HeapType) -> HeapType {
@@ -227,7 +227,7 @@ where
         T::type_index_of_function(self, func_idx)
     }
 
-    fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
+    fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), Error> {
         T::check_heap_type(self, t, offset)
     }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -15,7 +15,7 @@
 
 use crate::prelude::*;
 use crate::{
-    AbstractHeapType, BinaryReaderError, Encoding, FromReader, FunctionBody, HeapType, Parser,
+    AbstractHeapType, Error, Encoding, FromReader, FunctionBody, HeapType, Parser,
     Payload, RefType, Result, SectionLimited, ValType, WASM_MODULE_VERSION, WasmFeatures,
     limits::*,
 };
@@ -184,11 +184,11 @@ impl State {
             Self::Module => Ok(()),
             #[cfg(feature = "component-model")]
             Self::Component => Ok(()),
-            Self::Unparsed(_) => Err(BinaryReaderError::new(
+            Self::Unparsed(_) => Err(Error::new(
                 "unexpected section before header was parsed",
                 offset,
             )),
-            Self::End => Err(BinaryReaderError::new(
+            Self::End => Err(Error::new(
                 "unexpected section after parsing has completed",
                 offset,
             )),
@@ -676,7 +676,7 @@ impl Validator {
                 }
             }
             _ => {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "wasm version header out of order",
                     range.start,
                 ));
@@ -850,7 +850,7 @@ impl Validator {
     /// This method should only be called when parsing a module.
     pub fn tag_section(&mut self, section: &crate::TagSectionReader<'_>) -> Result<()> {
         if !self.features.exceptions() {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "exceptions proposal not enabled",
                 section.range().start,
             ));
@@ -931,7 +931,7 @@ impl Validator {
 
         let ty = state.module.get_func_type(func, &self.types, offset)?;
         if !ty.params().is_empty() || !ty.results().is_empty() {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "invalid start function type",
                 offset,
             ));
@@ -976,7 +976,7 @@ impl Validator {
         let state = self.module.as_mut().unwrap();
 
         if count > MAX_WASM_DATA_SEGMENTS as u32 {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "data count section specifies too many data segments",
                 offset,
             ));
@@ -1197,7 +1197,7 @@ impl Validator {
             section,
             "alias",
             |_, _, _, _| Ok(()), // maximums checked via `add_alias`
-            |components, types, _features, alias, offset| -> Result<(), BinaryReaderError> {
+            |components, types, _features, alias, offset| -> Result<(), Error> {
                 ComponentState::add_alias(components, alias, types, offset)
             },
         )
@@ -1348,11 +1348,11 @@ impl Validator {
     /// Returns the types known to the validator for the module or component.
     pub fn end(&mut self, offset: usize) -> Result<Types> {
         match mem::replace(&mut self.state, State::End) {
-            State::Unparsed(_) => Err(BinaryReaderError::new(
+            State::Unparsed(_) => Err(Error::new(
                 "cannot call `end` before a header has been parsed",
                 offset,
             )),
-            State::End => Err(BinaryReaderError::new(
+            State::End => Err(Error::new(
                 "cannot call `end` after parsing has completed",
                 offset,
             )),

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -15,9 +15,8 @@
 
 use crate::prelude::*;
 use crate::{
-    AbstractHeapType, Error, Encoding, FromReader, FunctionBody, HeapType, Parser,
-    Payload, RefType, Result, SectionLimited, ValType, WASM_MODULE_VERSION, WasmFeatures,
-    limits::*,
+    AbstractHeapType, Encoding, Error, FromReader, FunctionBody, HeapType, Parser, Payload,
+    RefType, Result, SectionLimited, ValType, WASM_MODULE_VERSION, WasmFeatures, limits::*,
 };
 use ::core::mem;
 use ::core::ops::Range;
@@ -676,10 +675,7 @@ impl Validator {
                 }
             }
             _ => {
-                return Err(Error::new(
-                    "wasm version header out of order",
-                    range.start,
-                ));
+                return Err(Error::new("wasm version header out of order", range.start));
             }
         }
 
@@ -931,10 +927,7 @@ impl Validator {
 
         let ty = state.module.get_func_type(func, &self.types, offset)?;
         if !ty.params().is_empty() || !ty.results().is_empty() {
-            return Err(Error::new(
-                "invalid start function type",
-                offset,
-            ));
+            return Err(Error::new("invalid start function type", offset));
         }
 
         Ok(())

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -18,7 +18,7 @@ use crate::limits::*;
 use crate::prelude::*;
 use crate::validator::names::{ComponentName, ComponentNameKind, KebabStr, KebabString};
 use crate::{
-    BinaryReaderError, CanonicalFunction, CanonicalOption, ComponentExternName,
+    Error, CanonicalFunction, CanonicalOption, ComponentExternName,
     ComponentExternalKind, ComponentOuterAliasKind, ComponentTypeRef, CompositeInnerType,
     ExternalKind, FuncType, GlobalType, InstantiationArgKind, MemoryType, PackedIndex, RefType,
     Result, SubType, TableType, TypeBounds, ValType, WasmFeatures,
@@ -380,7 +380,7 @@ impl CanonicalOptions {
             } => {
                 let func_ty = types[state.core_function_at(idx, offset)?].unwrap_func();
                 if func_ty.params() != [ValType::I32; 3] && func_ty.params() != [ValType::I32] {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "canonical option `callback` uses a core function with an incorrect signature",
                         offset,
                     ));
@@ -2618,7 +2618,7 @@ impl ComponentState {
             );
         }
         if self.has_start {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "component cannot have more than one start function",
                 offset,
             ));
@@ -2720,7 +2720,7 @@ impl ComponentState {
                             Some(*idx)
                         }
                         Some(_) => {
-                            return Err(BinaryReaderError::new(
+                            return Err(Error::new(
                                 "canonical option `memory` is specified more than once",
                                 offset,
                             ));
@@ -2734,7 +2734,7 @@ impl ComponentState {
                             Some(*idx)
                         }
                         Some(_) => {
-                            return Err(BinaryReaderError::new(
+                            return Err(Error::new(
                                 "canonical option `realloc` is specified more than once",
                                 offset,
                             ));
@@ -2745,7 +2745,7 @@ impl ComponentState {
                     post_return = match post_return {
                         None => Some(*idx),
                         Some(_) => {
-                            return Err(BinaryReaderError::new(
+                            return Err(Error::new(
                                 "canonical option `post-return` is specified more than once",
                                 offset,
                             ));
@@ -2754,7 +2754,7 @@ impl ComponentState {
                 }
                 CanonicalOption::Async => {
                     if is_async {
-                        return Err(BinaryReaderError::new(
+                        return Err(Error::new(
                             "canonical option `async` is specified more than once",
                             offset,
                         ));
@@ -2773,7 +2773,7 @@ impl ComponentState {
                     callback = match callback {
                         None => Some(*idx),
                         Some(_) => {
-                            return Err(BinaryReaderError::new(
+                            return Err(Error::new(
                                 "canonical option `callback` is specified more than once",
                                 offset,
                             ));
@@ -2792,7 +2792,7 @@ impl ComponentState {
                             let ty = match self.core_type_at(*idx, offset)? {
                                 ComponentCoreTypeId::Sub(ty) => ty,
                                 ComponentCoreTypeId::Module(_) => {
-                                    return Err(BinaryReaderError::new(
+                                    return Err(Error::new(
                                         "canonical option `core type` must reference a core function \
                                      type",
                                         offset,
@@ -2804,7 +2804,7 @@ impl ComponentState {
                                 CompositeInnerType::Array(_)
                                 | CompositeInnerType::Struct(_)
                                 | CompositeInnerType::Cont(_) => {
-                                    return Err(BinaryReaderError::new(
+                                    return Err(Error::new(
                                         "canonical option `core type` must reference a core function \
                                      type",
                                         offset,
@@ -2814,7 +2814,7 @@ impl ComponentState {
                             Some(ty)
                         }
                         Some(_) => {
-                            return Err(BinaryReaderError::new(
+                            return Err(Error::new(
                                 "canonical option `core type` is specified more than once",
                                 offset,
                             ));
@@ -2823,13 +2823,13 @@ impl ComponentState {
                 }
                 CanonicalOption::Gc => {
                     if gc {
-                        return Err(BinaryReaderError::new(
+                        return Err(Error::new(
                             "canonical option `gc` is specified more than once",
                             offset,
                         ));
                     }
                     if !self.features.cm_gc() {
-                        return Err(BinaryReaderError::new(
+                        return Err(Error::new(
                             "canonical option `gc` requires the `cm-gc` feature",
                             offset,
                         ));
@@ -2861,7 +2861,7 @@ impl ComponentState {
             let mty = match memory {
                 Some(i) => self.memory_at(i, offset)?,
                 None => {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "canonical option `realloc` requires `memory` to also be specified",
                         offset,
                     ));
@@ -2876,7 +2876,7 @@ impl ComponentState {
             if func_ty.params() != [addr_type, addr_type, addr_type, addr_type]
                 || func_ty.results() != [addr_type]
             {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "canonical option `realloc` uses a core function with an incorrect signature",
                     offset,
                 ));
@@ -4201,7 +4201,7 @@ impl ComponentState {
         }
 
         if cases.len() > u32::MAX as usize {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "variant type cannot be represented with a 32-bit discriminant value",
                 offset,
             ));
@@ -4287,7 +4287,7 @@ impl ComponentState {
 
     fn create_enum_type(&self, cases: &[&str], offset: usize) -> Result<ComponentDefinedType> {
         if cases.len() > u32::MAX as usize {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "enumeration type cannot be represented with a 32-bit discriminant value",
                 offset,
             ));

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -18,10 +18,10 @@ use crate::limits::*;
 use crate::prelude::*;
 use crate::validator::names::{ComponentName, ComponentNameKind, KebabStr, KebabString};
 use crate::{
-    Error, CanonicalFunction, CanonicalOption, ComponentExternName,
-    ComponentExternalKind, ComponentOuterAliasKind, ComponentTypeRef, CompositeInnerType,
-    ExternalKind, FuncType, GlobalType, InstantiationArgKind, MemoryType, PackedIndex, RefType,
-    Result, SubType, TableType, TypeBounds, ValType, WasmFeatures,
+    CanonicalFunction, CanonicalOption, ComponentExternName, ComponentExternalKind,
+    ComponentOuterAliasKind, ComponentTypeRef, CompositeInnerType, Error, ExternalKind, FuncType,
+    GlobalType, InstantiationArgKind, MemoryType, PackedIndex, RefType, Result, SubType, TableType,
+    TypeBounds, ValType, WasmFeatures,
 };
 use core::mem;
 

--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -9,9 +9,7 @@ use crate::validator::types::{
     Types, TypesKind, TypesRef, TypesRefKind,
 };
 use crate::{AbstractHeapType, CompositeInnerType, HeapType, RefType, StorageType, prelude::*};
-use crate::{
-    BinaryReaderError, FuncType, MemoryType, PrimitiveValType, Result, TableType, ValType,
-};
+use crate::{Error, FuncType, MemoryType, PrimitiveValType, Result, TableType, ValType};
 use core::fmt;
 use core::ops::Index;
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -1773,7 +1771,7 @@ fn lower_gc_product_type<'a, I>(
     offset: usize,
     core: ArgOrField,
     kind: &str,
-) -> core::result::Result<(), BinaryReaderError>
+) -> core::result::Result<(), Error>
 where
     I: IntoIterator<Item = &'a ComponentValType>,
     I::IntoIter: ExactSizeIterator,
@@ -4038,7 +4036,7 @@ impl<T> Context for Result<T> {
     }
 }
 
-impl Context for BinaryReaderError {
+impl Context for Error {
     fn with_context<S>(mut self, context: impl FnOnce() -> S) -> Self
     where
         S: Into<String>,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -13,7 +13,7 @@ use super::{
 #[cfg(feature = "simd")]
 use crate::VisitSimdOperator;
 use crate::{
-    BinaryReaderError, ConstExpr, Data, DataKind, Element, ElementKind, ExternalKind, FrameKind,
+    Error, ConstExpr, Data, DataKind, Element, ElementKind, ExternalKind, FrameKind,
     FrameStack, FuncType, Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result,
     SubType, Table, TableInit, TableType, TagType, TypeRef, UnpackedIndex, ValType, VisitOperator,
     WasmFeatures, WasmModuleResources, limits::*,
@@ -144,7 +144,7 @@ impl ModuleState {
             } => {
                 let table = self.module.table_at(table_index.unwrap_or(0), offset)?;
                 if !types.reftype_is_subtype(element_ty, table.element_type) {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         format!(
                             "type mismatch: invalid element type `{}` for table type `{}`",
                             ty_to_str(element_ty.into()),
@@ -158,7 +158,7 @@ impl ModuleState {
             }
             ElementKind::Passive | ElementKind::Declared => {
                 if !self.module.features.bulk_memory() {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "bulk memory must be enabled",
                         offset,
                     ));
@@ -166,9 +166,9 @@ impl ModuleState {
             }
         }
 
-        let validate_count = |count: u32| -> Result<(), BinaryReaderError> {
+        let validate_count = |count: u32| -> Result<(), Error> {
             if count > MAX_WASM_TABLE_ENTRIES as u32 {
-                Err(BinaryReaderError::new(
+                Err(Error::new(
                     "number of elements is out of bounds",
                     offset,
                 ))
@@ -246,7 +246,7 @@ impl ModuleState {
                 if self.ops.features.extended_const() {
                     Ok(())
                 } else {
-                    Err(BinaryReaderError::new(
+                    Err(Error::new(
                         format!("constant expression required: non-constant operator: {op}"),
                         self.offset,
                     ))
@@ -257,7 +257,7 @@ impl ModuleState {
                 if self.ops.features.gc() {
                     Ok(())
                 } else {
-                    Err(BinaryReaderError::new(
+                    Err(Error::new(
                         format!("constant expression required: non-constant operator: {op}"),
                         self.offset,
                     ))
@@ -268,7 +268,7 @@ impl ModuleState {
                 if self.ops.features.shared_everything_threads() {
                     Ok(())
                 } else {
-                    Err(BinaryReaderError::new(
+                    Err(Error::new(
                         format!("constant expression required: non-constant operator: {op}"),
                         self.offset,
                     ))
@@ -280,13 +280,13 @@ impl ModuleState {
                 let global = module.global_at(index, self.offset)?;
 
                 if index >= module.num_imported_globals && !self.ops.features.gc() {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "constant expression required: global.get of locally defined global",
                         self.offset,
                     ));
                 }
                 if global.mutable {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "constant expression required: global.get of mutable global",
                         self.offset,
                     ));
@@ -323,8 +323,8 @@ impl ModuleState {
                 }
             }
 
-            fn not_const(&self, instr: &str) -> BinaryReaderError {
-                BinaryReaderError::new(
+            fn not_const(&self, instr: &str) -> Error {
+                Error::new(
                     format!("constant expression required: non-constant operator: {instr}"),
                     self.offset,
                 )
@@ -586,7 +586,7 @@ impl Module {
             }
             TypeRef::Global(ty) => {
                 if !self.features.mutable_global() && ty.mutable {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "mutable global support is not enabled",
                         offset,
                     ));
@@ -620,7 +620,7 @@ impl Module {
         if !self.features.mutable_global() {
             if let EntityType::Global(global_type) = ty {
                 if global_type.mutable {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "mutable global support is not enabled",
                         offset,
                     ));
@@ -741,15 +741,15 @@ impl Module {
         };
         let err = format!("table size must be at most {true_maximum:#x} entries");
         if ty.initial > true_maximum {
-            return Err(BinaryReaderError::new(err, offset));
+            return Err(Error::new(err, offset));
         }
         if let Some(maximum) = ty.maximum {
             if maximum > true_maximum {
-                return Err(BinaryReaderError::new(err, offset));
+                return Err(Error::new(err, offset));
             }
         }
         if ty.shared && !types.reftype_is_shared(ty.element_type) {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "shared tables must have a shared element type",
                 offset,
             ));
@@ -769,7 +769,7 @@ impl Module {
 
         let page_size = if let Some(page_size_log2) = ty.page_size_log2 {
             if !self.features().custom_page_sizes() {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "the custom page sizes proposal must be enabled to customize a memory's page size",
                     offset,
                 ));
@@ -777,7 +777,7 @@ impl Module {
             // Currently 2**0 and 2**16 are the only valid page sizes, but this
             // may be relaxed to allow any power of two in the future.
             if page_size_log2 != 0 && page_size_log2 != 16 {
-                return Err(BinaryReaderError::new("invalid custom page size", offset));
+                return Err(Error::new("invalid custom page size", offset));
             }
             let page_size = 1_u64 << page_size_log2;
             debug_assert!(page_size.is_power_of_two());
@@ -795,15 +795,15 @@ impl Module {
         };
         let err = format!("memory size must be at most {true_maximum:#x} {page_size}-byte pages");
         if ty.initial > true_maximum {
-            return Err(BinaryReaderError::new(err, offset));
+            return Err(Error::new(err, offset));
         }
         if let Some(maximum) = ty.maximum {
             if maximum > true_maximum {
-                return Err(BinaryReaderError::new(err, offset));
+                return Err(Error::new(err, offset));
             }
         }
         if ty.shared && ty.maximum.is_none() {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "shared memory must have maximum size",
                 offset,
             ));
@@ -841,14 +841,14 @@ impl Module {
             _ => self
                 .features
                 .check_value_type(*ty)
-                .map_err(|e| BinaryReaderError::new(e, offset)),
+                .map_err(|e| Error::new(e, offset)),
         }
     }
 
     fn check_ref_type(&self, ty: &mut RefType, offset: usize) -> Result<()> {
         self.features
             .check_ref_type(*ty)
-            .map_err(|e| BinaryReaderError::new(e, offset))?;
+            .map_err(|e| Error::new(e, offset))?;
         let mut hty = ty.heap_type();
         self.check_heap_type(&mut hty, offset)?;
         *ty = RefType::new(ty.is_nullable(), hty).unwrap();
@@ -880,7 +880,7 @@ impl Module {
         }
         let ty = self.func_type_at(ty.func_type_idx, types, offset)?;
         if !ty.results().is_empty() && !self.features.stack_switching() {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "invalid exception type: non-empty tag result type",
                 offset,
             ));
@@ -902,7 +902,7 @@ impl Module {
             );
         }
         if ty.shared && !types.valtype_is_shared(ty.content_type) {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "shared globals must have a shared value type",
                 offset,
             ));
@@ -916,7 +916,7 @@ impl Module {
     {
         if let Some(max) = maximum {
             if initial.into() > max.into() {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "size minimum must not be greater than maximum",
                     offset,
                 ));

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -12,13 +12,13 @@ use super::{
 };
 #[cfg(feature = "simd")]
 use crate::VisitSimdOperator;
-use crate::{
-    Error, ConstExpr, Data, DataKind, Element, ElementKind, ExternalKind, FrameKind,
-    FrameStack, FuncType, Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result,
-    SubType, Table, TableInit, TableType, TagType, TypeRef, UnpackedIndex, ValType, VisitOperator,
-    WasmFeatures, WasmModuleResources, limits::*,
-};
 use crate::{CompositeInnerType, prelude::*};
+use crate::{
+    ConstExpr, Data, DataKind, Element, ElementKind, Error, ExternalKind, FrameKind, FrameStack,
+    FuncType, Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result, SubType, Table,
+    TableInit, TableType, TagType, TypeRef, UnpackedIndex, ValType, VisitOperator, WasmFeatures,
+    WasmModuleResources, limits::*,
+};
 use alloc::sync::Arc;
 use core::mem;
 
@@ -158,20 +158,14 @@ impl ModuleState {
             }
             ElementKind::Passive | ElementKind::Declared => {
                 if !self.module.features.bulk_memory() {
-                    return Err(Error::new(
-                        "bulk memory must be enabled",
-                        offset,
-                    ));
+                    return Err(Error::new("bulk memory must be enabled", offset));
                 }
             }
         }
 
         let validate_count = |count: u32| -> Result<(), Error> {
             if count > MAX_WASM_TABLE_ENTRIES as u32 {
-                Err(Error::new(
-                    "number of elements is out of bounds",
-                    offset,
-                ))
+                Err(Error::new("number of elements is out of bounds", offset))
             } else {
                 Ok(())
             }
@@ -586,10 +580,7 @@ impl Module {
             }
             TypeRef::Global(ty) => {
                 if !self.features.mutable_global() && ty.mutable {
-                    return Err(Error::new(
-                        "mutable global support is not enabled",
-                        offset,
-                    ));
+                    return Err(Error::new("mutable global support is not enabled", offset));
                 }
                 self.globals.push(ty);
                 self.num_imported_globals += 1;
@@ -620,10 +611,7 @@ impl Module {
         if !self.features.mutable_global() {
             if let EntityType::Global(global_type) = ty {
                 if global_type.mutable {
-                    return Err(Error::new(
-                        "mutable global support is not enabled",
-                        offset,
-                    ));
+                    return Err(Error::new("mutable global support is not enabled", offset));
                 }
             }
         }
@@ -803,10 +791,7 @@ impl Module {
             }
         }
         if ty.shared && ty.maximum.is_none() {
-            return Err(Error::new(
-                "shared memory must have maximum size",
-                offset,
-            ));
+            return Err(Error::new("shared memory must have maximum size", offset));
         }
         Ok(())
     }

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -69,8 +69,8 @@
 
 use super::{RecGroupId, TypeAlloc, TypeList};
 use crate::{
-    Error, CompositeInnerType, CompositeType, PackedIndex, RecGroup, Result,
-    StorageType, UnpackedIndex, ValType, WasmFeatures,
+    CompositeInnerType, CompositeType, Error, PackedIndex, RecGroup, Result, StorageType,
+    UnpackedIndex, ValType, WasmFeatures,
     types::{CoreTypeId, TypeIdentifier},
 };
 

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -69,7 +69,7 @@
 
 use super::{RecGroupId, TypeAlloc, TypeList};
 use crate::{
-    BinaryReaderError, CompositeInnerType, CompositeType, PackedIndex, RecGroup, Result,
+    Error, CompositeInnerType, CompositeType, PackedIndex, RecGroup, Result,
     StorageType, UnpackedIndex, ValType, WasmFeatures,
     types::{CoreTypeId, TypeIdentifier},
 };
@@ -173,7 +173,7 @@ pub(crate) trait InternRecGroup {
         let ty = &types[id].composite_type;
         if ty.descriptor_idx.is_some() || ty.describes_idx.is_some() {
             if !self.features().custom_descriptors() {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "custom descriptors proposal must be enabled to use descriptor and describes",
                     offset,
                 ));
@@ -181,7 +181,7 @@ pub(crate) trait InternRecGroup {
             match &ty.inner {
                 CompositeInnerType::Struct(_) => (),
                 _ => {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         if ty.descriptor_idx.is_some() {
                             "descriptor clause on non-struct type"
                         } else {
@@ -289,9 +289,9 @@ pub(crate) trait InternRecGroup {
         let check = |ty: &ValType, shared: bool| {
             features
                 .check_value_type(*ty)
-                .map_err(|e| BinaryReaderError::new(e, offset))?;
+                .map_err(|e| Error::new(e, offset))?;
             if shared && !types.valtype_is_shared(*ty) {
-                return Err(BinaryReaderError::new(
+                return Err(Error::new(
                     "shared composite type must contain shared types",
                     offset,
                 ));
@@ -304,7 +304,7 @@ pub(crate) trait InternRecGroup {
             Ok(())
         };
         if !features.shared_everything_threads() && ty.shared {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "shared composite types require the shared-everything-threads proposal",
                 offset,
             ));
@@ -315,7 +315,7 @@ pub(crate) trait InternRecGroup {
                     check(vt, ty.shared)?;
                 }
                 if t.results().len() > 1 && !features.multi_value() {
-                    return Err(BinaryReaderError::new(
+                    return Err(Error::new(
                         "func type returns multiple values but the multi-value feature is not enabled",
                         offset,
                     ));

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -25,11 +25,10 @@
 #[cfg(feature = "simd")]
 use crate::VisitSimdOperator;
 use crate::{
-    AbstractHeapType, Error, BlockType, BrTable, Catch, ContType, FieldType, FrameKind,
-    FrameStack, FuncType, GlobalType, Handle, HeapType, Ieee32, Ieee64, MemArg, ModuleArity,
-    RefType, Result, ResumeTable, StorageType, StructType, SubType, TableType, TryTable,
-    UnpackedIndex, ValType, VisitOperator, WasmFeatures, WasmModuleResources,
-    limits::MAX_WASM_FUNCTION_LOCALS,
+    AbstractHeapType, BlockType, BrTable, Catch, ContType, Error, FieldType, FrameKind, FrameStack,
+    FuncType, GlobalType, Handle, HeapType, Ieee32, Ieee64, MemArg, ModuleArity, RefType, Result,
+    ResumeTable, StorageType, StructType, SubType, TableType, TryTable, UnpackedIndex, ValType,
+    VisitOperator, WasmFeatures, WasmModuleResources, limits::MAX_WASM_FUNCTION_LOCALS,
 };
 use crate::{CompositeInnerType, Ordering, prelude::*};
 use core::ops::{Deref, DerefMut};
@@ -460,10 +459,7 @@ impl OperatorValidator {
             return Ok(());
         }
         if !self.locals.define(count, ty) {
-            return Err(Error::new(
-                "too many locals: locals exceed maximum",
-                offset,
-            ));
+            return Err(Error::new("too many locals: locals exceed maximum", offset));
         }
         self.local_inits.define_locals(count, ty);
         Ok(())
@@ -918,11 +914,7 @@ where
     }
 
     /// Match expected vs. actual operand.
-    fn match_operand(
-        &mut self,
-        actual: ValType,
-        expected: ValType,
-    ) -> Result<(), Error> {
+    fn match_operand(&mut self, actual: ValType, expected: ValType) -> Result<(), Error> {
         self.push_operand(actual)?;
         self.pop_operand(Some(expected))?;
         Ok(())
@@ -1418,9 +1410,8 @@ where
         self.resources
             .check_heap_type(&mut heap_type, self.offset)?;
 
-        let sub_ty = RefType::new(nullable, heap_type).ok_or_else(|| {
-            Error::new("implementation limit: type index too large", self.offset)
-        })?;
+        let sub_ty = RefType::new(nullable, heap_type)
+            .ok_or_else(|| Error::new("implementation limit: type index too large", self.offset))?;
         let top = self.resources.top_type(&heap_type);
         self.check_cast_to_allowed(top)?;
         let sup_ty = RefType::new(true, top).expect("can't panic with non-concrete heap types");
@@ -1559,10 +1550,7 @@ where
             match heap_type {
                 HeapType::Concrete(index) | HeapType::Exact(index) => {
                     index.pack().ok_or_else(|| {
-                        Error::new(
-                            "implementation limit: type index too large",
-                            self.offset,
-                        )
+                        Error::new("implementation limit: type index too large", self.offset)
                     })?
                 }
                 _ => panic!(),
@@ -1676,16 +1664,13 @@ where
     }
 
     fn struct_field_at(&self, struct_type_index: u32, field_index: u32) -> Result<FieldType> {
-        let field_index = usize::try_from(field_index).map_err(|_| {
-            Error::new("unknown field: field index out of bounds", self.offset)
-        })?;
+        let field_index = usize::try_from(field_index)
+            .map_err(|_| Error::new("unknown field: field index out of bounds", self.offset))?;
         self.struct_type_at(struct_type_index)?
             .fields
             .get(field_index)
             .copied()
-            .ok_or_else(|| {
-                Error::new("unknown field: field index out of bounds", self.offset)
-            })
+            .ok_or_else(|| Error::new("unknown field: field index out of bounds", self.offset))
     }
 
     fn mutable_struct_field_at(

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -25,7 +25,7 @@
 #[cfg(feature = "simd")]
 use crate::VisitSimdOperator;
 use crate::{
-    AbstractHeapType, BinaryReaderError, BlockType, BrTable, Catch, ContType, FieldType, FrameKind,
+    AbstractHeapType, Error, BlockType, BrTable, Catch, ContType, FieldType, FrameKind,
     FrameStack, FuncType, GlobalType, Handle, HeapType, Ieee32, Ieee64, MemArg, ModuleArity,
     RefType, Result, ResumeTable, StorageType, StructType, SubType, TableType, TryTable,
     UnpackedIndex, ValType, VisitOperator, WasmFeatures, WasmModuleResources,
@@ -460,7 +460,7 @@ impl OperatorValidator {
             return Ok(());
         }
         if !self.locals.define(count, ty) {
-            return Err(BinaryReaderError::new(
+            return Err(Error::new(
                 "too many locals: locals exceed maximum",
                 offset,
             ));
@@ -922,7 +922,7 @@ where
         &mut self,
         actual: ValType,
         expected: ValType,
-    ) -> Result<(), BinaryReaderError> {
+    ) -> Result<(), Error> {
         self.push_operand(actual)?;
         self.pop_operand(Some(expected))?;
         Ok(())
@@ -1419,7 +1419,7 @@ where
             .check_heap_type(&mut heap_type, self.offset)?;
 
         let sub_ty = RefType::new(nullable, heap_type).ok_or_else(|| {
-            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+            Error::new("implementation limit: type index too large", self.offset)
         })?;
         let top = self.resources.top_type(&heap_type);
         self.check_cast_to_allowed(top)?;
@@ -1559,7 +1559,7 @@ where
             match heap_type {
                 HeapType::Concrete(index) | HeapType::Exact(index) => {
                     index.pack().ok_or_else(|| {
-                        BinaryReaderError::new(
+                        Error::new(
                             "implementation limit: type index too large",
                             self.offset,
                         )
@@ -1677,14 +1677,14 @@ where
 
     fn struct_field_at(&self, struct_type_index: u32, field_index: u32) -> Result<FieldType> {
         let field_index = usize::try_from(field_index).map_err(|_| {
-            BinaryReaderError::new("unknown field: field index out of bounds", self.offset)
+            Error::new("unknown field: field index out of bounds", self.offset)
         })?;
         self.struct_type_at(struct_type_index)?
             .fields
             .get(field_index)
             .copied()
             .ok_or_else(|| {
-                BinaryReaderError::new("unknown field: field index out of bounds", self.offset)
+                Error::new("unknown field: field index out of bounds", self.offset)
             })
     }
 
@@ -3316,7 +3316,7 @@ where
         if let Some(ty) = RefType::new(true, heap_type) {
             self.features
                 .check_ref_type(ty)
-                .map_err(|e| BinaryReaderError::new(e, self.offset))?;
+                .map_err(|e| Error::new(e, self.offset))?;
         }
         self.resources
             .check_heap_type(&mut heap_type, self.offset)?;
@@ -3387,7 +3387,7 @@ where
             HeapType::Concrete(index)
         };
         let ty = ValType::Ref(RefType::new(false, hty).ok_or_else(|| {
-            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+            Error::new("implementation limit: type index too large", self.offset)
         })?);
         self.push_operand(ty)?;
         Ok(())

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -564,7 +564,7 @@ impl Printer<'_, '_> {
                                     self.print_known_custom_section(c.clone())?;
                                 }
                                 Ok(false) => self.print_raw_custom_section(state, c.clone())?,
-                                Err(e) if !e.is::<BinaryReaderError>() => return Err(e),
+                                Err(e) if !e.is::<wasmparser::Error>() => return Err(e),
                                 Err(e) => {
                                     let msg = format!(
                                         "failed to parse custom section `{}`: {e}",

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -6,9 +6,7 @@ use std::fmt::Write;
 use std::mem;
 use std::time::Instant;
 use wasm_tools::addr2line::Addr2lineModules;
-use wasmparser::{
-    BinaryReaderError, FuncValidatorAllocations, Parser, ValidPayload, Validator, WasmFeatures,
-};
+use wasmparser::{FuncValidatorAllocations, Parser, ValidPayload, Validator, WasmFeatures};
 
 /// Validate a WebAssembly binary
 ///
@@ -106,7 +104,7 @@ impl Opts {
             Ok(()) => return Ok(()),
             Err(e) => e,
         };
-        let offset = match error.downcast_ref::<BinaryReaderError>() {
+        let offset = match error.downcast_ref::<wasmparser::Error>() {
             Some(err) => err.offset(),
             None => return Err(error.into()),
         };


### PR DESCRIPTION
This type hasn't been particularly `BinaryReader`-specific for a long time, being returned by e.g. `Validator` which can be used without any direct use of a `BinaryReader`.

- Move `crate::binary_reader::BinaryReaderError` to `crate::error::Error`
- Add `crate::BianryReaderError` type alias for backward compatibility
- Update references in other workspace crates