### PR TITLE
Fix requiring `realloc` for `async`-lowered results-with-pointers

### DIFF
--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -1265,17 +1265,17 @@ impl ComponentFuncType {
             }
         }
 
+        // Results of lowered functions that contains pointers must be allocated
+        // by the callee meaning that realloc is required. Results of lifted
+        // function are allocated by the guest which means that no realloc
+        // option is necessary.
+        if let Some(ty) = &self.result {
+            options.require_realloc_if(offset, || abi == Abi::Lower && ty.contains_ptr(types))?;
+        }
+
         match (abi, options.concurrency) {
             (Abi::Lower | Abi::Lift, Concurrency::Sync) => {
                 if let Some(ty) = &self.result {
-                    // Results of lowered functions that contains pointers must be
-                    // allocated by the callee meaning that realloc is required.
-                    // Results of lifted function are allocated by the guest which
-                    // means that no realloc option is necessary.
-                    options.require_realloc_if(offset, || {
-                        abi == Abi::Lower && ty.contains_ptr(types)
-                    })?;
-
                     if !ty.push_wasm_types(ptr_size, types, &mut sig.results) {
                         // Too many results to return directly, either a retptr
                         // parameter will be used (import) or a single pointer

--- a/tests/cli/component-model/async/lower.wast
+++ b/tests/cli/component-model/async/lower.wast
@@ -48,3 +48,21 @@
   )
   "the `async` canonical option requires an async function type"
 )
+
+;; `async` option requires as `async` function type
+(assert_invalid
+  (component
+    (import "foo" (func $foo async (result string)))
+    (core func $foo (canon lower (func $foo) async))
+  )
+  "canonical option `memory` is required"
+)
+(assert_invalid
+  (component
+    (import "foo" (func $foo async (result string)))
+    (core module $libc (memory (export "memory") 1))
+    (core instance $libc (instantiate $libc))
+    (core func $foo (canon lower (func $foo) async (memory (core memory $libc "memory"))))
+  )
+  "canonical option `realloc` is required"
+)

--- a/tests/snapshots/cli/component-model/async/lower.wast.json
+++ b/tests/snapshots/cli/component-model/async/lower.wast.json
@@ -27,6 +27,20 @@
       "filename": "lower.3.wasm",
       "module_type": "binary",
       "text": "the `async` canonical option requires an async function type"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 54,
+      "filename": "lower.4.wasm",
+      "module_type": "binary",
+      "text": "canonical option `memory` is required"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 61,
+      "filename": "lower.5.wasm",
+      "module_type": "binary",
+      "text": "canonical option `realloc` is required"
     }
   ]
 }


### PR DESCRIPTION
This commit fixes a mistake in the validation of `canon lower` options when the `async` ABI was used. Previously it accidentally skipped the requirement the `realloc` was present, but any lower'd functions with results that contain pointers (strings, lists, etc), requires `realloc`.