### PR TITLE
wasmparser: Add Error::missing_wasm_feature

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -818,21 +818,21 @@ impl<'a> BinaryReader<'a> {
                 visitor.visit_else()
             }
             0x06 => {
-                if !self.legacy_exceptions() {
-                    bail!(
-                        pos,
-                        "legacy_exceptions feature required for try instruction"
-                    );
-                }
+                #[cfg(feature = "features")]
+                require_feature::legacy_exceptions(
+                    self.features,
+                    "legacy_exceptions feature required for try instruction",
+                    pos,
+                )?;
                 visitor.visit_try(self.read_block_type()?)
             }
             0x07 => {
-                if !self.legacy_exceptions() {
-                    bail!(
-                        pos,
-                        "legacy_exceptions feature required for catch instruction"
-                    );
-                }
+                #[cfg(feature = "features")]
+                require_feature::legacy_exceptions(
+                    self.features,
+                    "legacy_exceptions feature required for catch instruction",
+                    pos,
+                )?;
                 match self.expect_frame(visitor, FrameKind::LegacyCatch, "catch") {
                     Ok(()) => (),
                     Err(_) => self.expect_frame(visitor, FrameKind::LegacyTry, "catch")?,
@@ -862,12 +862,12 @@ impl<'a> BinaryReader<'a> {
                 visitor.visit_delegate(self.read_var_u32()?)
             }
             0x19 => {
-                if !self.legacy_exceptions() {
-                    bail!(
-                        pos,
-                        "legacy_exceptions feature required for catch_all instruction"
-                    );
-                }
+                #[cfg(feature = "features")]
+                require_feature::legacy_exceptions(
+                    self.features,
+                    "legacy_exceptions feature required for catch_all instruction",
+                    pos,
+                )?;
                 match self.expect_frame(visitor, FrameKind::LegacyCatch, "catch_all") {
                     Ok(()) => (),
                     Err(_) => self.expect_frame(visitor, FrameKind::LegacyTry, "catch_all")?,
@@ -1939,7 +1939,7 @@ impl<'a> BinaryReader<'a> {
             0 => Ok(Ordering::SeqCst),
             1 => Ok(Ordering::AcqRel),
             x => Err(Error::new(
-                &format!("invalid atomic consistency ordering {x}"),
+                format!("invalid atomic consistency ordering {x}"),
                 self.original_position() - 1,
             )),
         }

--- a/crates/wasmparser/src/error.rs
+++ b/crates/wasmparser/src/error.rs
@@ -13,10 +13,10 @@ pub struct Error {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ErrorInner {
-    pub(crate) message: String,
-    pub(crate) kind: ErrorKind,
-    pub(crate) offset: usize,
-    pub(crate) needed_hint: Option<usize>,
+    message: String,
+    kind: ErrorKind,
+    offset: usize,
+    needed_hint: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -96,5 +96,14 @@ impl Error {
 
     pub(crate) fn set_message(&mut self, message: &str) {
         self.inner.message = message.to_string();
+    }
+
+    pub(crate) fn needed_hint(&self) -> Option<usize> {
+        self.inner.needed_hint
+    }
+
+    pub(crate) fn without_needed_hint(mut self) -> Self {
+        self.inner.needed_hint = None;
+        self
     }
 }

--- a/crates/wasmparser/src/error.rs
+++ b/crates/wasmparser/src/error.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use crate::WasmFeatures;
 use crate::prelude::*;
 
 /// A binary reader for WebAssembly modules.
@@ -23,6 +24,7 @@ pub(crate) struct ErrorInner {
 pub(crate) enum ErrorKind {
     Uncategorized,
     InvalidHeapType,
+    WasmFeature(WasmFeatures),
 }
 
 /// The result for `BinaryReader` operations.
@@ -64,6 +66,15 @@ impl Error {
     }
 
     #[cold]
+    pub(crate) fn wasm_feature(
+        feature: crate::WasmFeatures,
+        msg: impl fmt::Display,
+        offset: usize,
+    ) -> Self {
+        Self::_new(ErrorKind::WasmFeature(feature), msg.to_string(), offset)
+    }
+
+    #[cold]
     pub(crate) fn fmt(args: fmt::Arguments<'_>, offset: usize) -> Self {
         Error::new(args.to_string(), offset)
     }
@@ -75,7 +86,7 @@ impl Error {
         err
     }
 
-    pub(crate) fn kind(&mut self) -> ErrorKind {
+    pub(crate) fn kind(&self) -> ErrorKind {
         self.inner.kind
     }
 
@@ -89,13 +100,27 @@ impl Error {
         self.inner.offset
     }
 
+    /// Returns `Some` if this error is due to a disabled Wasm feature.
+    ///
+    /// If the `features` crate feature is enabled, a returned [`WasmFeatures`]
+    /// will contain a feature that could be enabled to prevent this error.
+    ///
+    /// **Note:** This is not comprehensive; `None` may be returned in some
+    /// cases where enabling a feature could avoid the error.
+    pub fn missing_wasm_feature(&self) -> Option<WasmFeatures> {
+        match self.inner.kind {
+            ErrorKind::WasmFeature(features) => Some(features),
+            _ => None,
+        }
+    }
+
     #[cfg(all(feature = "validate", feature = "component-model"))]
     pub(crate) fn add_context(&mut self, context: String) {
         self.inner.message = format!("{context}\n{}", self.inner.message);
     }
 
-    pub(crate) fn set_message(&mut self, message: &str) {
-        self.inner.message = message.to_string();
+    pub(crate) fn set_message(&mut self, message: impl Into<String>) {
+        self.inner.message = message.into();
     }
 
     pub(crate) fn needed_hint(&self) -> Option<usize> {

--- a/crates/wasmparser/src/error.rs
+++ b/crates/wasmparser/src/error.rs
@@ -21,8 +21,8 @@ pub(crate) struct ErrorInner {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ErrorKind {
-    Custom,
-    Invalid,
+    Uncategorized,
+    InvalidHeapType,
 }
 
 /// The result for `BinaryReader` operations.
@@ -55,12 +55,12 @@ impl Error {
 
     #[cold]
     pub(crate) fn new(message: impl Into<String>, offset: usize) -> Self {
-        Self::_new(ErrorKind::Custom, message.into(), offset)
+        Self::_new(ErrorKind::Uncategorized, message.into(), offset)
     }
 
     #[cold]
-    pub(crate) fn invalid(msg: &'static str, offset: usize) -> Self {
-        Self::_new(ErrorKind::Invalid, msg.into(), offset)
+    pub(crate) fn invalid_heap_type(msg: &'static str, offset: usize) -> Self {
+        Self::_new(ErrorKind::InvalidHeapType, msg.into(), offset)
     }
 
     #[cold]

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -105,6 +105,34 @@ macro_rules! define_wasm_features {
             }
         }
         pub(crate) use foreach_wasm_feature;
+
+        #[allow(dead_code)]
+        pub(crate) mod require_feature {
+            use crate::Error;
+            use super::WasmFeatures;
+
+            $(
+                #[inline]
+                #[doc = "Returns an error if [`WasmFeatures::"]
+                #[doc = stringify!($const)]
+                #[doc = "`] is not enabled in `features`."]
+                pub fn $field(
+                    features: WasmFeatures,
+                    msg: impl core::fmt::Display,
+                    offset: usize,
+                ) -> Result<(), Error> {
+                    if features.$field() {
+                        Ok(())
+                    } else {
+                        #[cfg(feature = "features")]
+                        let feature = WasmFeatures::$const;
+                        #[cfg(not(feature = "features"))]
+                        let feature = WasmFeatures::default();
+                        Err(Error::wasm_feature(feature, msg, offset))
+                    }
+                }
+            )*
+        }
     };
 }
 

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -656,7 +656,7 @@ impl Parser {
                 // If our error doesn't look like it can be resolved with more
                 // data being pulled down, then propagate it, otherwise switch
                 // the error to "feed me please"
-                match e.inner.needed_hint {
+                match e.needed_hint() {
                     Some(hint) => Ok(Chunk::NeedMoreData(usize_to_u64(hint))),
                     None => Err(e),
                 }
@@ -1238,7 +1238,7 @@ fn section<'a, T>(
     // clear the hint for "need this many more bytes" here because we already
     // read all the bytes, so it's not possible to read more bytes if this
     // fails.
-    let reader = ctor(reader).map_err(clear_hint)?;
+    let reader = ctor(reader).map_err(Error::without_needed_hint)?;
     Ok(variant(reader))
 }
 
@@ -1259,7 +1259,7 @@ where
     // We can't recover from "unexpected eof" here because our entire section is
     // already resident in memory, so clear the hint for how many more bytes are
     // expected.
-    let ret = content.read().map_err(clear_hint)?;
+    let ret = content.read().map_err(Error::without_needed_hint)?;
     if !content.eof() {
         bail!(
             content.original_position(),
@@ -1480,11 +1480,6 @@ impl fmt::Debug for Payload<'_> {
             End(offset) => f.debug_tuple("End").field(offset).finish(),
         }
     }
-}
-
-fn clear_hint(mut err: Error) -> Error {
-    err.inner.needed_hint = None;
-    err
 }
 
 #[cfg(test)]

--- a/crates/wasmparser/src/readers/core/imports.rs
+++ b/crates/wasmparser/src/readers/core/imports.rs
@@ -95,13 +95,13 @@ impl<'a> FromReader<'a> for Imports<'a> {
         let discriminator = reader.peek_bytes(1)?[0];
         match (single_item_name, discriminator) {
             ("", 0x7F) => {
-                if !reader.compact_imports() {
-                    bail!(
-                        reader.original_position(),
-                        "invalid leading byte 0x7F with compact imports \
-                         proposal disabled"
-                    );
-                }
+                #[cfg(feature = "features")]
+                crate::require_feature::compact_imports(
+                    reader.features(),
+                    "invalid leading byte 0x7F with compact imports \
+                     proposal disabled",
+                    reader.original_position(),
+                )?;
                 // Compact encoding 1: one module name, many item names / types
                 reader.read_bytes(1)?;
                 // FIXME(#188) shouldn't need to skip here
@@ -119,13 +119,13 @@ impl<'a> FromReader<'a> for Imports<'a> {
                 })
             }
             ("", 0x7E) => {
-                if !reader.compact_imports() {
-                    bail!(
-                        reader.original_position(),
-                        "invalid leading byte 0x7E with compact imports \
-                         proposal disabled"
-                    );
-                }
+                #[cfg(feature = "features")]
+                crate::require_feature::compact_imports(
+                    reader.features(),
+                    "invalid leading byte 0x7E with compact imports \
+                     proposal disabled",
+                    reader.original_position(),
+                )?;
                 // Compact encoding 2: one module name / type, many item names
                 reader.read_bytes(1)?;
                 let ty: TypeRef = reader.read()?;

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1798,7 +1798,7 @@ impl<'a> FromReader<'a> for ValType {
                 // that's the "root" of what was being parsed rather than
                 // reference types.
                 let refty = reader.read().map_err(|mut e| {
-                    if let ErrorKind::Invalid = e.kind() {
+                    if let ErrorKind::InvalidHeapType = e.kind() {
                         e.set_message("invalid value type");
                     }
                     e
@@ -1826,7 +1826,7 @@ impl<'a> FromReader<'a> for RefType {
                 // that's the "root" of what was being parsed rather than
                 // heap types.
                 let hty = reader.read().map_err(|mut e| {
-                    if let ErrorKind::Invalid = e.kind() {
+                    if let ErrorKind::InvalidHeapType = e.kind() {
                         e.set_message("malformed reference type");
                     }
                     e
@@ -1877,7 +1877,7 @@ impl<'a> FromReader<'a> for HeapType {
                     // that's the "root" of what was being parsed rather than
                     // abstract heap types.
                     let ty = reader.read().map_err(|mut e| {
-                        if let ErrorKind::Invalid = e.kind() {
+                        if let ErrorKind::InvalidHeapType = e.kind() {
                             e.set_message("invalid heap type");
                         }
                         e
@@ -1908,7 +1908,7 @@ impl<'a> FromReader<'a> for AbstractHeapType {
             0x68 => Ok(Cont),
             0x75 => Ok(NoCont),
             _ => {
-                return Err(Error::invalid(
+                return Err(Error::invalid_heap_type(
                     "invalid abstract heap type",
                     reader.original_position() - 1,
                 ));

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -85,9 +85,7 @@ pub trait WasmModuleResources {
         features: &WasmFeatures,
         offset: usize,
     ) -> Result<(), Error> {
-        features
-            .check_value_type(*t)
-            .map_err(|s| Error::new(s, offset))?;
+        features.check_value_type(*t, offset)?;
         match t {
             ValType::Ref(r) => self.check_ref_type(r, offset),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => Ok(()),

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -17,6 +17,7 @@ use crate::prelude::*;
 use crate::{
     AbstractHeapType, Encoding, Error, FromReader, FunctionBody, HeapType, Parser, Payload,
     RefType, Result, SectionLimited, ValType, WASM_MODULE_VERSION, WasmFeatures, limits::*,
+    require_feature,
 };
 use ::core::mem;
 use ::core::ops::Range;
@@ -235,31 +236,19 @@ impl WasmFeatures {
     ///
     /// To check that reference types are valid, we need access to the module
     /// types. Use module.check_value_type.
-    pub(crate) fn check_value_type(&self, ty: ValType) -> Result<(), &'static str> {
+    pub(crate) fn check_value_type(&self, ty: ValType, offset: usize) -> Result<()> {
         match ty {
             ValType::I32 | ValType::I64 => Ok(()),
             ValType::F32 | ValType::F64 => {
-                if self.floats() {
-                    Ok(())
-                } else {
-                    Err("floating-point support is disabled")
-                }
+                require_feature::floats(*self, "floating-point support is disabled", offset)
             }
-            ValType::Ref(r) => self.check_ref_type(r),
-            ValType::V128 => {
-                if self.simd() {
-                    Ok(())
-                } else {
-                    Err("SIMD support is not enabled")
-                }
-            }
+            ValType::Ref(r) => self.check_ref_type(r, offset),
+            ValType::V128 => require_feature::simd(*self, "SIMD support is not enabled", offset),
         }
     }
 
-    pub(crate) fn check_ref_type(&self, r: RefType) -> Result<(), &'static str> {
-        if !self.reference_types() {
-            return Err("reference types support is not enabled");
-        }
+    pub(crate) fn check_ref_type(&self, r: RefType, offset: usize) -> Result<()> {
+        require_feature::reference_types(*self, "reference types support is not enabled", offset)?;
         match r.heap_type() {
             HeapType::Concrete(_) => {
                 // Note that `self.gc_types()` is not checked here because
@@ -270,33 +259,43 @@ impl WasmFeatures {
 
                 // Indexed types require either the function-references or gc
                 // proposal as gc implies function references here.
-                if self.function_references() || self.gc() {
+                if self.gc() {
                     Ok(())
                 } else {
-                    Err("function references required for index reference types")
+                    require_feature::function_references(
+                        *self,
+                        "function references required for index reference types",
+                        offset,
+                    )
                 }
             }
             HeapType::Exact(_) => {
                 // Exact types were introduced with the custom descriptors
                 // proposal.
-                if self.custom_descriptors() {
-                    Ok(())
-                } else {
-                    Err("custom descriptors required for exact reference types")
-                }
+                require_feature::custom_descriptors(
+                    *self,
+                    "custom descriptors required for exact reference types",
+                    offset,
+                )
             }
             HeapType::Abstract { shared, ty } => {
                 use AbstractHeapType::*;
-                if shared && !self.shared_everything_threads() {
-                    return Err(
+                if shared {
+                    require_feature::shared_everything_threads(
+                        *self,
                         "shared reference types require the shared-everything-threads proposal",
-                    );
+                        offset,
+                    )?;
                 }
 
                 // Apply the "gc-types" feature which disallows all heap types
                 // except exnref/funcref.
-                if !self.gc_types() && ty != Func && ty != Exn {
-                    return Err("gc types are disallowed but found type which requires gc");
+                if ty != Func && ty != Exn {
+                    require_feature::gc_types(
+                        *self,
+                        "gc types are disallowed but found type which requires gc",
+                        offset,
+                    )?;
                 }
 
                 match (ty, r.is_nullable()) {
@@ -305,44 +304,34 @@ impl WasmFeatures {
 
                     // Non-nullable func/extern references requires the
                     // `function-references` proposal.
-                    (Func | Extern, false) => {
-                        if self.function_references() {
-                            Ok(())
-                        } else {
-                            Err("function references required for non-nullable types")
-                        }
-                    }
+                    (Func | Extern, false) => require_feature::function_references(
+                        *self,
+                        "function references required for non-nullable types",
+                        offset,
+                    ),
 
                     // These types were added in the gc proposal.
                     (Any | None | Eq | Struct | Array | I31 | NoExtern | NoFunc, _) => {
-                        if self.gc() {
-                            Ok(())
-                        } else {
-                            Err("heap types not supported without the gc feature")
-                        }
+                        require_feature::gc(
+                            *self,
+                            "heap types not supported without the gc feature",
+                            offset,
+                        )
                     }
 
                     // These types were added in the exception-handling proposal.
-                    (Exn | NoExn, _) => {
-                        if self.exceptions() {
-                            Ok(())
-                        } else {
-                            Err(
-                                "exception refs not supported without the exception handling feature",
-                            )
-                        }
-                    }
+                    (Exn | NoExn, _) => require_feature::exceptions(
+                        *self,
+                        "exception refs not supported without the exception handling feature",
+                        offset,
+                    ),
 
                     // These types were added in the stack switching proposal.
-                    (Cont | NoCont, _) => {
-                        if self.stack_switching() {
-                            Ok(())
-                        } else {
-                            Err(
-                                "continuation refs not supported without the stack switching feature",
-                            )
-                        }
-                    }
+                    (Cont | NoCont, _) => require_feature::stack_switching(
+                        *self,
+                        "continuation refs not supported without the stack switching feature",
+                        offset,
+                    ),
                 }
             }
         }
@@ -690,14 +679,15 @@ impl Validator {
                 }
             }
             Encoding::Component => {
-                if !self.features.component_model() {
-                    bail!(
-                        range.start,
+                require_feature::component_model(
+                    self.features,
+                    format_args!(
                         "unknown binary version and encoding combination: {num:#x} and 0x1, \
                         note: encoded as a component but the WebAssembly component model feature \
                         is not enabled - enable the feature to allow component validation",
-                    );
-                }
+                    ),
+                    range.start,
+                )?;
                 #[cfg(feature = "component-model")]
                 if num == crate::WASM_COMPONENT_VERSION {
                     self.components
@@ -845,12 +835,11 @@ impl Validator {
     ///
     /// This method should only be called when parsing a module.
     pub fn tag_section(&mut self, section: &crate::TagSectionReader<'_>) -> Result<()> {
-        if !self.features.exceptions() {
-            return Err(Error::new(
-                "exceptions proposal not enabled",
-                section.range().start,
-            ));
-        }
+        require_feature::exceptions(
+            self.features,
+            "exceptions proposal not enabled",
+            section.range().start,
+        )?;
         self.process_module_section(
             section,
             "tag",
@@ -1634,5 +1623,25 @@ mod tests {
     #[test]
     fn reset_fresh_validator() {
         Validator::new().reset();
+    }
+
+    #[cfg(feature = "features")]
+    #[test]
+    fn test_validate_missing_wasm_feature_exceptions_disabled() {
+        let bytes = wat::parse_str(
+            r#"
+            (module
+                (func (throw 0))
+            )
+        "#,
+        )
+        .unwrap();
+
+        let mut validator =
+            Validator::new_with_features(WasmFeatures::default() & !WasmFeatures::EXCEPTIONS);
+        let Err(err) = validator.validate_all(&bytes) else {
+            panic!("should fail validation");
+        };
+        assert_eq!(err.missing_wasm_feature(), Some(WasmFeatures::EXCEPTIONS));
     }
 }

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -21,7 +21,7 @@ use crate::{
     CanonicalFunction, CanonicalOption, ComponentExternName, ComponentExternalKind,
     ComponentOuterAliasKind, ComponentTypeRef, CompositeInnerType, Error, ExternalKind, FuncType,
     GlobalType, InstantiationArgKind, MemoryType, PackedIndex, RefType, Result, SubType, TableType,
-    TypeBounds, ValType, WasmFeatures,
+    TypeBounds, ValType, WasmFeatures, require_feature,
 };
 use core::mem;
 
@@ -382,13 +382,13 @@ impl CanonicalOptions {
         match self.concurrency {
             Concurrency::Sync => {}
 
-            Concurrency::Async { callback: None } if !state.features.cm_async_stackful() => {
-                bail!(
+            Concurrency::Async { callback: None } => {
+                require_feature::cm_async_stackful(
+                    state.features,
+                    "requires the component model async stackful feature",
                     offset,
-                    "requires the component model async stackful feature"
-                )
+                )?;
             }
-            Concurrency::Async { callback: None } => {}
 
             Concurrency::Async {
                 callback: Some(idx),
@@ -620,11 +620,12 @@ impl ComponentState {
                 }
 
                 // Current MVP restriction of the component model.
-                if rep == ValType::I64 && !component.features.cm64() {
-                    bail!(
+                if rep == ValType::I64 {
+                    require_feature::cm64(
+                        component.features,
+                        "resources with `i64` require the `cm64` feature to be enabled",
                         offset,
-                        "resources with `i64` require the `cm64` feature to be enabled"
-                    )
+                    )?;
                 }
                 if rep != ValType::I32 && rep != ValType::I64 {
                     bail!(
@@ -1425,12 +1426,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "`resource.drop` as `async` requires the component model more async builtins feature"
-            )
-        }
+        require_feature::cm_more_async_builtins(
+            self.features,
+            "`resource.drop` as `async` requires the component model more async builtins feature",
+            offset,
+        )?;
         self.resource_at(resource, types, offset)?;
         let id = types.intern_func_type(FuncType::new([ValType::I32], []), offset);
         self.core_funcs.push(id);
@@ -1445,12 +1445,11 @@ impl ComponentState {
     }
 
     fn backpressure_inc(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`backpressure.inc` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`backpressure.inc` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], []), offset));
@@ -1458,12 +1457,11 @@ impl ComponentState {
     }
 
     fn backpressure_dec(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`backpressure.dec` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`backpressure.dec` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], []), offset));
@@ -1477,12 +1475,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`task.return` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`task.return` requires the component model async feature",
+            offset,
+        )?;
 
         let func_ty = ComponentFuncType {
             async_: false,
@@ -1527,12 +1524,11 @@ impl ComponentState {
     }
 
     fn task_cancel(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`task.cancel` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`task.cancel` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], []), offset));
@@ -1545,13 +1541,18 @@ impl ComponentState {
         operation: &str,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() && immediate > 0 {
-            bail!(offset, "`{operation}` immediate must be zero: {immediate}")
-        } else if immediate > 1 {
-            bail!(
+        if immediate > 0 {
+            require_feature::cm_threading(
+                self.features,
+                format_args!("`{operation}` immediate must be zero: {immediate}"),
                 offset,
-                "`{operation}` immediate must be zero or one: {immediate}"
-            )
+            )?;
+            if immediate > 1 {
+                bail!(
+                    offset,
+                    "`{operation}` immediate must be zero or one: {immediate}"
+                )
+            }
         }
         Ok(())
     }
@@ -1563,12 +1564,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`context.get` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`context.get` requires the component model async feature",
+            offset,
+        )?;
         self.validate_context_type(ty, "context.get", offset)?;
         self.validate_context_immediate(i, "context.get", offset)?;
 
@@ -1584,12 +1584,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`context.set` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`context.set` requires the component model async feature",
+            offset,
+        )?;
         self.validate_context_type(ty, "context.set", offset)?;
         self.validate_context_immediate(i, "context.set", offset)?;
 
@@ -1602,12 +1601,13 @@ impl ComponentState {
         match ty {
             ValType::I32 => {}
             ValType::I64 => {
-                if !self.features.cm64() {
-                    bail!(
-                        offset,
+                require_feature::cm64(
+                    self.features,
+                    format_args!(
                         "64-bit `{intrinsic}` requires the component model 64-bit feature"
-                    )
-                }
+                    ),
+                    offset,
+                )?;
                 {}
             }
             _ => bail!(offset, "`{intrinsic}` only supports `i32` or `i64`"),
@@ -1628,12 +1628,11 @@ impl ComponentState {
     }
 
     fn thread_yield(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`thread.yield` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`thread.yield` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], [ValType::I32]), offset));
@@ -1641,12 +1640,11 @@ impl ComponentState {
     }
 
     fn subtask_drop(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`subtask.drop` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`subtask.drop` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
@@ -1654,17 +1652,17 @@ impl ComponentState {
     }
 
     fn subtask_cancel(&mut self, async_: bool, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
+        require_feature::cm_async(
+            self.features,
+            "`subtask.cancel` requires the component model async feature",
+            offset,
+        )?;
+        if async_ {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "async `subtask.cancel` requires the component model more async builtins feature",
                 offset,
-                "`subtask.cancel` requires the component model async feature"
-            )
-        }
-        if async_ && !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "async `subtask.cancel` requires the component model more async builtins feature"
-            )
+            )?;
         }
 
         self.core_funcs
@@ -1673,12 +1671,11 @@ impl ComponentState {
     }
 
     fn stream_new(&mut self, ty: u32, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`stream.new` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`stream.new` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Stream(_) = &types[ty] else {
@@ -1697,12 +1694,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`stream.read` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`stream.read` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Stream(elem_ty) = &types[ty] else {
@@ -1710,11 +1706,12 @@ impl ComponentState {
         };
 
         let options = self.check_options(types, options, offset)?;
-        if options.concurrency.is_sync() && !self.features.cm_more_async_builtins() {
-            bail!(
+        if options.concurrency.is_sync() {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "synchronous `stream.read` requires the component model more async builtins feature",
                 offset,
-                "synchronous `stream.read` requires the component model more async builtins feature"
-            );
+            )?;
         }
         let ty_id = options
             .require_memory_if(offset, || elem_ty.is_some())?
@@ -1737,12 +1734,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`stream.write` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`stream.write` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Stream(elem_ty) = &types[ty] else {
@@ -1750,11 +1746,12 @@ impl ComponentState {
         };
 
         let options = self.check_options(types, options, offset)?;
-        if options.concurrency.is_sync() && !self.features.cm_more_async_builtins() {
-            bail!(
+        if options.concurrency.is_sync() {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "synchronous `stream.write` requires the component model more async builtins feature",
                 offset,
-                "synchronous `stream.write` requires the component model more async builtins feature"
-            );
+            )?;
         }
         let ty_id = options
             .require_memory_if(offset, || elem_ty.is_some())?
@@ -1776,17 +1773,17 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
+        require_feature::cm_async(
+            self.features,
+            "`stream.cancel-read` requires the component model async feature",
+            offset,
+        )?;
+        if cancellable {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "async `stream.cancel-read` requires the component model more async builtins feature",
                 offset,
-                "`stream.cancel-read` requires the component model async feature"
-            )
-        }
-        if cancellable && !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "async `stream.cancel-read` requires the component model more async builtins feature"
-            )
+            )?;
         }
 
         let ty = self.defined_type_at(ty, offset)?;
@@ -1806,17 +1803,17 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
+        require_feature::cm_async(
+            self.features,
+            "`stream.cancel-write` requires the component model async feature",
+            offset,
+        )?;
+        if cancellable {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "async `stream.cancel-write` requires the component model more async builtins feature",
                 offset,
-                "`stream.cancel-write` requires the component model async feature"
-            )
-        }
-        if cancellable && !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "async `stream.cancel-write` requires the component model more async builtins feature"
-            )
+            )?;
         }
 
         let ty = self.defined_type_at(ty, offset)?;
@@ -1835,12 +1832,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`stream.drop-readable` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`stream.drop-readable` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Stream(_) = &types[ty] else {
@@ -1858,12 +1854,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`stream.drop-writable` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`stream.drop-writable` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Stream(_) = &types[ty] else {
@@ -1876,12 +1871,11 @@ impl ComponentState {
     }
 
     fn future_new(&mut self, ty: u32, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`future.new` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`future.new` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Future(_) = &types[ty] else {
@@ -1900,12 +1894,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`future.read` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`future.read` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Future(elem_ty) = &types[ty] else {
@@ -1913,11 +1906,12 @@ impl ComponentState {
         };
 
         let options = self.check_options(types, options, offset)?;
-        if options.concurrency.is_sync() && !self.features.cm_more_async_builtins() {
-            bail!(
+        if options.concurrency.is_sync() {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "synchronous `future.read` requires the component model more async builtins feature",
                 offset,
-                "synchronous `future.read` requires the component model more async builtins feature"
-            );
+            )?;
         }
         let ty_id = options
             .require_memory_if(offset, || elem_ty.is_some())?
@@ -1940,12 +1934,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`future.write` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`future.write` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Future(elem_ty) = &types[ty] else {
@@ -1953,11 +1946,12 @@ impl ComponentState {
         };
 
         let options = self.check_options(types, &options, offset)?;
-        if options.concurrency.is_sync() && !self.features.cm_more_async_builtins() {
-            bail!(
+        if options.concurrency.is_sync() {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "synchronous `future.write` requires the component model more async builtins feature",
                 offset,
-                "synchronous `future.write` requires the component model more async builtins feature"
-            );
+            )?;
         }
         let ty_id = options
             .require_memory_if(offset, || elem_ty.is_some())?
@@ -1978,17 +1972,17 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
+        require_feature::cm_async(
+            self.features,
+            "`future.cancel-read` requires the component model async feature",
+            offset,
+        )?;
+        if cancellable {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "async `future.cancel-read` requires the component model more async builtins feature",
                 offset,
-                "`future.cancel-read` requires the component model async feature"
-            )
-        }
-        if cancellable && !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "async `future.cancel-read` requires the component model more async builtins feature"
-            )
+            )?;
         }
 
         let ty = self.defined_type_at(ty, offset)?;
@@ -2008,17 +2002,17 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
+        require_feature::cm_async(
+            self.features,
+            "`future.cancel-write` requires the component model async feature",
+            offset,
+        )?;
+        if cancellable {
+            require_feature::cm_more_async_builtins(
+                self.features,
+                "async `future.cancel-write` requires the component model more async builtins feature",
                 offset,
-                "`future.cancel-write` requires the component model async feature"
-            )
-        }
-        if cancellable && !self.features.cm_more_async_builtins() {
-            bail!(
-                offset,
-                "async `future.cancel-write` requires the component model more async builtins feature"
-            )
+            )?;
         }
 
         let ty = self.defined_type_at(ty, offset)?;
@@ -2037,12 +2031,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`future.drop-readable` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`future.drop-readable` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Future(_) = &types[ty] else {
@@ -2060,12 +2053,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`future.drop-writable` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`future.drop-writable` requires the component model async feature",
+            offset,
+        )?;
 
         let ty = self.defined_type_at(ty, offset)?;
         let ComponentDefinedType::Future(_) = &types[ty] else {
@@ -2083,12 +2075,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_error_context() {
-            bail!(
-                offset,
-                "`error-context.new` requires the component model error-context feature"
-            )
-        }
+        require_feature::cm_error_context(
+            self.features,
+            "`error-context.new` requires the component model error-context feature",
+            offset,
+        )?;
 
         let ty_id = self
             .check_options(types, &options, offset)?
@@ -2111,12 +2102,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_error_context() {
-            bail!(
-                offset,
-                "`error-context.debug-message` requires the component model error-context feature"
-            )
-        }
+        require_feature::cm_error_context(
+            self.features,
+            "`error-context.debug-message` requires the component model error-context feature",
+            offset,
+        )?;
 
         let ty_id = self
             .check_options(types, &options, offset)?
@@ -2131,12 +2121,11 @@ impl ComponentState {
     }
 
     fn error_context_drop(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_error_context() {
-            bail!(
-                offset,
-                "`error-context.drop` requires the component model error-context feature"
-            )
-        }
+        require_feature::cm_error_context(
+            self.features,
+            "`error-context.drop` requires the component model error-context feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
@@ -2144,12 +2133,11 @@ impl ComponentState {
     }
 
     fn waitable_set_new(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`waitable-set.new` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`waitable-set.new` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], [ValType::I32]), offset));
@@ -2162,12 +2150,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`waitable-set.wait` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`waitable-set.wait` requires the component model async feature",
+            offset,
+        )?;
 
         self.cabi_memory_at(memory, offset)?;
         let memory64 = self.memory_at(memory, offset)?.memory64;
@@ -2184,12 +2171,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`waitable-set.poll` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`waitable-set.poll` requires the component model async feature",
+            offset,
+        )?;
 
         self.cabi_memory_at(memory, offset)?;
         let memory64 = self.memory_at(memory, offset)?.memory64;
@@ -2201,12 +2187,11 @@ impl ComponentState {
     }
 
     fn waitable_set_drop(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`waitable-set.drop` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`waitable-set.drop` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
@@ -2214,12 +2199,11 @@ impl ComponentState {
     }
 
     fn waitable_join(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_async() {
-            bail!(
-                offset,
-                "`waitable.join` requires the component model async feature"
-            )
-        }
+        require_feature::cm_async(
+            self.features,
+            "`waitable.join` requires the component model async feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32; 2], []), offset));
@@ -2227,12 +2211,11 @@ impl ComponentState {
     }
 
     fn thread_index(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.index` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.index` requires the component model threading feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], [ValType::I32]), offset));
@@ -2246,12 +2229,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.new-indirect` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.new-indirect` requires the component model threading feature",
+            offset,
+        )?;
 
         let core_type_id = match self.core_type_at(func_ty_index, offset)? {
             ComponentCoreTypeId::Sub(c) => c,
@@ -2304,12 +2286,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.suspend_to_suspended` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.suspend_to_suspended` requires the component model threading feature",
+            offset,
+        )?;
 
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], [ValType::I32]), offset));
@@ -2322,12 +2303,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.suspend` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.suspend` requires the component model threading feature",
+            offset,
+        )?;
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([], [ValType::I32]), offset));
         Ok(())
@@ -2339,24 +2319,22 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.suspend_to` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.suspend_to` requires the component model threading feature",
+            offset,
+        )?;
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], [ValType::I32]), offset));
         Ok(())
     }
 
     fn thread_unsuspend(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.unsuspend` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.unsuspend` requires the component model threading feature",
+            offset,
+        )?;
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
         Ok(())
@@ -2368,12 +2346,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_threading() {
-            bail!(
-                offset,
-                "`thread.yield_to_suspended` requires the component model threading feature"
-            )
-        }
+        require_feature::cm_threading(
+            self.features,
+            "`thread.yield_to_suspended` requires the component model threading feature",
+            offset,
+        )?;
         self.core_funcs
             .push(types.intern_func_type(FuncType::new([ValType::I32], [ValType::I32]), offset));
         Ok(())
@@ -2409,12 +2386,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.shared_everything_threads() {
-            bail!(
-                offset,
-                "`thread.spawn-ref` requires the shared-everything-threads proposal"
-            )
-        }
+        require_feature::shared_everything_threads(
+            self.features,
+            "`thread.spawn-ref` requires the shared-everything-threads proposal",
+            offset,
+        )?;
         let core_type_id = self.validate_spawn_type(func_ty_index, types, offset)?;
 
         // Insert the core function.
@@ -2437,12 +2413,11 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.shared_everything_threads() {
-            bail!(
-                offset,
-                "`thread.spawn-indirect` requires the shared-everything-threads proposal"
-            )
-        }
+        require_feature::shared_everything_threads(
+            self.features,
+            "`thread.spawn-indirect` requires the shared-everything-threads proposal",
+            offset,
+        )?;
         let _ = self.validate_spawn_type(func_ty_index, types, offset)?;
 
         // Check this much like `call_indirect` (see
@@ -2517,12 +2492,11 @@ impl ComponentState {
     }
 
     fn thread_available_parallelism(&mut self, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        if !self.features.shared_everything_threads() {
-            bail!(
-                offset,
-                "`thread.available_parallelism` requires the shared-everything-threads proposal"
-            )
-        }
+        require_feature::shared_everything_threads(
+            self.features,
+            "`thread.available_parallelism` requires the shared-everything-threads proposal",
+            offset,
+        )?;
 
         let func_ty = FuncType::new([], [ValType::I32]);
         let core_ty = SubType::func(func_ty, true);
@@ -2626,12 +2600,11 @@ impl ComponentState {
         types: &mut TypeList,
         offset: usize,
     ) -> Result<()> {
-        if !self.features.cm_values() {
-            bail!(
-                offset,
-                "support for component model `value`s is not enabled"
-            );
-        }
+        require_feature::cm_values(
+            self.features,
+            "support for component model `value`s is not enabled",
+            offset,
+        )?;
         if self.has_start {
             return Err(Error::new(
                 "component cannot have more than one start function",
@@ -2774,12 +2747,11 @@ impl ComponentState {
                             offset,
                         ));
                     } else {
-                        if !self.features.cm_async() {
-                            bail!(
-                                offset,
-                                "canonical option `async` requires the component model async feature"
-                            );
-                        }
+                        require_feature::cm_async(
+                            self.features,
+                            "canonical option `async` requires the component model async feature",
+                            offset,
+                        )?;
 
                         is_async = true;
                     }
@@ -2798,12 +2770,11 @@ impl ComponentState {
                 CanonicalOption::CoreType(idx) => {
                     core_type = match core_type {
                         None => {
-                            if !self.features.cm_gc() {
-                                bail!(
-                                    offset,
-                                    "canonical option `core type` requires the component model gc feature"
-                                )
-                            }
+                            require_feature::cm_gc(
+                                self.features,
+                                "canonical option `core type` requires the component model gc feature",
+                                offset,
+                            )?;
                             let ty = match self.core_type_at(*idx, offset)? {
                                 ComponentCoreTypeId::Sub(ty) => ty,
                                 ComponentCoreTypeId::Module(_) => {
@@ -2843,12 +2814,11 @@ impl ComponentState {
                             offset,
                         ));
                     }
-                    if !self.features.cm_gc() {
-                        return Err(Error::new(
-                            "canonical option `gc` requires the `cm-gc` feature",
-                            offset,
-                        ));
-                    }
+                    require_feature::cm_gc(
+                        self.features,
+                        "canonical option `gc` requires the `cm-gc` feature",
+                        offset,
+                    )?;
                     gc = true;
                 }
             }
@@ -3179,11 +3149,12 @@ impl ComponentState {
     ) -> Result<ComponentFuncType> {
         let mut info = TypeInfo::new();
 
-        if ty.async_ && !self.features.cm_async() {
-            bail!(
+        if ty.async_ {
+            require_feature::cm_async(
+                self.features,
+                "async component functions require the component model async feature",
                 offset,
-                "async component functions require the component model async feature"
-            );
+            )?;
         }
 
         let mut set = Set::default();
@@ -3765,9 +3736,11 @@ impl ComponentState {
                     )?;
                 }
                 ExternalKind::Tag => {
-                    if !self.features.exceptions() {
-                        bail!(offset, "exceptions proposal not enabled");
-                    }
+                    require_feature::exceptions(
+                        self.features,
+                        "exceptions proposal not enabled",
+                        offset,
+                    )?;
                     insert_export(
                         types,
                         export.name,
@@ -3853,9 +3826,11 @@ impl ComponentState {
                 push_module_export!(EntityType::Global, core_globals, "global");
             }
             ExternalKind::Tag => {
-                if !self.features.exceptions() {
-                    bail!(offset, "exceptions proposal not enabled");
-                }
+                require_feature::exceptions(
+                    self.features,
+                    "exceptions proposal not enabled",
+                    offset,
+                )?;
                 check_max(
                     self.core_tags.len(),
                     1,
@@ -4059,21 +4034,22 @@ impl ComponentState {
                 self.create_component_val_type(ty, offset)?,
             )),
             crate::ComponentDefinedType::Map(key, value) => {
-                if !self.features.cm_map() {
-                    bail!(offset, "Maps require the component model map feature")
-                }
+                require_feature::cm_map(
+                    self.features,
+                    "Maps require the component model map feature",
+                    offset,
+                )?;
                 Ok(ComponentDefinedType::Map(
                     self.create_component_val_type(key, offset)?,
                     self.create_component_val_type(value, offset)?,
                 ))
             }
             crate::ComponentDefinedType::FixedLengthList(ty, elements) => {
-                if !self.features.cm_fixed_length_lists() {
-                    bail!(
-                        offset,
-                        "Fixed-length lists require the component model fixed-length lists feature"
-                    )
-                }
+                require_feature::cm_fixed_length_lists(
+                    self.features,
+                    "Fixed-length lists require the component model fixed-length lists feature",
+                    offset,
+                )?;
                 if elements < 1 {
                     bail!(
                         offset,
@@ -4119,24 +4095,22 @@ impl ComponentState {
                 self.resource_at(idx, types, offset)?,
             )),
             crate::ComponentDefinedType::Future(ty) => {
-                if !self.features.cm_async() {
-                    bail!(
-                        offset,
-                        "`future` requires the component model async feature"
-                    )
-                }
+                require_feature::cm_async(
+                    self.features,
+                    "`future` requires the component model async feature",
+                    offset,
+                )?;
                 Ok(ComponentDefinedType::Future(
                     ty.map(|ty| self.create_component_val_type(ty, offset))
                         .transpose()?,
                 ))
             }
             crate::ComponentDefinedType::Stream(ty) => {
-                if !self.features.cm_async() {
-                    bail!(
-                        offset,
-                        "`stream` requires the component model async feature"
-                    )
-                }
+                require_feature::cm_async(
+                    self.features,
+                    "`stream` requires the component model async feature",
+                    offset,
+                )?;
                 let ty = ty
                     .map(|ty| self.create_component_val_type(ty, offset))
                     .transpose()?;
@@ -4499,11 +4473,12 @@ impl ComponentState {
             shared: false,
             page_size_log2: ty.page_size_log2,
         };
-        if ty.memory64 && !self.features.cm64() {
-            bail!(
+        if ty.memory64 {
+            require_feature::cm64(
+                self.features,
+                "64-bit memories require the `cm64` feature to be enabled",
                 offset,
-                "64-bit memories require the `cm64` feature to be enabled"
-            );
+            )?;
         }
         SubtypeCx::memory_type(ty, &valid_memory_type, offset)?;
         Ok(if ty.memory64 {
@@ -4614,21 +4589,21 @@ impl ComponentState {
     }
 
     fn check_value_support(&self, offset: usize) -> Result<()> {
-        if !self.features.cm_values() {
-            bail!(
-                offset,
-                "support for component model `value`s is not enabled"
-            );
-        }
+        require_feature::cm_values(
+            self.features,
+            "support for component model `value`s is not enabled",
+            offset,
+        )?;
         Ok(())
     }
 
     fn check_primitive_type(&self, ty: crate::PrimitiveValType, offset: usize) -> Result<()> {
-        if ty == crate::PrimitiveValType::ErrorContext && !self.features.cm_error_context() {
-            bail!(
+        if ty == crate::PrimitiveValType::ErrorContext {
+            require_feature::cm_error_context(
+                self.features,
+                "`error-context` requires the component model error-context feature",
                 offset,
-                "`error-context` requires the component model error-context feature"
-            )
+            )?;
         }
         Ok(())
     }
@@ -4709,9 +4684,11 @@ impl ComponentNameContext {
         }
 
         if let Some(implements) = name.implements {
-            if !features.cm_implements() {
-                bail!(offset, "the `cm-implements` feature is not active");
-            }
+            require_feature::cm_implements(
+                *features,
+                "the `cm-implements` feature is not active",
+                offset,
+            )?;
             match kebab.kind() {
                 ComponentNameKind::Label(_) => {}
                 _ => bail!(

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -17,7 +17,7 @@ use crate::{
     ConstExpr, Data, DataKind, Element, ElementKind, Error, ExternalKind, FrameKind, FrameStack,
     FuncType, Global, GlobalType, HeapType, MemoryType, RecGroup, RefType, Result, SubType, Table,
     TableInit, TableType, TagType, TypeRef, UnpackedIndex, ValType, VisitOperator, WasmFeatures,
-    WasmModuleResources, limits::*,
+    WasmModuleResources, limits::*, require_feature,
 };
 use alloc::sync::Arc;
 use core::mem;
@@ -86,13 +86,12 @@ impl ModuleState {
                 }
             }
             TableInit::Expr(expr) => {
-                if !self.module.features.function_references() {
-                    bail!(
-                        offset,
-                        "tables with expression initializers require \
-                         the function-references proposal"
-                    );
-                }
+                require_feature::function_references(
+                    self.module.features,
+                    "tables with expression initializers require \
+                     the function-references proposal",
+                    offset,
+                )?;
                 self.check_const_expr(expr, table.ty.element_type.into(), types)?;
             }
         }
@@ -103,12 +102,11 @@ impl ModuleState {
     pub fn add_data_segment(&mut self, data: Data, types: &TypeList, offset: usize) -> Result<()> {
         match data.kind {
             DataKind::Passive => {
-                if !self.module.features.bulk_memory() {
-                    bail!(
-                        offset,
-                        "passive data segments require the bulk-memory proposal"
-                    );
-                }
+                require_feature::bulk_memory(
+                    self.module.features,
+                    "passive data segments require the bulk-memory proposal",
+                    offset,
+                )?;
                 Ok(())
             }
             DataKind::Active {
@@ -157,9 +155,11 @@ impl ModuleState {
                 self.check_const_expr(&offset_expr, table.index_type(), types)?;
             }
             ElementKind::Passive | ElementKind::Declared => {
-                if !self.module.features.bulk_memory() {
-                    return Err(Error::new("bulk memory must be enabled", offset));
-                }
+                require_feature::bulk_memory(
+                    self.module.features,
+                    "bulk memory must be enabled",
+                    offset,
+                )?;
             }
         }
 
@@ -237,47 +237,39 @@ impl ModuleState {
             }
 
             fn validate_extended_const(&mut self, op: &str) -> Result<()> {
-                if self.ops.features.extended_const() {
-                    Ok(())
-                } else {
-                    Err(Error::new(
-                        format!("constant expression required: non-constant operator: {op}"),
-                        self.offset,
-                    ))
-                }
+                require_feature::extended_const(
+                    self.ops.features,
+                    format_args!("constant expression required: non-constant operator: {op}"),
+                    self.offset,
+                )
             }
 
             fn validate_gc(&mut self, op: &str) -> Result<()> {
-                if self.ops.features.gc() {
-                    Ok(())
-                } else {
-                    Err(Error::new(
-                        format!("constant expression required: non-constant operator: {op}"),
-                        self.offset,
-                    ))
-                }
+                require_feature::gc(
+                    self.ops.features,
+                    format_args!("constant expression required: non-constant operator: {op}"),
+                    self.offset,
+                )
             }
 
             fn validate_shared_everything_threads(&mut self, op: &str) -> Result<()> {
-                if self.ops.features.shared_everything_threads() {
-                    Ok(())
-                } else {
-                    Err(Error::new(
-                        format!("constant expression required: non-constant operator: {op}"),
-                        self.offset,
-                    ))
-                }
+                require_feature::shared_everything_threads(
+                    self.ops.features,
+                    format_args!("constant expression required: non-constant operator: {op}"),
+                    self.offset,
+                )
             }
 
             fn validate_global(&mut self, index: u32) -> Result<()> {
                 let module = &self.resources.module;
                 let global = module.global_at(index, self.offset)?;
 
-                if index >= module.num_imported_globals && !self.ops.features.gc() {
-                    return Err(Error::new(
+                if index >= module.num_imported_globals {
+                    require_feature::gc(
+                        self.ops.features,
                         "constant expression required: global.get of locally defined global",
                         self.offset,
-                    ));
+                    )?;
                 }
                 if global.mutable {
                     return Err(Error::new(
@@ -579,8 +571,12 @@ impl Module {
                 (self.tags.len(), MAX_WASM_TAGS, "tags")
             }
             TypeRef::Global(ty) => {
-                if !self.features.mutable_global() && ty.mutable {
-                    return Err(Error::new("mutable global support is not enabled", offset));
+                if ty.mutable {
+                    require_feature::mutable_global(
+                        self.features,
+                        "mutable global support is not enabled",
+                        offset,
+                    )?;
                 }
                 self.globals.push(ty);
                 self.num_imported_globals += 1;
@@ -608,11 +604,13 @@ impl Module {
         check_limit: bool,
         types: &TypeList,
     ) -> Result<()> {
-        if !self.features.mutable_global() {
-            if let EntityType::Global(global_type) = ty {
-                if global_type.mutable {
-                    return Err(Error::new("mutable global support is not enabled", offset));
-                }
+        if let EntityType::Global(global_type) = ty {
+            if global_type.mutable {
+                require_feature::mutable_global(
+                    self.features,
+                    "mutable global support is not enabled",
+                    offset,
+                )?;
             }
         }
 
@@ -712,14 +710,19 @@ impl Module {
         }
 
         self.check_limits(ty.initial, ty.maximum, offset)?;
-        if ty.table64 && !self.features().memory64() {
-            bail!(offset, "memory64 must be enabled for 64-bit tables");
-        }
-        if ty.shared && !self.features().shared_everything_threads() {
-            bail!(
+        if ty.table64 {
+            require_feature::memory64(
+                *self.features(),
+                "memory64 must be enabled for 64-bit tables",
                 offset,
-                "shared tables require the shared-everything-threads proposal"
-            );
+            )?;
+        }
+        if ty.shared {
+            require_feature::shared_everything_threads(
+                *self.features(),
+                "shared tables require the shared-everything-threads proposal",
+                offset,
+            )?;
         }
 
         let true_maximum = if ty.table64 {
@@ -748,20 +751,27 @@ impl Module {
     fn check_memory_type(&self, ty: &MemoryType, offset: usize) -> Result<()> {
         self.check_limits(ty.initial, ty.maximum, offset)?;
 
-        if ty.memory64 && !self.features().memory64() {
-            bail!(offset, "memory64 must be enabled for 64-bit memories");
+        if ty.memory64 {
+            require_feature::memory64(
+                *self.features(),
+                "memory64 must be enabled for 64-bit memories",
+                offset,
+            )?;
         }
-        if ty.shared && !self.features().threads() {
-            bail!(offset, "threads must be enabled for shared memories");
+        if ty.shared {
+            require_feature::threads(
+                *self.features(),
+                "threads must be enabled for shared memories",
+                offset,
+            )?;
         }
 
         let page_size = if let Some(page_size_log2) = ty.page_size_log2 {
-            if !self.features().custom_page_sizes() {
-                return Err(Error::new(
-                    "the custom page sizes proposal must be enabled to customize a memory's page size",
-                    offset,
-                ));
-            }
+            require_feature::custom_page_sizes(
+                *self.features(),
+                "the custom page sizes proposal must be enabled to customize a memory's page size",
+                offset,
+            )?;
             // Currently 2**0 and 2**16 are the only valid page sizes, but this
             // may be relaxed to allow any power of two in the future.
             if page_size_log2 != 0 && page_size_log2 != 16 {
@@ -823,17 +833,12 @@ impl Module {
         // We must check it if it's a reference.
         match ty {
             ValType::Ref(rt) => self.check_ref_type(rt, offset),
-            _ => self
-                .features
-                .check_value_type(*ty)
-                .map_err(|e| Error::new(e, offset)),
+            _ => self.features.check_value_type(*ty, offset),
         }
     }
 
     fn check_ref_type(&self, ty: &mut RefType, offset: usize) -> Result<()> {
-        self.features
-            .check_ref_type(*ty)
-            .map_err(|e| Error::new(e, offset))?;
+        self.features.check_ref_type(*ty, offset)?;
         let mut hty = ty.heap_type();
         self.check_heap_type(&mut hty, offset)?;
         *ty = RefType::new(ty.is_nullable(), hty).unwrap();
@@ -860,15 +865,14 @@ impl Module {
     }
 
     fn check_tag_type(&self, ty: &TagType, types: &TypeList, offset: usize) -> Result<()> {
-        if !self.features().exceptions() {
-            bail!(offset, "exceptions proposal not enabled");
-        }
+        require_feature::exceptions(self.features, "exceptions proposal not enabled", offset)?;
         let ty = self.func_type_at(ty.func_type_idx, types, offset)?;
-        if !ty.results().is_empty() && !self.features.stack_switching() {
-            return Err(Error::new(
+        if !ty.results().is_empty() {
+            require_feature::stack_switching(
+                self.features,
                 "invalid exception type: non-empty tag result type",
                 offset,
-            ));
+            )?;
         }
         Ok(())
     }
@@ -880,11 +884,12 @@ impl Module {
         offset: usize,
     ) -> Result<()> {
         self.check_value_type(&mut ty.content_type, offset)?;
-        if ty.shared && !self.features.shared_everything_threads() {
-            bail!(
+        if ty.shared {
+            require_feature::shared_everything_threads(
+                self.features,
+                "shared globals require the shared-everything-threads proposal",
                 offset,
-                "shared globals require the shared-everything-threads proposal"
-            );
+            )?;
         }
         if ty.shared && !types.valtype_is_shared(ty.content_type) {
             return Err(Error::new(

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -70,7 +70,7 @@
 use super::{RecGroupId, TypeAlloc, TypeList};
 use crate::{
     CompositeInnerType, CompositeType, Error, PackedIndex, RecGroup, Result, StorageType,
-    UnpackedIndex, ValType, WasmFeatures,
+    UnpackedIndex, ValType, WasmFeatures, require_feature,
     types::{CoreTypeId, TypeIdentifier},
 };
 
@@ -93,11 +93,12 @@ pub(crate) trait InternRecGroup {
         Self: Sized,
     {
         debug_assert!(rec_group.is_explicit_rec_group() || rec_group.types().len() == 1);
-        if rec_group.is_explicit_rec_group() && !self.features().gc() {
-            bail!(
+        if rec_group.is_explicit_rec_group() {
+            require_feature::gc(
+                *self.features(),
+                "rec group usage requires `gc` proposal to be enabled",
                 offset,
-                "rec group usage requires `gc` proposal to be enabled"
-            );
+            )?;
         }
         if self.features().needs_type_canonicalization() {
             TypeCanonicalizer::new(self, offset).canonicalize_rec_group(&mut rec_group)?;
@@ -130,8 +131,12 @@ pub(crate) trait InternRecGroup {
         offset: usize,
     ) -> Result<()> {
         let ty = &types[id];
-        if !self.features().gc() && (!ty.is_final || ty.supertype_idx.is_some()) {
-            bail!(offset, "gc proposal must be enabled to use subtypes");
+        if !ty.is_final || ty.supertype_idx.is_some() {
+            require_feature::gc(
+                *self.features(),
+                "gc proposal must be enabled to use subtypes",
+                offset,
+            )?;
         }
 
         self.check_composite_type(&ty.composite_type, &types, offset)?;
@@ -172,12 +177,11 @@ pub(crate) trait InternRecGroup {
     ) -> Result<()> {
         let ty = &types[id].composite_type;
         if ty.descriptor_idx.is_some() || ty.describes_idx.is_some() {
-            if !self.features().custom_descriptors() {
-                return Err(Error::new(
-                    "custom descriptors proposal must be enabled to use descriptor and describes",
-                    offset,
-                ));
-            }
+            require_feature::custom_descriptors(
+                *self.features(),
+                "custom descriptors proposal must be enabled to use descriptor and describes",
+                offset,
+            )?;
             match &ty.inner {
                 CompositeInnerType::Struct(_) => (),
                 _ => {
@@ -285,11 +289,9 @@ pub(crate) trait InternRecGroup {
         types: &TypeList,
         offset: usize,
     ) -> Result<()> {
-        let features = self.features();
+        let features = *self.features();
         let check = |ty: &ValType, shared: bool| {
-            features
-                .check_value_type(*ty)
-                .map_err(|e| Error::new(e, offset))?;
+            features.check_value_type(*ty, offset)?;
             if shared && !types.valtype_is_shared(*ty) {
                 return Err(Error::new(
                     "shared composite type must contain shared types",
@@ -303,37 +305,37 @@ pub(crate) trait InternRecGroup {
             }
             Ok(())
         };
-        if !features.shared_everything_threads() && ty.shared {
-            return Err(Error::new(
+        if ty.shared {
+            require_feature::shared_everything_threads(
+                features,
                 "shared composite types require the shared-everything-threads proposal",
                 offset,
-            ));
+            )?;
         }
         match &ty.inner {
             CompositeInnerType::Func(t) => {
                 for vt in t.params().iter().chain(t.results()) {
                     check(vt, ty.shared)?;
                 }
-                if t.results().len() > 1 && !features.multi_value() {
-                    return Err(Error::new(
+                if t.results().len() > 1 {
+                    require_feature::multi_value(
+                        features,
                         "func type returns multiple values but the multi-value feature is not enabled",
                         offset,
-                    ));
+                    )?;
                 }
             }
             CompositeInnerType::Array(t) => {
-                if !features.gc() {
-                    bail!(
-                        offset,
-                        "array indexed types not supported without the gc feature",
-                    );
-                }
-                if !features.gc_types() {
-                    bail!(
-                        offset,
-                        "cannot define array types when gc types are disabled",
-                    );
-                }
+                require_feature::gc(
+                    features,
+                    "array indexed types not supported without the gc feature",
+                    offset,
+                )?;
+                require_feature::gc_types(
+                    features,
+                    "cannot define array types when gc types are disabled",
+                    offset,
+                )?;
                 match &t.0.element_type {
                     StorageType::I8 | StorageType::I16 => {
                         // Note: scalar types are always `shared`.
@@ -342,18 +344,16 @@ pub(crate) trait InternRecGroup {
                 };
             }
             CompositeInnerType::Struct(t) => {
-                if !features.gc() {
-                    bail!(
-                        offset,
-                        "struct indexed types not supported without the gc feature",
-                    );
-                }
-                if !features.gc_types() {
-                    bail!(
-                        offset,
-                        "cannot define struct types when gc types are disabled",
-                    );
-                }
+                require_feature::gc(
+                    features,
+                    "struct indexed types not supported without the gc feature",
+                    offset,
+                )?;
+                require_feature::gc_types(
+                    features,
+                    "cannot define struct types when gc types are disabled",
+                    offset,
+                )?;
                 for ft in t.fields.iter() {
                     match &ft.element_type {
                         StorageType::I8 | StorageType::I16 => {
@@ -364,18 +364,16 @@ pub(crate) trait InternRecGroup {
                 }
             }
             CompositeInnerType::Cont(t) => {
-                if !features.stack_switching() {
-                    bail!(
-                        offset,
-                        "cannot define continuation types when stack switching is disabled",
-                    );
-                }
-                if !features.gc_types() {
-                    bail!(
-                        offset,
-                        "cannot define continuation types when gc types are disabled",
-                    );
-                }
+                require_feature::stack_switching(
+                    features,
+                    "cannot define continuation types when stack switching is disabled",
+                    offset,
+                )?;
+                require_feature::gc_types(
+                    features,
+                    "cannot define continuation types when gc types are disabled",
+                    offset,
+                )?;
                 // Check that the type index points to a valid function type.
                 let id = t.0.as_core_type_id().unwrap();
                 match types[id].composite_type.inner {

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -24,6 +24,7 @@
 
 #[cfg(feature = "simd")]
 use crate::VisitSimdOperator;
+use crate::features::require_feature;
 use crate::{
     AbstractHeapType, BlockType, BrTable, Catch, ContType, Error, FieldType, FrameKind, FrameStack,
     FuncType, GlobalType, Handle, HeapType, Ieee32, Ieee64, MemArg, ModuleArity, RefType, Result,
@@ -1141,9 +1142,11 @@ where
     }
 
     fn check_floats_enabled(&self) -> Result<()> {
-        if !self.features.floats() {
-            bail!(self.offset, "floating-point instruction disallowed");
-        }
+        require_feature::floats(
+            self.features,
+            "floating-point instruction disallowed",
+            self.offset,
+        )?;
         Ok(())
     }
 
@@ -1165,13 +1168,12 @@ where
                 .resources
                 .check_value_type(t, &self.features, self.offset),
             BlockType::FuncType(idx) => {
-                if !self.features.multi_value() {
-                    bail!(
-                        self.offset,
-                        "blocks, loops, and ifs may only produce a resulttype \
-                         when multi-value is not enabled",
-                    );
-                }
+                require_feature::multi_value(
+                    self.features,
+                    "blocks, loops, and ifs may only produce a resulttype \
+                     when multi-value is not enabled",
+                    self.offset,
+                )?;
                 self.func_type_at(*idx)?;
                 Ok(())
             }
@@ -1961,13 +1963,6 @@ where
         self.push_operand(ValType::I64)?;
         Ok(())
     }
-
-    fn check_enabled(&self, flag: bool, desc: &str) -> Result<()> {
-        if flag {
-            return Ok(());
-        }
-        bail!(self.offset, "{desc} support is not enabled");
-    }
 }
 
 pub fn ty_to_str(ty: ValType) -> &'static str {
@@ -2013,7 +2008,11 @@ macro_rules! validate_proposal {
     (validate self $proposal:ident / MemoryCopy) => {};
 
     (validate $self:ident $proposal:ident / $op:ident) => {
-        $self.0.check_enabled($self.0.features.$proposal(), validate_proposal!(desc $proposal))?
+        require_feature::$proposal(
+            $self.0.features,
+            concat!(validate_proposal!(desc $proposal), " support is not enabled"),
+            $self.0.offset,
+        )?
     };
 
     (desc simd) => ("SIMD");
@@ -3299,9 +3298,7 @@ where
     }
     fn visit_ref_null(&mut self, mut heap_type: HeapType) -> Self::Output {
         if let Some(ty) = RefType::new(true, heap_type) {
-            self.features
-                .check_ref_type(ty)
-                .map_err(|e| Error::new(e, self.offset))?;
+            self.features.check_ref_type(ty, self.offset)?;
         }
         self.resources
             .check_heap_type(&mut heap_type, self.offset)?;
@@ -3411,7 +3408,11 @@ where
         Ok(())
     }
     fn visit_memory_copy(&mut self, dst: u32, src: u32) -> Self::Output {
-        self.check_enabled(self.features.bulk_memory_opt(), "bulk memory")?;
+        require_feature::bulk_memory_opt(
+            self.features,
+            "bulk memory support is not enabled",
+            self.offset,
+        )?;
         let dst_ty = self.check_memory_index(dst)?;
         let src_ty = self.check_memory_index(src)?;
 
@@ -3429,7 +3430,11 @@ where
         Ok(())
     }
     fn visit_memory_fill(&mut self, mem: u32) -> Self::Output {
-        self.check_enabled(self.features.bulk_memory_opt(), "bulk memory")?;
+        require_feature::bulk_memory_opt(
+            self.features,
+            "bulk memory support is not enabled",
+            self.offset,
+        )?;
         let ty = self.check_memory_index(mem)?;
         self.pop_operand(Some(ty))?;
         self.pop_operand(Some(ValType::I32))?;


### PR DESCRIPTION
Add generated require_feature::* methods that return Errors with a new ErrorKind::WasmFeature if the named feature is disabled. Replace most feature checks with calls to these methods.
    
Checks in BinaryReader (and ancillary code) are gated on the 'features' feature to preserve existing behavior.

Additional internal changes:

- Made Error fields private by adding a couple of methods
- Renamed ErrorKind variants for clarity
