### PR TITLE
Refactor `KebabStr` to not require unsafe code

### DIFF
--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -42,7 +42,6 @@ extern crate std;
 /// like `String`. This custom prelude helps bring those types into scope to
 /// avoid having to import each of them manually.
 mod prelude {
-    pub use alloc::borrow::ToOwned;
     pub use alloc::boxed::Box;
     pub use alloc::format;
     pub use alloc::string::{String, ToString};

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -25,8 +25,8 @@ use crate::{
 };
 use core::mem;
 
-fn to_kebab_str<'a>(s: &'a str, desc: &str, offset: usize) -> Result<&'a KebabStr> {
-    match KebabStr::new(s) {
+fn to_kebab_string<'a>(s: &'a str, desc: &str, offset: usize) -> Result<KebabString> {
+    match KebabString::new(s) {
         Some(s) => Ok(s),
         None => {
             if s.is_empty() {
@@ -3196,8 +3196,8 @@ impl ComponentState {
             .params
             .iter()
             .map(|(name, ty)| {
-                let name: &KebabStr = to_kebab_str(name, "function parameter", offset)?;
-                if !set.insert(name) {
+                let name = to_kebab_string(name, "function parameter", offset)?;
+                if !set.insert(name.clone()) {
                     bail!(
                         offset,
                         "function parameter name `{name}` conflicts with previous parameter name `{prev}`",
@@ -3207,7 +3207,7 @@ impl ComponentState {
 
                 let ty = self.create_component_val_type(*ty, offset)?;
                 info.combine(ty.info(types), offset)?;
-                Ok((name.to_owned(), ty))
+                Ok((name, ty))
             })
             .collect::<Result<_>>()?;
 
@@ -4175,10 +4175,10 @@ impl ComponentState {
         }
 
         for (name, ty) in fields {
-            let name = to_kebab_str(name, "record field", offset)?;
+            let kebab = to_kebab_string(name, "record field", offset)?;
             let ty = self.create_component_val_type(*ty, offset)?;
 
-            match field_map.entry(name.to_owned()) {
+            match field_map.entry(kebab) {
                 Entry::Occupied(e) => bail!(
                     offset,
                     "record field name `{name}` conflicts with previous field name `{prev}`",
@@ -4219,14 +4219,14 @@ impl ComponentState {
         }
 
         for case in cases {
-            let name = to_kebab_str(case.name, "variant case", offset)?;
+            let name = to_kebab_string(case.name, "variant case", offset)?;
 
             let ty = case
                 .ty
                 .map(|ty| self.create_component_val_type(ty, offset))
                 .transpose()?;
 
-            match case_map.entry(name.to_owned()) {
+            match case_map.entry(name) {
                 Entry::Occupied(e) => bail!(
                     offset,
                     "variant case name `{name}` conflicts with previous case name `{prev}`",
@@ -4283,12 +4283,11 @@ impl ComponentState {
         }
 
         for name in names {
-            let name = to_kebab_str(name, "flag", offset)?;
-            if !names_set.insert(name.to_owned()) {
+            let kebab = to_kebab_string(name, "flag", offset)?;
+            if let Some(prev) = names_set.replace(kebab) {
                 bail!(
                     offset,
                     "flag name `{name}` conflicts with previous flag name `{prev}`",
-                    prev = names_set.get(name).unwrap()
                 );
             }
         }
@@ -4312,12 +4311,11 @@ impl ComponentState {
         tags.reserve(cases.len());
 
         for tag in cases {
-            let tag = to_kebab_str(tag, "enum tag", offset)?;
-            if !tags.insert(tag.to_owned()) {
+            let kebab = to_kebab_string(tag, "enum tag", offset)?;
+            if let Some(prev) = tags.replace(kebab) {
                 bail!(
                     offset,
                     "enum tag name `{tag}` conflicts with previous tag name `{prev}`",
-                    prev = tags.get(tag).unwrap()
                 );
             }
         }
@@ -4885,7 +4883,7 @@ impl ComponentNameContext {
     fn validate_resource_name(
         &self,
         id: AliasableResourceId,
-        name: &KebabStr,
+        name: KebabStr<'_>,
         offset: usize,
     ) -> Result<()> {
         let expected_name_idx = match self.resource_name_map.get(&id) {
@@ -4901,8 +4899,7 @@ impl ComponentNameContext {
         if name.as_str() != expected_name {
             bail!(
                 offset,
-                "function does not match expected \
-                         resource name `{expected_name}`"
+                "function does not match expected resource name `{expected_name}`"
             );
         }
         Ok(())

--- a/crates/wasmparser/src/validator/names.rs
+++ b/crates/wasmparser/src/validator/names.rs
@@ -3,7 +3,6 @@
 
 use crate::prelude::*;
 use crate::{Result, WasmFeatures};
-use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
@@ -18,26 +17,21 @@ use semver::Version;
 ///
 /// It also provides an equality and hashing implementation
 /// that ignores ASCII case.
-#[derive(Debug, Eq)]
+#[derive(Debug, Eq, Clone, Copy)]
 #[repr(transparent)]
-pub struct KebabStr(str);
+pub struct KebabStr<'a>(&'a str);
 
-impl KebabStr {
+impl<'a> KebabStr<'a> {
     /// Creates a new kebab string slice.
     ///
     /// Returns `None` if the given string is not a valid kebab string.
-    pub fn new<'a>(s: impl AsRef<str> + 'a) -> Option<&'a Self> {
+    pub fn new(s: &'a str) -> Option<Self> {
         let s = Self::new_unchecked(s);
         if s.is_kebab_case() { Some(s) } else { None }
     }
 
-    pub(crate) fn new_unchecked<'a>(s: impl AsRef<str> + 'a) -> &'a Self {
-        // Safety: `KebabStr` is a transparent wrapper around `str`
-        // Therefore transmuting `&str` to `&KebabStr` is safe.
-        #[allow(unsafe_code)]
-        unsafe {
-            core::mem::transmute::<_, &Self>(s.as_ref())
-        }
+    pub(crate) fn new_unchecked(s: &'a str) -> Self {
+        Self(s)
     }
 
     /// Gets the underlying string slice.
@@ -77,7 +71,7 @@ impl KebabStr {
     }
 }
 
-impl Deref for KebabStr {
+impl Deref for KebabStr<'_> {
     type Target = str;
 
     fn deref(&self) -> &str {
@@ -85,7 +79,7 @@ impl Deref for KebabStr {
     }
 }
 
-impl PartialEq for KebabStr {
+impl PartialEq for KebabStr<'_> {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             return false;
@@ -97,13 +91,13 @@ impl PartialEq for KebabStr {
     }
 }
 
-impl PartialEq<KebabString> for KebabStr {
+impl PartialEq<KebabString> for KebabStr<'_> {
     fn eq(&self, other: &KebabString) -> bool {
-        self.eq(other.as_kebab_str())
+        self.eq(&other.as_kebab_str())
     }
 }
 
-impl Ord for KebabStr {
+impl Ord for KebabStr<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_chars = self.chars().map(|c| c.to_ascii_lowercase());
         let other_chars = other.chars().map(|c| c.to_ascii_lowercase());
@@ -111,13 +105,13 @@ impl Ord for KebabStr {
     }
 }
 
-impl PartialOrd for KebabStr {
+impl PartialOrd for KebabStr<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Hash for KebabStr {
+impl Hash for KebabStr<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.len().hash(state);
 
@@ -127,17 +121,9 @@ impl Hash for KebabStr {
     }
 }
 
-impl fmt::Display for KebabStr {
+impl fmt::Display for KebabStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (self as &str).fmt(f)
-    }
-}
-
-impl ToOwned for KebabStr {
-    type Owned = KebabString;
-
-    fn to_owned(&self) -> Self::Owned {
-        self.to_kebab_string()
+        self.as_str().fmt(f)
     }
 }
 
@@ -171,46 +157,38 @@ impl KebabString {
     }
 
     /// Converts the kebab string to a kebab string slice.
-    pub fn as_kebab_str(&self) -> &KebabStr {
-        // Safety: internal string is always valid kebab-case
+    pub fn as_kebab_str(&self) -> KebabStr<'_> {
         KebabStr::new_unchecked(self.as_str())
     }
 }
 
 impl Deref for KebabString {
-    type Target = KebabStr;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_kebab_str()
-    }
-}
-
-impl Borrow<KebabStr> for KebabString {
-    fn borrow(&self) -> &KebabStr {
-        self.as_kebab_str()
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.as_str()
     }
 }
 
 impl Ord for KebabString {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.as_kebab_str().cmp(other.as_kebab_str())
+        self.as_kebab_str().cmp(&other.as_kebab_str())
     }
 }
 
 impl PartialOrd for KebabString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.as_kebab_str().partial_cmp(other.as_kebab_str())
+        self.as_kebab_str().partial_cmp(&other.as_kebab_str())
     }
 }
 
 impl PartialEq for KebabString {
     fn eq(&self, other: &Self) -> bool {
-        self.as_kebab_str().eq(other.as_kebab_str())
+        self.as_kebab_str().eq(&other.as_kebab_str())
     }
 }
 
-impl PartialEq<KebabStr> for KebabString {
-    fn eq(&self, other: &KebabStr) -> bool {
+impl PartialEq<KebabStr<'_>> for KebabString {
+    fn eq(&self, other: &KebabStr<'_>) -> bool {
         self.as_kebab_str().eq(other)
     }
 }
@@ -274,9 +252,9 @@ enum ParsedComponentNameKind {
 #[derive(Debug, Clone)]
 pub enum ComponentNameKind<'a> {
     /// `a-b-c`
-    Label(&'a KebabStr),
+    Label(KebabStr<'a>),
     /// `[constructor]a-b`
-    Constructor(&'a KebabStr),
+    Constructor(KebabStr<'a>),
     /// `[method]a-b.c-d`
     #[allow(missing_docs)]
     Method(ResourceFunc<'a>),
@@ -496,13 +474,13 @@ impl<'a> ResourceFunc<'a> {
     }
 
     /// Returns the resource name or the `a` in `a.b`
-    pub fn resource(&self) -> &'a KebabStr {
+    pub fn resource(&self) -> KebabStr<'a> {
         let dot = self.0.find('.').unwrap();
         KebabStr::new_unchecked(&self.0[..dot])
     }
 
     /// Returns the method name or the `b` in `a.b`
-    pub fn method(&self) -> &'a KebabStr {
+    pub fn method(&self) -> KebabStr<'a> {
         let dot = self.0.find('.').unwrap();
         KebabStr::new_unchecked(&self.0[dot + 1..])
     }
@@ -519,27 +497,27 @@ impl<'a> InterfaceName<'a> {
     }
 
     /// Returns the `a:b` in `a:b:c/d/e`
-    pub fn namespace(&self) -> &'a KebabStr {
+    pub fn namespace(&self) -> KebabStr<'a> {
         let colon = self.0.rfind(':').unwrap();
         KebabStr::new_unchecked(&self.0[..colon])
     }
 
     /// Returns the `c` in `a:b:c/d/e`
-    pub fn package(&self) -> &'a KebabStr {
+    pub fn package(&self) -> KebabStr<'a> {
         let colon = self.0.rfind(':').unwrap();
         let slash = self.0.find('/').unwrap();
         KebabStr::new_unchecked(&self.0[colon + 1..slash])
     }
 
     /// Returns the `d` in `a:b:c/d/e`.
-    pub fn interface(&self) -> &'a KebabStr {
+    pub fn interface(&self) -> KebabStr<'a> {
         let projection = self.projection();
         let slash = projection.find('/').unwrap_or(projection.len());
-        KebabStr::new_unchecked(&projection[..slash])
+        KebabStr::new_unchecked(&projection.0[..slash])
     }
 
     /// Returns the `d/e` in `a:b:c/d/e`
-    pub fn projection(&self) -> &'a KebabStr {
+    pub fn projection(&self) -> KebabStr<'a> {
         let slash = self.0.find('/').unwrap();
         let at = self.0.find('@').unwrap_or(self.0.len());
         KebabStr::new_unchecked(&self.0[slash + 1..at])
@@ -844,7 +822,7 @@ impl<'a> ComponentNameParser<'a> {
         Some(a)
     }
 
-    fn kebab(&self, s: &'a str) -> Result<&'a KebabStr> {
+    fn kebab(&self, s: &'a str) -> Result<KebabStr<'a>> {
         match KebabStr::new(s) {
             Some(name) => Ok(name),
             None => bail!(self.offset, "`{s}` is not in kebab case"),
@@ -878,7 +856,7 @@ impl<'a> ComponentNameParser<'a> {
         ret
     }
 
-    fn take_kebab(&mut self) -> Result<&'a KebabStr> {
+    fn take_kebab(&mut self) -> Result<KebabStr<'a>> {
         self.next
             .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-'))
             .map(|i| {
@@ -889,7 +867,7 @@ impl<'a> ComponentNameParser<'a> {
             .unwrap_or_else(|| self.expect_kebab())
     }
 
-    fn take_lowercase_kebab(&mut self) -> Result<&'a KebabStr> {
+    fn take_lowercase_kebab(&mut self) -> Result<KebabStr<'a>> {
         let kebab = self.take_kebab()?;
         if let Some(c) = kebab
             .chars()
@@ -903,7 +881,7 @@ impl<'a> ComponentNameParser<'a> {
         Ok(kebab)
     }
 
-    fn expect_kebab(&mut self) -> Result<&'a KebabStr> {
+    fn expect_kebab(&mut self) -> Result<KebabStr<'a>> {
         let s = self.take_rest();
         self.kebab(s)
     }


### PR DESCRIPTION
This requires changing `KebabStr`'s implementation internally and adjusting callers in various locations, but the overall concept remains the same. The main difference now is that `KebabStr` and `KebabString` no longer have a `Borrow` or `ToOwned` relationship, and `KebabString` no longer derefs to `KebabStr`. For making wasmparser 100% safe this seems like a reasonable tradeoff.

This additionally fixes a problem with the previous signature of `KebabStr::new_unchecked` which enabled UB at runtime if called with owned types such as `String` or `Box<str>` or such. While `wasmparser` never actually did this it was still an unsound API to expose to users, so worthwhile to fix.