### PR TITLE
Validate component model type depth

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -655,16 +655,16 @@ impl<'a> TypeEncoder<'a> {
             }
             ComponentDefinedType::Record(r) => self.record(state, r),
             ComponentDefinedType::Variant(v) => self.variant(state, v),
-            ComponentDefinedType::List(ty) => self.list(state, *ty),
-            ComponentDefinedType::Map(key, value) => self.map(state, *key, *value),
-            ComponentDefinedType::FixedLengthList(ty, elements) => {
-                self.fixed_length_list(state, *ty, *elements)
-            }
+            ComponentDefinedType::List { element, .. } => self.list(state, *element),
+            ComponentDefinedType::Map { key, value, .. } => self.map(state, *key, *value),
+            ComponentDefinedType::FixedLengthList {
+                element, length, ..
+            } => self.fixed_length_list(state, *element, *length),
             ComponentDefinedType::Tuple(t) => self.tuple(state, t),
             ComponentDefinedType::Flags(names) => Self::flags(&mut state.cur.encodable, names),
             ComponentDefinedType::Enum(cases) => Self::enum_type(&mut state.cur.encodable, cases),
-            ComponentDefinedType::Option(ty) => self.option(state, *ty),
-            ComponentDefinedType::Result { ok, err } => self.result(state, *ok, *err),
+            ComponentDefinedType::Option { ty, .. } => self.option(state, *ty),
+            ComponentDefinedType::Result { ok, err, .. } => self.result(state, *ok, *err),
             ComponentDefinedType::Own(r) => {
                 let ty = self.ty(state, (*r).into());
                 let index = state.cur.encodable.type_count();
@@ -677,8 +677,8 @@ impl<'a> TypeEncoder<'a> {
                 state.cur.encodable.ty().defined_type().borrow(ty);
                 index
             }
-            ComponentDefinedType::Future(ty) => self.future(state, *ty),
-            ComponentDefinedType::Stream(ty) => self.stream(state, *ty),
+            ComponentDefinedType::Future { ty, .. } => self.future(state, *ty),
+            ComponentDefinedType::Stream { ty, .. } => self.stream(state, *ty),
         }
     }
 
@@ -1267,12 +1267,12 @@ impl DependencyRegistrar<'_, '_> {
             ComponentDefinedType::Primitive(_)
             | ComponentDefinedType::Enum(_)
             | ComponentDefinedType::Flags(_) => {}
-            ComponentDefinedType::List(t)
-            | ComponentDefinedType::FixedLengthList(t, _)
-            | ComponentDefinedType::Option(t) => self.val_type(*t),
-            ComponentDefinedType::Map(k, v) => {
-                self.val_type(*k);
-                self.val_type(*v);
+            ComponentDefinedType::List { element: t, .. }
+            | ComponentDefinedType::FixedLengthList { element: t, .. }
+            | ComponentDefinedType::Option { ty: t, .. } => self.val_type(*t),
+            ComponentDefinedType::Map { key, value, .. } => {
+                self.val_type(*key);
+                self.val_type(*value);
             }
             ComponentDefinedType::Own(r) | ComponentDefinedType::Borrow(r) => {
                 self.ty(ComponentAnyTypeId::Resource(*r))
@@ -1294,7 +1294,7 @@ impl DependencyRegistrar<'_, '_> {
                     }
                 }
             }
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 if let Some(ok) = ok {
                     self.val_type(*ok);
                 }
@@ -1302,12 +1302,7 @@ impl DependencyRegistrar<'_, '_> {
                     self.val_type(*err);
                 }
             }
-            ComponentDefinedType::Future(ty) => {
-                if let Some(ty) = ty {
-                    self.val_type(*ty);
-                }
-            }
-            ComponentDefinedType::Stream(ty) => {
+            ComponentDefinedType::Future { ty, .. } | ComponentDefinedType::Stream { ty, .. } => {
                 if let Some(ty) = ty {
                     self.val_type(*ty);
                 }

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -77,6 +77,7 @@ mod component_limits {
     pub const MAX_WASM_FIXED_LENGTH_LIST_ELEMENTS: usize = 1_073_741_824;
     pub const MAX_WASM_FLAG_NAMES: usize = 1_000;
     pub const MAX_WASM_ENUM_CASES: usize = 10_000;
+    pub const MAX_WASM_COMPONENT_TYPE_DEPTH: u32 = 100;
     pub const MAX_WASM_INSTANTIATION_EXPORTS: usize = 100_000;
     pub const MAX_WASM_CANONICAL_OPTIONS: usize = 10;
     pub const MAX_WASM_INSTANTIATION_ARGS: usize = 100_000;

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -11,7 +11,7 @@ use super::{
         RecordType, Remap, Remapping, ResourceId, SubtypeCx, TupleType, VariantCase, VariantType,
     },
     core::{InternRecGroup, Module},
-    types::{CoreTypeId, EntityType, TypeAlloc, TypeInfo, TypeList},
+    types::{CoreTypeId, EntityType, TypeAlloc, TypeData, TypeInfo, TypeList},
 };
 use crate::collections::index_map::Entry;
 use crate::limits::*;
@@ -593,6 +593,10 @@ impl ComponentState {
         let id = match ty {
             crate::ComponentType::Defined(ty) => {
                 let ty = current(components).create_defined_type(ty, types, offset)?;
+                let depth = ty.type_info(types).depth();
+                if depth > MAX_WASM_COMPONENT_TYPE_DEPTH {
+                    bail!(offset, "type nesting is too deep");
+                }
                 types.push(ty).into()
             }
             crate::ComponentType::Func(ty) => {
@@ -980,7 +984,7 @@ impl ComponentState {
                 .values()
                 .filter_map(|t| t.ty.as_ref())
                 .all(|t| types.type_named_valtype(t, set)),
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 ok.as_ref()
                     .map(|t| types.type_named_valtype(t, set))
                     .unwrap_or(true)
@@ -989,11 +993,11 @@ impl ComponentState {
                         .map(|t| types.type_named_valtype(t, set))
                         .unwrap_or(true)
             }
-            ComponentDefinedType::List(ty)
-            | ComponentDefinedType::FixedLengthList(ty, _)
-            | ComponentDefinedType::Option(ty) => types.type_named_valtype(ty, set),
-            ComponentDefinedType::Map(k, v) => {
-                types.type_named_valtype(k, set) && types.type_named_valtype(v, set)
+            ComponentDefinedType::List { element: ty, .. }
+            | ComponentDefinedType::FixedLengthList { element: ty, .. }
+            | ComponentDefinedType::Option { ty, .. } => types.type_named_valtype(ty, set),
+            ComponentDefinedType::Map { key, value, .. } => {
+                types.type_named_valtype(key, set) && types.type_named_valtype(value, set)
             }
 
             // The resource referred to by own/borrow must be named.
@@ -1001,11 +1005,7 @@ impl ComponentState {
                 set.contains(&ComponentAnyTypeId::from(*id))
             }
 
-            ComponentDefinedType::Future(ty) => ty
-                .as_ref()
-                .map(|ty| types.type_named_valtype(ty, set))
-                .unwrap_or(true),
-            ComponentDefinedType::Stream(ty) => ty
+            ComponentDefinedType::Future { ty, .. } | ComponentDefinedType::Stream { ty, .. } => ty
                 .as_ref()
                 .map(|ty| types.type_named_valtype(ty, set))
                 .unwrap_or(true),
@@ -1648,7 +1648,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(_) = &types[ty] else {
+        let ComponentDefinedType::Stream { .. } = &types[ty] else {
             bail!(offset, "`stream.new` requires a stream type")
         };
 
@@ -1671,7 +1671,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(elem_ty) = &types[ty] else {
+        let ComponentDefinedType::Stream { ty: elem_ty, .. } = &types[ty] else {
             bail!(offset, "`stream.read` requires a stream type")
         };
 
@@ -1711,7 +1711,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(elem_ty) = &types[ty] else {
+        let ComponentDefinedType::Stream { ty: elem_ty, .. } = &types[ty] else {
             bail!(offset, "`stream.write` requires a stream type")
         };
 
@@ -1757,7 +1757,7 @@ impl ComponentState {
         }
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(_) = &types[ty] else {
+        let ComponentDefinedType::Stream { .. } = &types[ty] else {
             bail!(offset, "`stream.cancel-read` requires a stream type")
         };
 
@@ -1787,7 +1787,7 @@ impl ComponentState {
         }
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(_) = &types[ty] else {
+        let ComponentDefinedType::Stream { .. } = &types[ty] else {
             bail!(offset, "`stream.cancel-write` requires a stream type")
         };
 
@@ -1809,7 +1809,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(_) = &types[ty] else {
+        let ComponentDefinedType::Stream { .. } = &types[ty] else {
             bail!(offset, "`stream.drop-readable` requires a stream type")
         };
 
@@ -1831,7 +1831,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Stream(_) = &types[ty] else {
+        let ComponentDefinedType::Stream { .. } = &types[ty] else {
             bail!(offset, "`stream.drop-writable` requires a stream type")
         };
 
@@ -1848,7 +1848,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(_) = &types[ty] else {
+        let ComponentDefinedType::Future { .. } = &types[ty] else {
             bail!(offset, "`future.new` requires a future type")
         };
 
@@ -1871,7 +1871,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(elem_ty) = &types[ty] else {
+        let ComponentDefinedType::Future { ty: elem_ty, .. } = &types[ty] else {
             bail!(offset, "`future.read` requires a future type")
         };
 
@@ -1911,7 +1911,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(elem_ty) = &types[ty] else {
+        let ComponentDefinedType::Future { ty: elem_ty, .. } = &types[ty] else {
             bail!(offset, "`future.write` requires a future type")
         };
 
@@ -1956,7 +1956,7 @@ impl ComponentState {
         }
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(_) = &types[ty] else {
+        let ComponentDefinedType::Future { .. } = &types[ty] else {
             bail!(offset, "`future.cancel-read` requires a future type")
         };
 
@@ -1986,7 +1986,7 @@ impl ComponentState {
         }
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(_) = &types[ty] else {
+        let ComponentDefinedType::Future { .. } = &types[ty] else {
             bail!(offset, "`future.cancel-write` requires a future type")
         };
 
@@ -2008,7 +2008,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(_) = &types[ty] else {
+        let ComponentDefinedType::Future { .. } = &types[ty] else {
             bail!(offset, "`future.drop-readable` requires a future type")
         };
 
@@ -2030,7 +2030,7 @@ impl ComponentState {
         )?;
 
         let ty = self.defined_type_at(ty, offset)?;
-        let ComponentDefinedType::Future(_) = &types[ty] else {
+        let ComponentDefinedType::Future { .. } = &types[ty] else {
             bail!(offset, "`future.drop-writable` requires a future type")
         };
 
@@ -4028,19 +4028,24 @@ impl ComponentState {
             crate::ComponentDefinedType::Variant(cases) => {
                 self.create_variant_type(cases.as_ref(), types, offset)
             }
-            crate::ComponentDefinedType::List(ty) => Ok(ComponentDefinedType::List(
-                self.create_component_val_type(ty, offset)?,
-            )),
+            crate::ComponentDefinedType::List(ty) => {
+                let element = self.create_component_val_type(ty, offset)?;
+                let mut info = TypeInfo::new();
+                info.combine(element.info(types), offset)?;
+                Ok(ComponentDefinedType::List { element, info })
+            }
             crate::ComponentDefinedType::Map(key, value) => {
                 require_feature::cm_map(
                     self.features,
                     "Maps require the component model map feature",
                     offset,
                 )?;
-                Ok(ComponentDefinedType::Map(
-                    self.create_component_val_type(key, offset)?,
-                    self.create_component_val_type(value, offset)?,
-                ))
+                let key = self.create_component_val_type(key, offset)?;
+                let value = self.create_component_val_type(value, offset)?;
+                let mut info = TypeInfo::new();
+                info.combine(key.info(types), offset)?;
+                info.combine(value.info(types), offset)?;
+                Ok(ComponentDefinedType::Map { key, value, info })
             }
             crate::ComponentDefinedType::FixedLengthList(ty, elements) => {
                 require_feature::cm_fixed_length_lists(
@@ -4061,10 +4066,14 @@ impl ComponentState {
                     "fixed-length list element",
                     offset,
                 )?;
-                Ok(ComponentDefinedType::FixedLengthList(
-                    self.create_component_val_type(ty, offset)?,
-                    elements,
-                ))
+                let element = self.create_component_val_type(ty, offset)?;
+                let mut info = TypeInfo::new();
+                info.combine(element.info(types), offset)?;
+                Ok(ComponentDefinedType::FixedLengthList {
+                    element,
+                    length: elements,
+                    info,
+                })
             }
             crate::ComponentDefinedType::Tuple(tys) => {
                 self.create_tuple_type(tys.as_ref(), types, offset)
@@ -4075,17 +4084,28 @@ impl ComponentState {
             crate::ComponentDefinedType::Enum(cases) => {
                 self.create_enum_type(cases.as_ref(), offset)
             }
-            crate::ComponentDefinedType::Option(ty) => Ok(ComponentDefinedType::Option(
-                self.create_component_val_type(ty, offset)?,
-            )),
-            crate::ComponentDefinedType::Result { ok, err } => Ok(ComponentDefinedType::Result {
-                ok: ok
+            crate::ComponentDefinedType::Option(ty) => {
+                let ty = self.create_component_val_type(ty, offset)?;
+                let mut info = TypeInfo::new();
+                info.combine(ty.info(types), offset)?;
+                Ok(ComponentDefinedType::Option { ty, info })
+            }
+            crate::ComponentDefinedType::Result { ok, err } => {
+                let ok = ok
                     .map(|ty| self.create_component_val_type(ty, offset))
-                    .transpose()?,
-                err: err
+                    .transpose()?;
+                let err = err
                     .map(|ty| self.create_component_val_type(ty, offset))
-                    .transpose()?,
-            }),
+                    .transpose()?;
+                let mut info = TypeInfo::new();
+                if let Some(ty) = &ok {
+                    info.combine(ty.info(types), offset)?;
+                }
+                if let Some(ty) = &err {
+                    info.combine(ty.info(types), offset)?;
+                }
+                Ok(ComponentDefinedType::Result { ok, err, info })
+            }
             crate::ComponentDefinedType::Own(idx) => Ok(ComponentDefinedType::Own(
                 self.resource_at(idx, types, offset)?,
             )),
@@ -4098,10 +4118,14 @@ impl ComponentState {
                     "`future` requires the component model async feature",
                     offset,
                 )?;
-                Ok(ComponentDefinedType::Future(
-                    ty.map(|ty| self.create_component_val_type(ty, offset))
-                        .transpose()?,
-                ))
+                let ty = ty
+                    .map(|ty| self.create_component_val_type(ty, offset))
+                    .transpose()?;
+                let mut info = TypeInfo::new();
+                if let Some(ty) = &ty {
+                    info.combine(ty.info(types), offset)?;
+                }
+                Ok(ComponentDefinedType::Future { ty, info })
             }
             crate::ComponentDefinedType::Stream(ty) => {
                 require_feature::cm_async(
@@ -4127,7 +4151,11 @@ impl ComponentState {
                          with a defined by encoding instead for now"
                     )
                 }
-                Ok(ComponentDefinedType::Stream(ty))
+                let mut info = TypeInfo::new();
+                if let Some(ty) = &ty {
+                    info.combine(ty.info(types), offset)?;
+                }
+                Ok(ComponentDefinedType::Stream { ty, info })
             }
         }
     }

--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -1496,11 +1496,30 @@ pub enum ComponentDefinedType {
     /// The type is a variant.
     Variant(VariantType),
     /// The type is a list.
-    List(ComponentValType),
+    List {
+        /// The element type of the list.
+        element: ComponentValType,
+        /// Cached type information.
+        info: TypeInfo,
+    },
     /// The type is a map.
-    Map(ComponentValType, ComponentValType),
+    Map {
+        /// The key type of the map.
+        key: ComponentValType,
+        /// The value type of the map.
+        value: ComponentValType,
+        /// Cached type information.
+        info: TypeInfo,
+    },
     /// The type is a fixed-length list.
-    FixedLengthList(ComponentValType, u32),
+    FixedLengthList {
+        /// The element type of the list.
+        element: ComponentValType,
+        /// The fixed number of elements in the list.
+        length: u32,
+        /// Cached type information.
+        info: TypeInfo,
+    },
     /// The type is a tuple.
     Tuple(TupleType),
     /// The type is a set of flags.
@@ -1508,52 +1527,58 @@ pub enum ComponentDefinedType {
     /// The type is an enumeration.
     Enum(IndexSet<KebabString>),
     /// The type is an `option`.
-    Option(ComponentValType),
+    Option {
+        /// The payload type of the option.
+        ty: ComponentValType,
+        /// Cached type information.
+        info: TypeInfo,
+    },
     /// The type is a `result`.
     Result {
         /// The `ok` type.
         ok: Option<ComponentValType>,
         /// The `error` type.
         err: Option<ComponentValType>,
+        /// Cached type information.
+        info: TypeInfo,
     },
     /// The type is an owned handle to the specified resource.
     Own(AliasableResourceId),
     /// The type is a borrowed handle to the specified resource.
     Borrow(AliasableResourceId),
     /// A future type with the specified payload type.
-    Future(Option<ComponentValType>),
+    Future {
+        /// The payload type of the future, if any.
+        ty: Option<ComponentValType>,
+        /// Cached type information.
+        info: TypeInfo,
+    },
     /// A stream type with the specified payload type.
-    Stream(Option<ComponentValType>),
+    Stream {
+        /// The payload type of the stream, if any.
+        ty: Option<ComponentValType>,
+        /// Cached type information.
+        info: TypeInfo,
+    },
 }
 
 impl TypeData for ComponentDefinedType {
     type Id = ComponentDefinedTypeId;
     const IS_CORE_SUB_TYPE: bool = false;
-    fn type_info(&self, types: &TypeList) -> TypeInfo {
+    fn type_info(&self, _types: &TypeList) -> TypeInfo {
         match self {
-            Self::Primitive(_)
-            | Self::Flags(_)
-            | Self::Enum(_)
-            | Self::Own(_)
-            | Self::Future(_)
-            | Self::Stream(_) => TypeInfo::new(),
+            Self::Primitive(_) | Self::Flags(_) | Self::Enum(_) | Self::Own(_) => TypeInfo::new(),
             Self::Borrow(_) => TypeInfo::borrow(),
             Self::Record(r) => r.info,
             Self::Variant(v) => v.info,
             Self::Tuple(t) => t.info,
-            Self::List(ty) | Self::FixedLengthList(ty, _) | Self::Option(ty) => ty.info(types),
-            Self::Map(k, v) => {
-                let mut info = k.info(types);
-                info.combine(v.info(types), 0).unwrap();
-                info
-            }
-            Self::Result { ok, err } => {
-                let default = TypeInfo::new();
-                let mut info = ok.map(|ty| ty.type_info(types)).unwrap_or(default);
-                info.combine(err.map(|ty| ty.type_info(types)).unwrap_or(default), 0)
-                    .unwrap();
-                info
-            }
+            Self::List { info, .. }
+            | Self::FixedLengthList { info, .. }
+            | Self::Option { info, .. }
+            | Self::Map { info, .. }
+            | Self::Result { info, .. }
+            | Self::Future { info, .. }
+            | Self::Stream { info, .. } => *info,
         }
     }
 }
@@ -1567,16 +1592,18 @@ impl ComponentDefinedType {
                 .cases
                 .values()
                 .any(|case| case.ty.map(|ty| ty.contains_ptr(types)).unwrap_or(false)),
-            Self::List(_) | Self::Map(_, _) => true,
+            Self::List { .. } | Self::Map { .. } => true,
             Self::Tuple(t) => t.types.iter().any(|ty| ty.contains_ptr(types)),
             Self::Flags(_)
             | Self::Enum(_)
             | Self::Own(_)
             | Self::Borrow(_)
-            | Self::Future(_)
-            | Self::Stream(_) => false,
-            Self::Option(ty) | Self::FixedLengthList(ty, _) => ty.contains_ptr(types),
-            Self::Result { ok, err } => {
+            | Self::Future { .. }
+            | Self::Stream { .. } => false,
+            Self::Option { ty, .. } | Self::FixedLengthList { element: ty, .. } => {
+                ty.contains_ptr(types)
+            }
+            Self::Result { ok, err, .. } => {
                 ok.map(|ty| ty.contains_ptr(types)).unwrap_or(false)
                     || err.map(|ty| ty.contains_ptr(types)).unwrap_or(false)
             }
@@ -1601,13 +1628,15 @@ impl ComponentDefinedType {
                 types,
                 lowered_types,
             ),
-            Self::List(_) | Self::Map(_, _) => {
+            Self::List { .. } | Self::Map { .. } => {
                 lowered_types.try_push(ptr_size.core_type())
                     && lowered_types.try_push(ptr_size.core_type())
             }
-            Self::FixedLengthList(ty, length) => {
-                (0..*length).all(|_n| ty.push_wasm_types(ptr_size, types, lowered_types))
-            }
+            Self::FixedLengthList {
+                element: ty,
+                length,
+                ..
+            } => (0..*length).all(|_n| ty.push_wasm_types(ptr_size, types, lowered_types)),
             Self::Tuple(t) => t
                 .types
                 .iter()
@@ -1615,13 +1644,15 @@ impl ComponentDefinedType {
             Self::Flags(names) => {
                 (0..(names.len() + 31) / 32).all(|_| lowered_types.try_push(ValType::I32))
             }
-            Self::Enum(_) | Self::Own(_) | Self::Borrow(_) | Self::Future(_) | Self::Stream(_) => {
-                lowered_types.try_push(ValType::I32)
-            }
-            Self::Option(ty) => {
+            Self::Enum(_)
+            | Self::Own(_)
+            | Self::Borrow(_)
+            | Self::Future { .. }
+            | Self::Stream { .. } => lowered_types.try_push(ValType::I32),
+            Self::Option { ty, .. } => {
                 Self::push_variant_wasm_types([ty].into_iter(), ptr_size, types, lowered_types)
             }
-            Self::Result { ok, err } => Self::push_variant_wasm_types(
+            Self::Result { ok, err, .. } => Self::push_variant_wasm_types(
                 ok.iter().chain(err.iter()),
                 ptr_size,
                 types,
@@ -1684,15 +1715,15 @@ impl ComponentDefinedType {
             ComponentDefinedType::Tuple(_) => "tuple",
             ComponentDefinedType::Enum(_) => "enum",
             ComponentDefinedType::Flags(_) => "flags",
-            ComponentDefinedType::Option(_) => "option",
-            ComponentDefinedType::List(_) => "list",
-            ComponentDefinedType::Map(_, _) => "map",
-            ComponentDefinedType::FixedLengthList(_, _) => "fixed-length list",
+            ComponentDefinedType::Option { .. } => "option",
+            ComponentDefinedType::List { .. } => "list",
+            ComponentDefinedType::Map { .. } => "map",
+            ComponentDefinedType::FixedLengthList { .. } => "fixed-length list",
             ComponentDefinedType::Result { .. } => "result",
             ComponentDefinedType::Own(_) => "own",
             ComponentDefinedType::Borrow(_) => "borrow",
-            ComponentDefinedType::Future(_) => "future",
-            ComponentDefinedType::Stream(_) => "stream",
+            ComponentDefinedType::Future { .. } => "future",
+            ComponentDefinedType::Stream { .. } => "stream",
         }
     }
 
@@ -1711,7 +1742,8 @@ impl ComponentDefinedType {
 
             ComponentDefinedType::Variant(ty) => ty.lower_gc(types, abi, options, offset, core),
 
-            ComponentDefinedType::List(ty) | ComponentDefinedType::FixedLengthList(ty, _) => {
+            ComponentDefinedType::List { element: ty, .. }
+            | ComponentDefinedType::FixedLengthList { element: ty, .. } => {
                 let id = match core.as_concrete_ref() {
                     Some(id) => id,
                     None => bail!(
@@ -1731,7 +1763,7 @@ impl ComponentDefinedType {
                 ty.lower_gc(types, abi, options, offset, array_ty.0.element_type.into())
             }
 
-            ComponentDefinedType::Map(_, _) => bail!(
+            ComponentDefinedType::Map { .. } => bail!(
                 offset,
                 "GC lowering for component `map` type is not yet implemented"
             ),
@@ -1763,7 +1795,7 @@ impl ComponentDefinedType {
                 }
             }
 
-            ComponentDefinedType::Option(_) => {
+            ComponentDefinedType::Option { .. } => {
                 lower_gc_sum_type(types, abi, options, offset, core, "option")
             }
 
@@ -1773,8 +1805,8 @@ impl ComponentDefinedType {
 
             ComponentDefinedType::Own(_)
             | ComponentDefinedType::Borrow(_)
-            | ComponentDefinedType::Future(_)
-            | ComponentDefinedType::Stream(_) => {
+            | ComponentDefinedType::Future { .. }
+            | ComponentDefinedType::Stream { .. } => {
                 if let Some(r) = core.as_ref_type() {
                     if let HeapType::Abstract {
                         shared: _,
@@ -2563,16 +2595,16 @@ impl TypeAlloc {
                     }
                 }
             }
-            ComponentDefinedType::List(ty)
-            | ComponentDefinedType::FixedLengthList(ty, _)
-            | ComponentDefinedType::Option(ty) => {
+            ComponentDefinedType::List { element: ty, .. }
+            | ComponentDefinedType::FixedLengthList { element: ty, .. }
+            | ComponentDefinedType::Option { ty, .. } => {
                 self.free_variables_valtype(ty, set);
             }
-            ComponentDefinedType::Map(k, v) => {
-                self.free_variables_valtype(k, set);
-                self.free_variables_valtype(v, set);
+            ComponentDefinedType::Map { key, value, .. } => {
+                self.free_variables_valtype(key, set);
+                self.free_variables_valtype(value, set);
             }
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 if let Some(ok) = ok {
                     self.free_variables_valtype(ok, set);
                 }
@@ -2583,12 +2615,7 @@ impl TypeAlloc {
             ComponentDefinedType::Own(id) | ComponentDefinedType::Borrow(id) => {
                 set.insert(id.resource());
             }
-            ComponentDefinedType::Future(ty) => {
-                if let Some(ty) = ty {
-                    self.free_variables_valtype(ty, set);
-                }
-            }
-            ComponentDefinedType::Stream(ty) => {
+            ComponentDefinedType::Future { ty, .. } | ComponentDefinedType::Stream { ty, .. } => {
                 if let Some(ty) = ty {
                     self.free_variables_valtype(ty, set);
                 }
@@ -2702,7 +2729,7 @@ impl TypeAlloc {
             ComponentDefinedType::Tuple(r) => {
                 r.types.iter().all(|t| self.type_named_valtype(t, set))
             }
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 ok.as_ref()
                     .map(|t| self.type_named_valtype(t, set))
                     .unwrap_or(true)
@@ -2711,11 +2738,11 @@ impl TypeAlloc {
                         .map(|t| self.type_named_valtype(t, set))
                         .unwrap_or(true)
             }
-            ComponentDefinedType::List(ty)
-            | ComponentDefinedType::FixedLengthList(ty, _)
-            | ComponentDefinedType::Option(ty) => self.type_named_valtype(ty, set),
-            ComponentDefinedType::Map(k, v) => {
-                self.type_named_valtype(k, set) && self.type_named_valtype(v, set)
+            ComponentDefinedType::List { element: ty, .. }
+            | ComponentDefinedType::FixedLengthList { element: ty, .. }
+            | ComponentDefinedType::Option { ty, .. } => self.type_named_valtype(ty, set),
+            ComponentDefinedType::Map { key, value, .. } => {
+                self.type_named_valtype(key, set) && self.type_named_valtype(value, set)
             }
 
             // own/borrow themselves don't have to be named, but the resource
@@ -2724,12 +2751,7 @@ impl TypeAlloc {
                 set.contains(&ComponentAnyTypeId::from(*id))
             }
 
-            ComponentDefinedType::Future(ty) => ty
-                .as_ref()
-                .map(|ty| self.type_named_valtype(ty, set))
-                .unwrap_or(true),
-
-            ComponentDefinedType::Stream(ty) => ty
+            ComponentDefinedType::Future { ty, .. } | ComponentDefinedType::Stream { ty, .. } => ty
                 .as_ref()
                 .map(|ty| self.type_named_valtype(ty, set))
                 .unwrap_or(true),
@@ -2904,16 +2926,16 @@ where
                     }
                 }
             }
-            ComponentDefinedType::List(ty)
-            | ComponentDefinedType::FixedLengthList(ty, _)
-            | ComponentDefinedType::Option(ty) => {
+            ComponentDefinedType::List { element: ty, .. }
+            | ComponentDefinedType::FixedLengthList { element: ty, .. }
+            | ComponentDefinedType::Option { ty, .. } => {
                 any_changed |= self.remap_valtype(ty, map);
             }
-            ComponentDefinedType::Map(k, v) => {
-                any_changed |= self.remap_valtype(k, map);
-                any_changed |= self.remap_valtype(v, map);
+            ComponentDefinedType::Map { key, value, .. } => {
+                any_changed |= self.remap_valtype(key, map);
+                any_changed |= self.remap_valtype(value, map);
             }
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 if let Some(ok) = ok {
                     any_changed |= self.remap_valtype(ok, map);
                 }
@@ -2924,7 +2946,7 @@ where
             ComponentDefinedType::Own(id) | ComponentDefinedType::Borrow(id) => {
                 any_changed |= self.remap_resource_id(id, map);
             }
-            ComponentDefinedType::Future(ty) | ComponentDefinedType::Stream(ty) => {
+            ComponentDefinedType::Future { ty, .. } | ComponentDefinedType::Stream { ty, .. } => {
                 if let Some(ty) = ty {
                     any_changed |= self.remap_valtype(ty, map);
                 }
@@ -3827,24 +3849,43 @@ impl<'a> SubtypeCx<'a> {
                 Ok(())
             }
             (Variant(_), b) => bail!(offset, "expected {}, found variant", b.desc()),
-            (List(a), List(b)) | (Option(a), Option(b)) => self.component_val_type(a, b, offset),
-            (List(_), b) => bail!(offset, "expected {}, found list", b.desc()),
-            (Map(ak, av), Map(bk, bv)) => {
+            (List { element: a, .. }, List { element: b, .. })
+            | (Option { ty: a, .. }, Option { ty: b, .. }) => self.component_val_type(a, b, offset),
+            (List { .. }, b) => bail!(offset, "expected {}, found list", b.desc()),
+            (
+                Map {
+                    key: ak, value: av, ..
+                },
+                Map {
+                    key: bk, value: bv, ..
+                },
+            ) => {
                 self.component_val_type(ak, bk, offset)
                     .with_context(|| "type mismatch in map key")?;
                 self.component_val_type(av, bv, offset)
                     .with_context(|| "type mismatch in map value")
             }
-            (Map(_, _), b) => bail!(offset, "expected {}, found map", b.desc()),
-            (FixedLengthList(a, asize), FixedLengthList(b, bsize)) => {
+            (Map { .. }, b) => bail!(offset, "expected {}, found map", b.desc()),
+            (
+                FixedLengthList {
+                    element: a,
+                    length: asize,
+                    ..
+                },
+                FixedLengthList {
+                    element: b,
+                    length: bsize,
+                    ..
+                },
+            ) => {
                 if asize != bsize {
                     bail!(offset, "expected fixed-length {bsize}, found size {asize}")
                 } else {
                     self.component_val_type(a, b, offset)
                 }
             }
-            (FixedLengthList(_, _), b) => bail!(offset, "expected {}, found list", b.desc()),
-            (Option(_), b) => bail!(offset, "expected {}, found option", b.desc()),
+            (FixedLengthList { .. }, b) => bail!(offset, "expected {}, found list", b.desc()),
+            (Option { .. }, b) => bail!(offset, "expected {}, found option", b.desc()),
             (Tuple(a), Tuple(b)) => {
                 if a.types.len() != b.types.len() {
                     bail!(
@@ -3874,7 +3915,14 @@ impl<'a> SubtypeCx<'a> {
             }
             (Flags(_), b) => bail!(offset, "expected {}, found flags", b.desc()),
             (Enum(_), b) => bail!(offset, "expected {}, found enum", b.desc()),
-            (Result { ok: ao, err: ae }, Result { ok: bo, err: be }) => {
+            (
+                Result {
+                    ok: ao, err: ae, ..
+                },
+                Result {
+                    ok: bo, err: be, ..
+                },
+            ) => {
                 match (ao, bo) {
                     (None, None) => {}
                     (Some(a), Some(b)) => self
@@ -3903,7 +3951,7 @@ impl<'a> SubtypeCx<'a> {
             }
             (Own(_), b) => bail!(offset, "expected {}, found own", b.desc()),
             (Borrow(_), b) => bail!(offset, "expected {}, found borrow", b.desc()),
-            (Future(a), Future(b)) => match (a, b) {
+            (Future { ty: a, .. }, Future { ty: b, .. }) => match (a, b) {
                 (None, None) => Ok(()),
                 (Some(a), Some(b)) => self
                     .component_val_type(a, b, offset)
@@ -3911,8 +3959,8 @@ impl<'a> SubtypeCx<'a> {
                 (None, Some(_)) => bail!(offset, "expected future type, but found none"),
                 (Some(_), None) => bail!(offset, "expected future type to not be present"),
             },
-            (Future(_), b) => bail!(offset, "expected {}, found future", b.desc()),
-            (Stream(a), Stream(b)) => match (a, b) {
+            (Future { .. }, b) => bail!(offset, "expected {}, found future", b.desc()),
+            (Stream { ty: a, .. }, Stream { ty: b, .. }) => match (a, b) {
                 (None, None) => Ok(()),
                 (Some(a), Some(b)) => self
                     .component_val_type(a, b, offset)
@@ -3920,7 +3968,7 @@ impl<'a> SubtypeCx<'a> {
                 (None, Some(_)) => bail!(offset, "expected stream type, but found none"),
                 (Some(_), None) => bail!(offset, "expected stream type to not be present"),
             },
-            (Stream(_), b) => bail!(offset, "expected {}, found stream", b.desc()),
+            (Stream { .. }, b) => bail!(offset, "expected {}, found stream", b.desc()),
         }
     }
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -169,14 +169,20 @@ impl TypeData for Range<CoreTypeId> {
 
 /// Metadata about a type and its transitive structure.
 ///
-/// Currently contains two properties:
+/// Currently contains three properties:
 ///
 /// * The "size" of a type - a proxy to the recursive size of a type if
 ///   everything in the type were unique (e.g. no shared references). Not an
 ///   approximation of runtime size, but instead of type-complexity size if
 ///   someone were to visit each element of the type individually. For example
 ///   `u32` has size 1 and `(list u32)` has size 2 (roughly). Used to prevent
-///   massive trees of types.
+///   massive trees of types and model the complexity time that would be needed
+///   to visit each "node" in the tree of this type.
+///
+/// * The "depth" of a type - used to model if a visit/walk was performed
+///   over this type how many recursive calls would be necessary. This is capped
+///   for example to prevent stack overflow. All types start with depth 1, and
+///   for example `(list u32)` would have depth 2.
 ///
 /// * Whether or not a type contains a "borrow" transitively inside of it. For
 ///   example `(borrow $t)` and `(list (borrow $t))` both contain borrows, but
@@ -184,67 +190,95 @@ impl TypeData for Range<CoreTypeId> {
 ///   not contain borrows.
 ///
 /// Currently this is represented as a compact 32-bit integer to ensure that
-/// `TypeId`, which this is stored in, remains relatively small. The maximum
-/// type size allowed in wasmparser is 1M at this time which is 20 bits of
-/// information, and then one more bit is used for whether or not a borrow is
-/// used. Currently this uses the low 24 bits for the type size and the MSB for
-/// the borrow bit.
+/// `TypeId`, which this is stored in, remains relatively small.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // Only public because it shows up in a public trait's `doc(hidden)` method.
 #[doc(hidden)]
 pub struct TypeInfo(u32);
 
 impl TypeInfo {
+    /// Current maximum is 1M, so 24 bits should be enough to represent this.
+    const SIZE_BITS: u32 = 24;
+    /// Current maximum is 100, fitting in 7 bits.
+    const DEPTH_BITS: u32 = 7;
+
+    const SIZE_OFFSET: u32 = 0;
+    const DEPTH_OFFSET: u32 = Self::SIZE_OFFSET + Self::SIZE_BITS;
+    const CONTAINS_BORROW_OFFSET: u32 = Self::DEPTH_OFFSET + Self::DEPTH_BITS;
+
+    const SIZE_MASK: u32 = ((1 << Self::SIZE_BITS) - 1) << Self::SIZE_OFFSET;
+    const DEPTH_MASK: u32 = ((1 << Self::DEPTH_BITS) - 1) << Self::DEPTH_OFFSET;
+    const CONTAINS_BORROW_MASK: u32 = 1 << Self::CONTAINS_BORROW_OFFSET;
+
+    const MAX_SIZE: u32 = (1 << Self::SIZE_BITS) - 1;
+    const MAX_DEPTH: u32 = (1 << Self::DEPTH_BITS) - 1;
+    const _ASSERT: () = {
+        assert!(Self::CONTAINS_BORROW_OFFSET < 32);
+        assert!(Self::MAX_DEPTH > crate::limits::MAX_WASM_COMPONENT_TYPE_DEPTH);
+        assert!(Self::MAX_SIZE > crate::limits::MAX_WASM_TYPE_SIZE);
+    };
+
     /// Creates a new blank set of type information.
     ///
     /// Defaults to size 1 to ensure that this consumes space in the final type
     /// structure.
     pub(crate) fn new() -> TypeInfo {
-        TypeInfo::_new(1, false)
+        TypeInfo::_new(1, 1, false)
     }
 
     /// Creates a new blank set of information about a leaf "borrow" type which
     /// has size 1.
     #[cfg(feature = "component-model")]
     pub(crate) fn borrow() -> TypeInfo {
-        TypeInfo::_new(1, true)
+        TypeInfo::_new(1, 1, true)
     }
 
     /// Creates type information corresponding to a core type of the `size`
     /// specified, meaning no borrows are contained within.
     pub(crate) fn core(size: u32) -> TypeInfo {
-        TypeInfo::_new(size, false)
+        TypeInfo::_new(size, 1, false)
     }
 
-    fn _new(size: u32, contains_borrow: bool) -> TypeInfo {
-        assert!(size < (1 << 24));
-        TypeInfo(size | ((contains_borrow as u32) << 31))
+    fn _new(size: u32, depth: u32, contains_borrow: bool) -> TypeInfo {
+        assert!(size <= Self::MAX_SIZE);
+        assert!(depth <= Self::MAX_DEPTH);
+        TypeInfo(
+            (size << Self::SIZE_OFFSET)
+                | (depth << Self::DEPTH_OFFSET)
+                | ((contains_borrow as u32) << Self::CONTAINS_BORROW_OFFSET),
+        )
     }
 
     /// Combines another set of type information into this one, for example if
     /// this is a record which has `other` as a field.
     ///
-    /// Updates the size of `self` and whether or not this type contains a
-    /// borrow based on whether `other` contains a borrow.
+    /// Updates the this info's various fields (size, depth, etc) based on this
+    /// being an aggregate containing `other`.
     ///
     /// Returns an error if the type size would exceed this crate's static limit
     /// of a type size.
     #[cfg(feature = "component-model")]
     pub(crate) fn combine(&mut self, other: TypeInfo, offset: usize) -> Result<()> {
-        *self = TypeInfo::_new(
-            super::combine_type_sizes(self.size(), other.size(), offset)?,
-            self.contains_borrow() || other.contains_borrow(),
-        );
+        let depth = self.depth().max(other.depth().saturating_add(1));
+        let size = super::combine_type_sizes(self.size(), other.size(), offset)?;
+        let contains_borrow = self.contains_borrow() || other.contains_borrow();
+        *self = TypeInfo::_new(size, depth, contains_borrow);
         Ok(())
     }
 
     pub(crate) fn size(&self) -> u32 {
-        self.0 & 0xffffff
+        (self.0 & Self::SIZE_MASK) >> Self::SIZE_OFFSET
+    }
+
+    /// The structural nesting depth of the type (see `MAX_WASM_COMPONENT_TYPE_DEPTH`).
+    #[cfg(feature = "component-model")]
+    pub(crate) fn depth(&self) -> u32 {
+        (self.0 & Self::DEPTH_MASK) >> Self::DEPTH_OFFSET
     }
 
     #[cfg(feature = "component-model")]
     pub(crate) fn contains_borrow(&self) -> bool {
-        (self.0 >> 31) != 0
+        (self.0 & Self::CONTAINS_BORROW_MASK) != 0
     }
 }
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -207,13 +207,16 @@ impl TypeInfo {
     const CONTAINS_BORROW_OFFSET: u32 = Self::DEPTH_OFFSET + Self::DEPTH_BITS;
 
     const SIZE_MASK: u32 = ((1 << Self::SIZE_BITS) - 1) << Self::SIZE_OFFSET;
+    #[cfg(feature = "component-model")]
     const DEPTH_MASK: u32 = ((1 << Self::DEPTH_BITS) - 1) << Self::DEPTH_OFFSET;
+    #[cfg(feature = "component-model")]
     const CONTAINS_BORROW_MASK: u32 = 1 << Self::CONTAINS_BORROW_OFFSET;
 
     const MAX_SIZE: u32 = (1 << Self::SIZE_BITS) - 1;
     const MAX_DEPTH: u32 = (1 << Self::DEPTH_BITS) - 1;
     const _ASSERT: () = {
         assert!(Self::CONTAINS_BORROW_OFFSET < 32);
+        #[cfg(feature = "component-model")]
         assert!(Self::MAX_DEPTH > crate::limits::MAX_WASM_COMPONENT_TYPE_DEPTH);
         assert!(Self::MAX_SIZE > crate::limits::MAX_WASM_TYPE_SIZE);
     };

--- a/crates/wasmparser/tests/big-module.rs
+++ b/crates/wasmparser/tests/big-module.rs
@@ -60,3 +60,36 @@ fn big_function_body() {
     let result = wasmparser::Validator::default().validate_all(&wasm);
     assert!(result.is_err());
 }
+
+#[test]
+fn deeply_nested_component_defined_type() {
+    fn build(n: u32) -> Vec<u8> {
+        let mut types = ComponentTypeSection::new();
+        types.defined_type().primitive(PrimitiveValType::Bool);
+        for i in 1..n {
+            types.defined_type().list(ComponentValType::Type(i - 1));
+        }
+        let mut exports = ComponentExportSection::new();
+        exports.export("foo", ComponentExportKind::Type, n - 1, None);
+        let mut component = Component::new();
+        component.section(&types);
+        component.section(&exports);
+        component.finish()
+    }
+
+    let features = wasmparser::WasmFeatures::all();
+
+    // Don't stack overflow please.
+    assert!(
+        wasmparser::Validator::new_with_features(features)
+            .validate_all(&build(100_000))
+            .is_err()
+    );
+
+    // But do allow somewhat deep types.
+    assert!(
+        wasmparser::Validator::new_with_features(features)
+            .validate_all(&build(50))
+            .is_ok()
+    );
+}

--- a/crates/wit-parser/src/decoding.rs
+++ b/crates/wit-parser/src/decoding.rs
@@ -1301,20 +1301,22 @@ impl WitPackageDecoder<'_> {
         match ty {
             ComponentDefinedType::Primitive(t) => Ok(TypeDefKind::Type(self.convert_primitive(*t))),
 
-            ComponentDefinedType::List(t) => {
-                let t = self.convert_valtype(t)?;
+            ComponentDefinedType::List { element, .. } => {
+                let t = self.convert_valtype(element)?;
                 Ok(TypeDefKind::List(t))
             }
 
-            ComponentDefinedType::Map(k, v) => {
-                let k = self.convert_valtype(k)?;
-                let v = self.convert_valtype(v)?;
+            ComponentDefinedType::Map { key, value, .. } => {
+                let k = self.convert_valtype(key)?;
+                let v = self.convert_valtype(value)?;
                 Ok(TypeDefKind::Map(k, v))
             }
 
-            ComponentDefinedType::FixedLengthList(t, size) => {
-                let t = self.convert_valtype(t)?;
-                Ok(TypeDefKind::FixedLengthList(t, *size))
+            ComponentDefinedType::FixedLengthList {
+                element, length, ..
+            } => {
+                let t = self.convert_valtype(element)?;
+                Ok(TypeDefKind::FixedLengthList(t, *length))
             }
 
             ComponentDefinedType::Tuple(t) => {
@@ -1326,12 +1328,12 @@ impl WitPackageDecoder<'_> {
                 Ok(TypeDefKind::Tuple(Tuple { types }))
             }
 
-            ComponentDefinedType::Option(t) => {
-                let t = self.convert_valtype(t)?;
+            ComponentDefinedType::Option { ty, .. } => {
+                let t = self.convert_valtype(ty)?;
                 Ok(TypeDefKind::Option(t))
             }
 
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 let ok = match ok {
                     Some(t) => Some(self.convert_valtype(t)?),
                     None => None,
@@ -1417,11 +1419,11 @@ impl WitPackageDecoder<'_> {
                 Ok(TypeDefKind::Handle(Handle::Borrow(id)))
             }
 
-            ComponentDefinedType::Future(ty) => Ok(TypeDefKind::Future(
+            ComponentDefinedType::Future { ty, .. } => Ok(TypeDefKind::Future(
                 ty.as_ref().map(|ty| self.convert_valtype(ty)).transpose()?,
             )),
 
-            ComponentDefinedType::Stream(ty) => Ok(TypeDefKind::Stream(
+            ComponentDefinedType::Stream { ty, .. } => Ok(TypeDefKind::Stream(
                 ty.as_ref().map(|ty| self.convert_valtype(ty)).transpose()?,
             )),
         }
@@ -1600,7 +1602,7 @@ impl Registrar<'_> {
         match def {
             ComponentDefinedType::Primitive(_) => Ok(()),
 
-            ComponentDefinedType::List(t) => {
+            ComponentDefinedType::List { element, .. } => {
                 let ty = match &self.resolve.types[id].kind {
                     TypeDefKind::List(r) => r,
                     // Note that all cases below have this match and the general
@@ -1613,26 +1615,28 @@ impl Registrar<'_> {
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
                     _ => bail!("expected a list"),
                 };
-                self.valtype(t, ty)
+                self.valtype(element, ty)
             }
 
-            ComponentDefinedType::Map(k, v) => {
+            ComponentDefinedType::Map { key, value, .. } => {
                 let (key_ty, value_ty) = match &self.resolve.types[id].kind {
                     TypeDefKind::Map(k, v) => (k, v),
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
                     _ => bail!("expected a map"),
                 };
-                self.valtype(k, key_ty)?;
-                self.valtype(v, value_ty)
+                self.valtype(key, key_ty)?;
+                self.valtype(value, value_ty)
             }
 
-            ComponentDefinedType::FixedLengthList(t, elements) => {
+            ComponentDefinedType::FixedLengthList {
+                element, length, ..
+            } => {
                 let ty = match &self.resolve.types[id].kind {
-                    TypeDefKind::FixedLengthList(r, elements2) if elements2 == elements => r,
+                    TypeDefKind::FixedLengthList(r, elements2) if elements2 == length => r,
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
-                    _ => bail!("expected a fixed-length {elements} list"),
+                    _ => bail!("expected a fixed-length {length} list"),
                 };
-                self.valtype(t, ty)
+                self.valtype(element, ty)
             }
 
             ComponentDefinedType::Tuple(t) => {
@@ -1650,7 +1654,7 @@ impl Registrar<'_> {
                 Ok(())
             }
 
-            ComponentDefinedType::Option(t) => {
+            ComponentDefinedType::Option { ty: t, .. } => {
                 let ty = match &self.resolve.types[id].kind {
                     TypeDefKind::Option(r) => r,
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
@@ -1659,7 +1663,7 @@ impl Registrar<'_> {
                 self.valtype(t, ty)
             }
 
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Result { ok, err, .. } => {
                 let ty = match &self.resolve.types[id].kind {
                     TypeDefKind::Result(r) => r,
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
@@ -1718,7 +1722,7 @@ impl Registrar<'_> {
                 Ok(())
             }
 
-            ComponentDefinedType::Future(payload) => {
+            ComponentDefinedType::Future { ty: payload, .. } => {
                 let ty = match &self.resolve.types[id].kind {
                     TypeDefKind::Future(p) => p,
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),
@@ -1731,7 +1735,7 @@ impl Registrar<'_> {
                 }
             }
 
-            ComponentDefinedType::Stream(payload) => {
+            ComponentDefinedType::Stream { ty: payload, .. } => {
                 let ty = match &self.resolve.types[id].kind {
                     TypeDefKind::Stream(p) => p,
                     TypeDefKind::Type(Type::Id(_)) => return Ok(()),


### PR DESCRIPTION
This commit adds a new validation to `wasmparser` to ensure that component model types aren't "too deep". The primary goal of this commit is to resolve `wasmparser` stack-overflowing during validation of a component which otherwise has an arbitrarily deeply nested type (e.g. `list<list<list<...`). The limit placed on types right now is 100.

One important part to note here is that this has some interesting relation to the checks Wasmtime does. Wasmtime actually already has a check for type depth as well, additionally limiting to 100. This is what gives rise to the value chosen here and additionally confidence that this won't break any realistic components in the wild. One important note though is that Wasmtime's depth-check actually only prevents stack overflow at runtime and it's still possible to stack-overflow at translation time (due to the order of when checks are applied). The fix here will resolve this problem in Wasmtime as well.

A final note is that the rationale for this check is that many algorithms over component model types are modeled as recursive algorithms. In this situation an arbitrarily nested type can lead to stack overflow easily not just in validation but when processing elsewhere in the system. For example this means that even if the stack overflow were fixed in `wasmparser` itself that would not be sufficient to fully support arbitrarily nested types everywhere in the component ecosystem (e.g. WIT crates, etc).