### PR TITLE
Render error

### DIFF
--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -178,7 +178,7 @@ fn run_test(path: &Path) -> Result<()> {
     assert_output(&wit, &component_wit_path)?;
 
     UnresolvedPackageGroup::parse(&component_wit_path, &wit)
-        .map_err(|(map, e)| anyhow::anyhow!("{}", e.highlight(&map)))
+        .map_err(|(map, e)| anyhow::anyhow!("{}", e.render(&map)))
         .context("failed to parse printed WIT")?;
 
     // Check that the producer data got piped through properly

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -99,7 +99,7 @@ fn assert_print(resolve: &Resolve, pkg_id: PackageId, path: &Path, is_dir: bool)
     assert_output(&expected, &output)?;
 
     UnresolvedPackageGroup::parse("foo.wit", &output)
-        .map_err(|(map, e)| anyhow::anyhow!("{}", e.highlight(&map)))
+        .map_err(|(map, e)| anyhow::anyhow!("{}", e.render(&map)))
         .context("failed to parse printed output")?;
     Ok(())
 }

--- a/crates/wit-parser/src/ast/error.rs
+++ b/crates/wit-parser/src/ast/error.rs
@@ -90,8 +90,15 @@ impl ParseError {
         &mut self.0
     }
 
-    /// Format this error with source context (file:line:col + snippet)
-    pub fn highlight(&self, source_map: &SourceMap) -> String {
+    /// Renders this error with source context (file:line:col + snippet).
+    ///
+    /// `source_map` must be the map this error's spans are valid in: for
+    /// errors returned by [`Resolve`](crate::Resolve) methods that is
+    /// [`Resolve::source_map`](crate::Resolve::source_map) (or use
+    /// [`Resolve::render_error`](crate::Resolve::render_error) directly), and
+    /// for errors from [`SourceMap::parse`] it is the map returned alongside
+    /// the error.
+    pub fn render(&self, source_map: &SourceMap) -> String {
         let e = self.kind();
         source_map
             .highlight_span(e.span(), e)

--- a/crates/wit-parser/src/ast/error.rs
+++ b/crates/wit-parser/src/ast/error.rs
@@ -92,12 +92,7 @@ impl ParseError {
 
     /// Renders this error with source context (file:line:col + snippet).
     ///
-    /// `source_map` must be the map this error's spans are valid in: for
-    /// errors returned by [`Resolve`](crate::Resolve) methods that is
-    /// [`Resolve::source_map`](crate::Resolve::source_map) (or use
-    /// [`Resolve::render_error`](crate::Resolve::render_error) directly), and
-    /// for errors from [`SourceMap::parse`] it is the map returned alongside
-    /// the error.
+    /// `source_map` must be the map this error's spans are valid in.
     pub fn render(&self, source_map: &SourceMap) -> String {
         let e = self.kind();
         source_map

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -70,22 +70,23 @@ pub fn validate_id(s: &str) -> anyhow::Result<()> {
 /// Renders an [`anyhow::Error`] chain produced by this crate, substituting
 /// snippet-bearing output for any [`ResolveError`] or [`ParseError`] layers.
 ///
-/// For each layer in the chain, this calls [`ResolveError::highlight`] or
-/// [`ParseError::highlight`] to format typed errors with file/line/column and
+/// For each layer in the chain, this calls [`ResolveError::render`] or
+/// [`ParseError::render`] to format typed errors with file/line/column and
 /// a source snippet. Other layers are formatted via their [`fmt::Display`]
 /// impl. Layers are joined with `": "`, matching `format!("{err:#}")`.
 ///
 /// `source_map` must be the [`SourceMap`] in which every typed error's spans
 /// are valid; combining typed errors from different source maps in one chain
-/// is unsupported.
+/// is unsupported. For errors returned by [`Resolve`] methods, prefer
+/// [`Resolve::render_error`] which supplies the right map automatically.
 #[cfg(feature = "std")]
 pub fn render_anyhow_error(err: &anyhow::Error, source_map: &SourceMap) -> String {
     err.chain()
         .map(|layer| {
             if let Some(re) = layer.downcast_ref::<ResolveError>() {
-                re.highlight(source_map)
+                re.render(source_map)
             } else if let Some(pe) = layer.downcast_ref::<ParseError>() {
-                pe.highlight(source_map)
+                pe.render(source_map)
             } else {
                 layer.to_string()
             }
@@ -328,7 +329,7 @@ impl UnresolvedPackageGroup {
     ///
     /// On failure the constructed [`SourceMap`] is returned alongside the
     /// typed [`ParseError`] so the caller can render a snippet via
-    /// [`ParseError::highlight`] or merge the source map elsewhere.
+    /// [`ParseError::render`] or merge the source map elsewhere.
     #[cfg(feature = "std")]
     pub fn parse(
         path: impl AsRef<Path>,
@@ -350,7 +351,7 @@ impl UnresolvedPackageGroup {
         let mut map = SourceMap::default();
         map.push_dir(path.as_ref())?;
         map.parse().map_err(|(map, e)| {
-            let rendered = e.highlight(&map);
+            let rendered = e.render(&map);
             anyhow::Error::from(e).context(rendered)
         })
     }

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -77,8 +77,8 @@ pub fn validate_id(s: &str) -> anyhow::Result<()> {
 ///
 /// `source_map` must be the [`SourceMap`] in which every typed error's spans
 /// are valid; combining typed errors from different source maps in one chain
-/// is unsupported. For errors returned by [`Resolve`] methods, prefer
-/// [`Resolve::render_error`] which supplies the right map automatically.
+/// is unsupported. For errors from [`Resolve`] methods, prefer
+/// [`Resolve::render_error`].
 #[cfg(feature = "std")]
 pub fn render_anyhow_error(err: &anyhow::Error, source_map: &SourceMap) -> String {
     err.chain()

--- a/crates/wit-parser/src/resolve/error.rs
+++ b/crates/wit-parser/src/resolve/error.rs
@@ -129,8 +129,13 @@ impl ResolveError {
         &mut self.0
     }
 
-    /// Format this error with source context (file:line:col + snippet).
-    pub fn highlight(&self, source_map: &SourceMap) -> String {
+    /// Renders this error with source context (file:line:col + snippet).
+    ///
+    /// `source_map` must be the map this error's spans are valid in: for
+    /// errors returned by [`Resolve`](crate::Resolve) methods that is
+    /// [`Resolve::source_map`](crate::Resolve::source_map) (or use
+    /// [`Resolve::render_error`](crate::Resolve::render_error) directly).
+    pub fn render(&self, source_map: &SourceMap) -> String {
         let e = self.kind();
         let msg = e.to_string();
         match e {

--- a/crates/wit-parser/src/resolve/error.rs
+++ b/crates/wit-parser/src/resolve/error.rs
@@ -131,10 +131,7 @@ impl ResolveError {
 
     /// Renders this error with source context (file:line:col + snippet).
     ///
-    /// `source_map` must be the map this error's spans are valid in: for
-    /// errors returned by [`Resolve`](crate::Resolve) methods that is
-    /// [`Resolve::source_map`](crate::Resolve::source_map) (or use
-    /// [`Resolve::render_error`](crate::Resolve::render_error) directly).
+    /// `source_map` must be the map this error's spans are valid in.
     pub fn render(&self, source_map: &SourceMap) -> String {
         let e = self.kind();
         let msg = e.to_string();

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -441,14 +441,8 @@ impl Resolve {
         self.source_map.render_location(span)
     }
 
-    /// Renders an error chain returned by this [`Resolve`]'s `push_*` methods,
-    /// substituting file/line/column snippets for any typed
-    /// [`ParseError`](crate::ParseError) or [`ResolveError`] layers.
-    ///
-    /// Spans in errors returned by [`Resolve`] methods are always valid
-    /// against [`Resolve::source_map`], including when the `push_*` call
-    /// failed, so this is the one-stop way for embedders to display those
-    /// errors.
+    /// Renders an error returned by this [`Resolve`]'s `push_*` methods with
+    /// source context (file:line:col + snippet).
     #[cfg(feature = "std")]
     pub fn render_error(&self, err: &anyhow::Error) -> String {
         crate::render_anyhow_error(err, &self.source_map)

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -441,6 +441,19 @@ impl Resolve {
         self.source_map.render_location(span)
     }
 
+    /// Renders an error chain returned by this [`Resolve`]'s `push_*` methods,
+    /// substituting file/line/column snippets for any typed
+    /// [`ParseError`](crate::ParseError) or [`ResolveError`] layers.
+    ///
+    /// Spans in errors returned by [`Resolve`] methods are always valid
+    /// against [`Resolve::source_map`], including when the `push_*` call
+    /// failed, so this is the one-stop way for embedders to display those
+    /// errors.
+    #[cfg(feature = "std")]
+    pub fn render_error(&self, err: &anyhow::Error) -> String {
+        crate::render_anyhow_error(err, &self.source_map)
+    }
+
     pub fn all_bits_valid(&self, ty: &Type) -> bool {
         match ty {
             Type::U8
@@ -5928,7 +5941,7 @@ interface iface {
         };
         let mut resolve = Resolve::default();
         let err = resolve.push_groups(a, Vec::from([b])).unwrap_err();
-        let msg = err.highlight(&resolve.source_map);
+        let msg = err.render(&resolve.source_map);
         assert!(
             msg.contains("file:///"),
             "cycle error should contain a file URI, got: {msg}"

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -87,7 +87,7 @@ impl Runner {
                             "some generic platform-agnostic error message",
                         );
                     }
-                    render_anyhow_error(&e, &resolve.source_map)
+                    resolve.render_error(&e)
                 }
             }
         } else {

--- a/crates/wit-parser/tests/downcast.rs
+++ b/crates/wit-parser/tests/downcast.rs
@@ -70,12 +70,12 @@ fn push_str_parse_error_is_downcastable() {
         .expect_err("expected parse to fail");
     let pe = parse_error_in_chain(&err);
     // Spans must be valid against `resolve.source_map` after the failure-path
-    // merge, so highlighting against it should not panic and should include
+    // merge, so rendering against it should not panic and should include
     // the file and line.
-    let rendered = pe.highlight(&resolve.source_map);
+    let rendered = pe.render(&resolve.source_map);
     assert!(
         rendered.contains("test.wit:2:"),
-        "expected highlighted error to reference test.wit:2:..., got:\n{rendered}"
+        "expected rendered error to reference test.wit:2:..., got:\n{rendered}"
     );
     assert!(
         matches!(pe.kind(), ParseErrorKind::Syntax { .. }),
@@ -104,10 +104,10 @@ fn parse_error_spans_are_adjusted_after_earlier_pushes() {
     // `resolve.source_map` because `first.wit` was merged before it, so this
     // only points at the right file and line if the error's spans were
     // adjusted during the failure-path merge.
-    let rendered = pe.highlight(&resolve.source_map);
+    let rendered = pe.render(&resolve.source_map);
     assert!(
         rendered.contains("second.wit:2:"),
-        "expected highlighted error to reference second.wit:2:..., got:\n{rendered}"
+        "expected rendered error to reference second.wit:2:..., got:\n{rendered}"
     );
     assert!(
         rendered.contains("not-a-keyword"),

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -967,12 +967,9 @@ impl WitOpts {
             if input.is_dir() {
                 let mut resolve =
                     WitResolve::resolve_with_features(&self.features, self.all_features);
-                let (pkg_id, _) = resolve.push_dir(&input).map_err(|e| {
-                    anyhow::anyhow!(
-                        "{}",
-                        wit_parser::render_anyhow_error(&e, &resolve.source_map)
-                    )
-                })?;
+                let (pkg_id, _) = resolve
+                    .push_dir(&input)
+                    .map_err(|e| anyhow::anyhow!("{}", resolve.render_error(&e)))?;
                 return Ok(DecodedWasm::WitPackage(resolve, pkg_id));
             }
         }
@@ -1029,12 +1026,9 @@ impl WitOpts {
                 };
                 let mut resolve =
                     WitResolve::resolve_with_features(&self.features, self.all_features);
-                let id = resolve.push_str(path, input).map_err(|e| {
-                    anyhow::anyhow!(
-                        "{}",
-                        wit_parser::render_anyhow_error(&e, &resolve.source_map)
-                    )
-                })?;
+                let id = resolve
+                    .push_str(path, input)
+                    .map_err(|e| anyhow::anyhow!("{}", resolve.render_error(&e)))?;
                 Ok(DecodedWasm::WitPackage(resolve, id))
             }
         }

--- a/src/wit.rs
+++ b/src/wit.rs
@@ -42,12 +42,9 @@ impl WitResolve {
 
     pub fn load(&self) -> Result<(Resolve, PackageId)> {
         let mut resolve = Self::resolve_with_features(&self.features, self.all_features);
-        let (pkg_id, _) = resolve.push_path(&self.wit).map_err(|e| {
-            anyhow::anyhow!(
-                "{}",
-                wit_parser::render_anyhow_error(&e, &resolve.source_map)
-            )
-        })?;
+        let (pkg_id, _) = resolve
+            .push_path(&self.wit)
+            .map_err(|e| anyhow::anyhow!("{}", resolve.render_error(&e)))?;
         Ok((resolve, pkg_id))
     }
 }


### PR DESCRIPTION
- Renames `ParseError::highlight` and `ResolveError::highlight` to `render`
- Adds `Resolve::render_error(&anyhow::Error) -> String`, a convenience wrapper that calls `render_anyhow_error` with the right soure map (which makes the consumer code less error prone)