### PR TITLE
Remove `resource.drop async`

### DIFF
--- a/crates/wasm-encoder/src/component/builder.rs
+++ b/crates/wasm-encoder/src/component/builder.rs
@@ -454,12 +454,6 @@ impl ComponentBuilder {
         self.core_funcs.add(Some("resource.drop"))
     }
 
-    /// Declares a new `resource.drop` intrinsic.
-    pub fn resource_drop_async(&mut self, ty: u32) -> u32 {
-        self.canonical_functions().resource_drop_async(ty);
-        self.core_funcs.add(Some("resource.drop async"))
-    }
-
     /// Declares a new `resource.new` intrinsic.
     pub fn resource_new(&mut self, ty: u32) -> u32 {
         self.canonical_functions().resource_new(ty);

--- a/crates/wasm-encoder/src/component/canonicals.rs
+++ b/crates/wasm-encoder/src/component/canonicals.rs
@@ -154,14 +154,6 @@ impl CanonicalFunctionSection {
         self
     }
 
-    /// Defines a function which will drop the specified type of handle.
-    pub fn resource_drop_async(&mut self, ty_index: u32) -> &mut Self {
-        self.bytes.push(0x07);
-        ty_index.encode(&mut self.bytes);
-        self.num_added += 1;
-        self
-    }
-
     /// Defines a function which will return the representation of the specified
     /// resource type.
     pub fn resource_rep(&mut self, ty_index: u32) -> &mut Self {

--- a/crates/wasm-encoder/src/reencode/component.rs
+++ b/crates/wasm-encoder/src/reencode/component.rs
@@ -957,10 +957,6 @@ pub mod component_utils {
                 let resource = reencoder.component_type_index(resource);
                 section.resource_drop(resource);
             }
-            wasmparser::CanonicalFunction::ResourceDropAsync { resource } => {
-                let resource = reencoder.component_type_index(resource);
-                section.resource_drop_async(resource);
-            }
             wasmparser::CanonicalFunction::ResourceRep { resource } => {
                 let resource = reencoder.component_type_index(resource);
                 section.resource_rep(resource);

--- a/crates/wasmparser/src/readers/component/canonicals.rs
+++ b/crates/wasmparser/src/readers/component/canonicals.rs
@@ -64,11 +64,6 @@ pub enum CanonicalFunction {
         /// The type index of the resource that's being dropped.
         resource: u32,
     },
-    /// Same as `ResourceDrop`, but implements the `async` ABI.
-    ResourceDropAsync {
-        /// The type index of the resource that's being dropped.
-        resource: u32,
-    },
     /// A function which returns the underlying i32-based representation of the
     /// specified resource.
     ResourceRep {
@@ -338,9 +333,6 @@ impl<'a> FromReader<'a> for CanonicalFunction {
                 resource: reader.read()?,
             },
             0x03 => CanonicalFunction::ResourceDrop {
-                resource: reader.read()?,
-            },
-            0x07 => CanonicalFunction::ResourceDropAsync {
                 resource: reader.read()?,
             },
             0x04 => CanonicalFunction::ResourceRep {

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1218,9 +1218,6 @@ impl ComponentState {
             CanonicalFunction::ResourceDrop { resource } => {
                 self.resource_drop(resource, types, offset)
             }
-            CanonicalFunction::ResourceDropAsync { resource } => {
-                self.resource_drop_async(resource, types, offset)
-            }
             CanonicalFunction::ResourceRep { resource } => {
                 self.resource_rep(resource, types, offset)
             }
@@ -1414,23 +1411,6 @@ impl ComponentState {
     }
 
     fn resource_drop(&mut self, resource: u32, types: &mut TypeAlloc, offset: usize) -> Result<()> {
-        self.resource_at(resource, types, offset)?;
-        let id = types.intern_func_type(FuncType::new([ValType::I32], []), offset);
-        self.core_funcs.push(id);
-        Ok(())
-    }
-
-    fn resource_drop_async(
-        &mut self,
-        resource: u32,
-        types: &mut TypeAlloc,
-        offset: usize,
-    ) -> Result<()> {
-        require_feature::cm_more_async_builtins(
-            self.features,
-            "`resource.drop` as `async` requires the component model more async builtins feature",
-            offset,
-        )?;
         self.resource_at(resource, types, offset)?;
         let id = types.intern_func_type(FuncType::new([ValType::I32], []), offset);
         self.core_funcs.push(id);

--- a/crates/wasmprinter/src/component.rs
+++ b/crates/wasmprinter/src/component.rs
@@ -934,12 +934,6 @@ impl Printer<'_, '_> {
                         me.print_idx(&state.component.type_names, resource)
                     })?;
                 }
-                CanonicalFunction::ResourceDropAsync { resource } => {
-                    self.print_intrinsic(state, "canon resource.drop ", &|me, state| {
-                        me.print_idx(&state.component.type_names, resource)?;
-                        me.print_type_keyword(" async")
-                    })?;
-                }
                 CanonicalFunction::ResourceRep { resource } => {
                     self.print_intrinsic(state, "canon resource.rep ", &|me, state| {
                         me.print_idx(&state.component.type_names, resource)

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -348,11 +348,7 @@ impl<'a> Encoder<'a> {
                 }
                 CoreFuncKind::ResourceDrop(info) => {
                     self.core_func_names.push(name);
-                    if info.async_ {
-                        self.funcs.resource_drop_async(info.ty.into());
-                    } else {
-                        self.funcs.resource_drop(info.ty.into());
-                    }
+                    self.funcs.resource_drop(info.ty.into());
                 }
                 CoreFuncKind::ResourceRep(info) => {
                     self.core_func_names.push(name);

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -476,8 +476,6 @@ impl<'a> Parse<'a> for CanonResourceNew<'a> {
 pub struct CanonResourceDrop<'a> {
     /// The resource type that this intrinsic is dropping.
     pub ty: Index<'a>,
-    /// Whether or not this function is async
-    pub async_: bool,
 }
 
 impl<'a> Parse<'a> for CanonResourceDrop<'a> {
@@ -486,7 +484,6 @@ impl<'a> Parse<'a> for CanonResourceDrop<'a> {
 
         Ok(Self {
             ty: parser.parse()?,
-            async_: parser.parse::<Option<kw::r#async>>()?.is_some(),
         })
     }
 }

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -461,7 +461,6 @@ impl<'a> Dump<'a> {
                             CanonicalFunction::Lower { .. }
                             | CanonicalFunction::ResourceNew { .. }
                             | CanonicalFunction::ResourceDrop { .. }
-                            | CanonicalFunction::ResourceDropAsync { .. }
                             | CanonicalFunction::ResourceRep { .. }
                             | CanonicalFunction::ThreadSpawnRef { .. }
                             | CanonicalFunction::ThreadSpawnIndirect { .. }

--- a/tests/cli/component-model/async/async-builtins.wast
+++ b/tests/cli/component-model/async/async-builtins.wast
@@ -49,11 +49,6 @@
 (component
   (core func (canon subtask.cancel async))
   (canon subtask.cancel async (core func))
-
-  (type $r (resource (rep i32)))
-  (core func (canon resource.drop $r async))
-  (canon resource.drop $r async (core func))
-
 )
 
 ;; future.cancel-read

--- a/tests/cli/missing-features/component-model/async-builtins.wast
+++ b/tests/cli/missing-features/component-model/async-builtins.wast
@@ -32,16 +32,6 @@
   (core func (canon stream.cancel-write $s))
 )
 
-;; async resource.drop
-(assert_invalid
-  (component
-    (type $t (resource (rep i32)))
-    (core func (canon resource.drop $t async)))
-  "requires the component model more async builtins feature")
-(component
-  (type $t (resource (rep i32)))
-  (core func (canon resource.drop $t)))
-
 (assert_invalid
   (component
     (type $t (stream))

--- a/tests/cli/missing-features/component-model/async.wast
+++ b/tests/cli/missing-features/component-model/async.wast
@@ -347,13 +347,6 @@
   (component (type (stream)))
   "requires the component model async feature"
 )
-(assert_invalid
-  (component
-    (type $t (resource (rep i32)))
-    (core func $f (canon resource.drop $t async))
-  )
-  "requires the component model more async builtins feature"
-)
 
 ;; async function types
 (assert_invalid

--- a/tests/snapshots/cli/component-model/async/async-builtins.wast.json
+++ b/tests/snapshots/cli/component-model/async/async-builtins.wast.json
@@ -35,33 +35,33 @@
     },
     {
       "type": "module",
-      "line": 60,
+      "line": 55,
       "filename": "async-builtins.5.wasm",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 71,
+      "line": 66,
       "filename": "async-builtins.6.wasm",
       "module_type": "binary",
       "text": "type mismatch for export `future.cancel-read` of module instantiation argument ``"
     },
     {
       "type": "module",
-      "line": 83,
+      "line": 78,
       "filename": "async-builtins.7.wasm",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 94,
+      "line": 89,
       "filename": "async-builtins.8.wasm",
       "module_type": "binary",
       "text": "type mismatch for export `future.cancel-write` of module instantiation argument ``"
     },
     {
       "type": "module",
-      "line": 106,
+      "line": 101,
       "filename": "async-builtins.9.wasm",
       "module_type": "binary"
     }

--- a/tests/snapshots/cli/component-model/async/async-builtins.wast/4.print
+++ b/tests/snapshots/cli/component-model/async/async-builtins.wast/4.print
@@ -1,7 +1,4 @@
 (component
   (core func (;0;) (canon subtask.cancel async))
   (core func (;1;) (canon subtask.cancel async))
-  (type $r (;0;) (resource (rep i32)))
-  (core func (;2;) (canon resource.drop $r async))
-  (core func (;3;) (canon resource.drop $r async))
 )

--- a/tests/snapshots/cli/missing-features/component-model/async-builtins.wast.json
+++ b/tests/snapshots/cli/missing-features/component-model/async-builtins.wast.json
@@ -37,42 +37,29 @@
     },
     {
       "type": "assert_invalid",
-      "line": 37,
+      "line": 36,
       "filename": "async-builtins.5.wasm",
       "module_type": "binary",
       "text": "requires the component model more async builtins feature"
     },
     {
-      "type": "module",
-      "line": 41,
+      "type": "assert_invalid",
+      "line": 42,
       "filename": "async-builtins.6.wasm",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "requires the component model more async builtins feature"
     },
     {
       "type": "assert_invalid",
-      "line": 46,
+      "line": 48,
       "filename": "async-builtins.7.wasm",
       "module_type": "binary",
       "text": "requires the component model more async builtins feature"
     },
     {
       "type": "assert_invalid",
-      "line": 52,
+      "line": 54,
       "filename": "async-builtins.8.wasm",
-      "module_type": "binary",
-      "text": "requires the component model more async builtins feature"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 58,
-      "filename": "async-builtins.9.wasm",
-      "module_type": "binary",
-      "text": "requires the component model more async builtins feature"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 64,
-      "filename": "async-builtins.10.wasm",
       "module_type": "binary",
       "text": "requires the component model more async builtins feature"
     }

--- a/tests/snapshots/cli/missing-features/component-model/async-builtins.wast/6.print
+++ b/tests/snapshots/cli/missing-features/component-model/async-builtins.wast/6.print
@@ -1,4 +1,0 @@
-(component
-  (type $t (;0;) (resource (rep i32)))
-  (core func (;0;) (canon resource.drop $t))
-)

--- a/tests/snapshots/cli/missing-features/component-model/async.wast.json
+++ b/tests/snapshots/cli/missing-features/component-model/async.wast.json
@@ -206,15 +206,8 @@
     },
     {
       "type": "assert_invalid",
-      "line": 351,
+      "line": 353,
       "filename": "async.29.wasm",
-      "module_type": "binary",
-      "text": "requires the component model more async builtins feature"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 360,
-      "filename": "async.30.wasm",
       "module_type": "binary",
       "text": "async component functions require the component model async feature"
     }


### PR DESCRIPTION
This has already been removed from the spec, so no need to keep carrying it here.