### PR TITLE
Pass flattened fixed-length lists as a pointer to linear memory

### DIFF
--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -1632,11 +1632,7 @@ impl ComponentDefinedType {
                 lowered_types.try_push(ptr_size.core_type())
                     && lowered_types.try_push(ptr_size.core_type())
             }
-            Self::FixedLengthList {
-                element: ty,
-                length,
-                ..
-            } => (0..*length).all(|_n| ty.push_wasm_types(ptr_size, types, lowered_types)),
+            Self::FixedLengthList { .. } => lowered_types.try_push(ptr_size.core_type()),
             Self::Tuple(t) => t
                 .types
                 .iter()

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -340,9 +340,7 @@ impl Resolve {
                     result.push(WasmType::Pointer) && result.push(WasmType::Length)
                 }
 
-                TypeDefKind::FixedLengthList(ty, size) => {
-                    self.push_flat_list((0..*size).map(|_| ty), result)
-                }
+                TypeDefKind::FixedLengthList(_, _) => result.push(WasmType::Pointer),
 
                 TypeDefKind::Variant(v) => {
                     result.push(v.tag().into())

--- a/tests/cli/component-model/async/abi.wast
+++ b/tests/cli/component-model/async/abi.wast
@@ -92,7 +92,7 @@
     (memory (export "memory") 1)
     (func (export "cb") (param i32 i32 i32) (result i32) unreachable)
     (func (export "realloc") (param i32 i32 i32 i32) (result i32) unreachable)
-    (func (export "f") (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32) unreachable))
+    (func (export "f") (param i32) (result i32) unreachable))
   (core instance $m6 (instantiate $m6))
   (func async (param "x" (list string 4))
     (canon lift (core func $m6 "f") async (callback (core func $m6 "cb"))

--- a/tests/cli/component-model/async/stackful.wast
+++ b/tests/cli/component-model/async/stackful.wast
@@ -115,7 +115,7 @@
   (core module $m6
     (memory (export "memory") 1)
     (func (export "realloc") (param i32 i32 i32 i32) (result i32) unreachable)
-    (func (export "f") (param i32 i32 i32 i32 i32 i32 i32 i32) unreachable))
+    (func (export "f") (param i32) unreachable))
   (core instance $m6 (instantiate $m6))
   (func async (param "x" (list string 4))
     (canon lift (core func $m6 "f") async

--- a/tests/cli/component-model/fixed-length-lists.wast
+++ b/tests/cli/component-model/fixed-length-lists.wast
@@ -14,7 +14,7 @@
 
 (component
   (core module $m
-    (func (export "param-list") (param i32 i32 i32 i32) unreachable)
+    (func (export "param-list") (param i32) unreachable)
   )
   (core instance $i (instantiate $m))
 

--- a/tests/snapshots/cli/component-model/async/abi.wast/1.print
+++ b/tests/snapshots/cli/component-model/async/abi.wast/1.print
@@ -96,7 +96,7 @@
   (core module $m6 (;5;)
     (type (;0;) (func (param i32 i32 i32) (result i32)))
     (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;2;) (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+    (type (;2;) (func (param i32) (result i32)))
     (memory (;0;) 1)
     (export "memory" (memory 0))
     (export "cb" (func 0))
@@ -108,7 +108,7 @@
     (func (;1;) (type 1) (param i32 i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;2;) (type 2) (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+    (func (;2;) (type 2) (param i32) (result i32)
       unreachable
     )
   )

--- a/tests/snapshots/cli/component-model/async/stackful.wast/6.print
+++ b/tests/snapshots/cli/component-model/async/stackful.wast/6.print
@@ -65,7 +65,7 @@
   (func (;4;) (type 4) (canon lift (core func 4) async (memory 0) (realloc 5)))
   (core module $m6 (;5;)
     (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;1;) (func (param i32 i32 i32 i32 i32 i32 i32 i32)))
+    (type (;1;) (func (param i32)))
     (memory (;0;) 1)
     (export "memory" (memory 0))
     (export "realloc" (func 0))
@@ -73,7 +73,7 @@
     (func (;0;) (type 0) (param i32 i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;1;) (type 1) (param i32 i32 i32 i32 i32 i32 i32 i32)
+    (func (;1;) (type 1) (param i32)
       unreachable
     )
   )

--- a/tests/snapshots/cli/component-model/fixed-length-lists.wast/1.print
+++ b/tests/snapshots/cli/component-model/fixed-length-lists.wast/1.print
@@ -1,8 +1,8 @@
 (component
   (core module $m (;0;)
-    (type (;0;) (func (param i32 i32 i32 i32)))
+    (type (;0;) (func (param i32)))
     (export "param-list" (func 0))
-    (func (;0;) (type 0) (param i32 i32 i32 i32)
+    (func (;0;) (type 0) (param i32)
       unreachable
     )
   )


### PR DESCRIPTION
See https://github.com/WebAssembly/component-model/pull/640 for details and https://github.com/WebAssembly/WASI/issues/944#issuecomment-5071783209 for the motivation.