### PR TITLE
Add CustomSectionReader -> BinaryReader conversion

### DIFF
--- a/crates/wasmparser/src/readers/core/custom.rs
+++ b/crates/wasmparser/src/readers/core/custom.rs
@@ -98,6 +98,11 @@ impl<'a> CustomSectionReader<'a> {
             _ => KnownCustom::Unknown,
         }
     }
+
+    /// Get a binary reader over the data in the custom section
+    pub fn data_reader(&self) -> BinaryReader<'a> {
+        self.reader.shrink()
+    }
 }
 
 /// Return value of [`CustomSectionReader::as_known`].


### PR DESCRIPTION
Construction by hand does not preserve features field of the parser.

This also shrinks the parser to the remaining data. Passing the reader as a field of `KnownCustom::Unknown` would break consumers, hence this is a standalone method here. The recommended approach is thus to use it as

```rust
match custom.name() {
  "my-interesting-custom-section" => foo(custom.data_reader()),
  _ => {},
}
```