### PR TITLE
feat(wit-parser): add more <resource>-not-found variants to `ResolveErrorKind`

### DIFF
--- a/crates/wit-parser/src/resolve/error.rs
+++ b/crates/wit-parser/src/resolve/error.rs
@@ -104,7 +104,10 @@ impl fmt::Display for ResolveErrorKind {
             } => write!(f, "world '{requested}' not found in package '{package}'"),
             ResolveErrorKind::InterfaceNotFound {
                 requested, package, ..
-            } => write!(f, "interface '{requested}' not found in package '{package}'"),
+            } => write!(
+                f,
+                "interface '{requested}' not found in package '{package}'"
+            ),
             ResolveErrorKind::InvalidTransitiveDependency { name, .. } => write!(
                 f,
                 "interface `{name}` transitively depends on an interface in incompatible ways",

--- a/crates/wit-parser/src/resolve/error.rs
+++ b/crates/wit-parser/src/resolve/error.rs
@@ -11,6 +11,10 @@ use crate::{PackageName, SourceMap, Span, Stability};
 /// Convenience alias for a `Result` whose error type is [`ResolveError`].
 pub type ResolveResult<T, E = ResolveError> = Result<T, E>;
 
+// temporary alias since most errors do not return `Ident`
+pub(crate) type WorldName = String;
+pub(crate) type InterfaceName = String;
+
 /// The category of error that occurred while resolving a WIT package.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq)]
@@ -20,6 +24,20 @@ pub enum ResolveErrorKind {
         span: Span,
         requested: PackageName,
         known: Vec<PackageName>,
+    },
+
+    /// A referenced world could not be found for the provided package
+    WorldNotFound {
+        span: Span,
+        requested: WorldName,
+        package: PackageName,
+    },
+
+    /// A referenced interface could not be found for the provided package
+    InterfaceNotFound {
+        span: Span,
+        requested: InterfaceName,
+        package: PackageName,
     },
     /// An interface has a transitive dependency that creates an incompatible
     /// import relationship.
@@ -53,6 +71,8 @@ impl ResolveErrorKind {
     pub fn span(&self) -> Span {
         match self {
             ResolveErrorKind::PackageNotFound { span, .. }
+            | ResolveErrorKind::WorldNotFound { span, .. }
+            | ResolveErrorKind::InterfaceNotFound { span, .. }
             | ResolveErrorKind::InvalidTransitiveDependency { span, .. }
             | ResolveErrorKind::PackageCycle { span, .. }
             | ResolveErrorKind::ItemShadowing { span, .. }
@@ -79,6 +99,12 @@ impl fmt::Display for ResolveErrorKind {
                     Ok(())
                 }
             }
+            ResolveErrorKind::WorldNotFound {
+                requested, package, ..
+            } => write!(f, "world '{requested}' not found in package '{package}'"),
+            ResolveErrorKind::InterfaceNotFound {
+                requested, package, ..
+            } => write!(f, "interface '{requested}' not found in package '{package}'"),
             ResolveErrorKind::InvalidTransitiveDependency { name, .. } => write!(
                 f,
                 "interface `{name}` transitively depends on an interface in incompatible ways",

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -3095,7 +3095,7 @@ impl Resolve {
         // never being importable-from it means that mutations to `CloneMaps`
         // are discarded when named interfaces are cloned. The trick here
         // happens where this unconditionally preserves all modifications to
-        // `CloneMaps` for `WorldKey::Interface` clones. Behaivor then "falls
+        // `CloneMaps` for `WorldKey::Interface` clones. Behavior then "falls
         // out" where references to cloned interfaces are naturally rewritten.
         //
         // This all falls down, however, if an import is cloned and recorded.

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -3808,19 +3808,50 @@ impl Remap {
         parent_pkg_id: &PackageId,
     ) -> ResolveResult<()> {
         for (unresolved_world_id, unresolved_world) in unresolved.worlds.iter() {
-            let pkg = match world_to_package.get(&unresolved_world_id) {
-                Some(items) => *items,
-                // Same as above, all worlds are foreign until we find a
-                // non-foreign one.
-                None => break,
-            };
-            self.process_foreign_world(
-                pkg,
-                unresolved_world_id,
-                unresolved_world,
-                resolve,
-                parent_pkg_id,
-            )?;
+            let (pkg_name, world, span, stabilities) =
+                match world_to_package.get(&unresolved_world_id) {
+                    Some(items) => *items,
+                    // Same as above, all worlds are foreign until we find a
+                    // non-foreign one.
+                    None => break,
+                };
+
+            let pkgid = resolve
+                .package_names
+                .get(pkg_name)
+                .copied()
+                .ok_or_else(|| {
+                    ResolveError::from(ResolveErrorKind::PackageNotFound {
+                        span,
+                        requested: pkg_name.clone(),
+                        known: resolve.package_names.keys().cloned().collect(),
+                    })
+                })?;
+            let pkg = &resolve.packages[pkgid];
+            let world_span = unresolved_world.span;
+
+            let mut enabled = false;
+            for stability in stabilities {
+                if resolve.include_stability(stability, parent_pkg_id, world_span)? {
+                    enabled = true;
+                    break;
+                }
+            }
+
+            if !enabled {
+                self.worlds.push(None);
+                continue;
+            }
+
+            let world_id = pkg.worlds.get(world).copied().ok_or_else(|| {
+                ResolveError::from(ResolveErrorKind::WorldNotFound {
+                    span: world_span,
+                    requested: world.to_string(),
+                    package: pkg.name.clone(),
+                })
+            })?;
+            assert_eq!(self.worlds.len(), unresolved_world_id.index());
+            self.worlds.push(Some(world_id));
         }
         for (id, _) in unresolved.worlds.iter().skip(self.worlds.len()) {
             assert!(
@@ -3828,53 +3859,6 @@ impl Remap {
                 "found foreign world after local world"
             );
         }
-        Ok(())
-    }
-
-    fn process_foreign_world(
-        &mut self,
-        (pkg_name, world, span, stabilities): (&PackageName, &String, Span, &Vec<Stability>),
-        unresolved_world_id: Id<World>,
-        unresolved_world: &World,
-        resolve: &mut Resolve,
-        parent_pkg_id: &PackageId,
-    ) -> ResolveResult<()> {
-        let pkgid = resolve
-            .package_names
-            .get(pkg_name)
-            .copied()
-            .ok_or_else(|| {
-                ResolveError::from(ResolveErrorKind::PackageNotFound {
-                    span,
-                    requested: pkg_name.clone(),
-                    known: resolve.package_names.keys().cloned().collect(),
-                })
-            })?;
-        let pkg = &resolve.packages[pkgid];
-        let world_span = unresolved_world.span;
-
-        let mut enabled = false;
-        for stability in stabilities {
-            if resolve.include_stability(stability, parent_pkg_id, world_span)? {
-                enabled = true;
-                break;
-            }
-        }
-
-        if !enabled {
-            self.worlds.push(None);
-            return Ok(());
-        }
-
-        let world_id = pkg.worlds.get(world).copied().ok_or_else(|| {
-            ResolveError::from(ResolveErrorKind::WorldNotFound {
-                span: world_span,
-                requested: world.to_string(),
-                package: pkg.name.clone(),
-            })
-        })?;
-        assert_eq!(self.worlds.len(), unresolved_world_id.index());
-        self.worlds.push(Some(world_id));
         Ok(())
     }
 

--- a/crates/wit-parser/src/resolve/mod.rs
+++ b/crates/wit-parser/src/resolve/mod.rs
@@ -3782,7 +3782,11 @@ impl Remap {
             }
 
             let iface_id = pkg.interfaces.get(interface).copied().ok_or_else(|| {
-                ResolveError::new_semantic(iface_span, "interface not found in package")
+                ResolveError::from(ResolveErrorKind::InterfaceNotFound {
+                    span: iface_span,
+                    requested: interface.to_string(),
+                    package: pkg.name.clone(),
+                })
             })?;
             assert_eq!(self.interfaces.len(), unresolved_iface_id.index());
             self.interfaces.push(Some(iface_id));
@@ -3804,46 +3808,19 @@ impl Remap {
         parent_pkg_id: &PackageId,
     ) -> ResolveResult<()> {
         for (unresolved_world_id, unresolved_world) in unresolved.worlds.iter() {
-            let (pkg_name, world, span, stabilities) =
-                match world_to_package.get(&unresolved_world_id) {
-                    Some(items) => *items,
-                    // Same as above, all worlds are foreign until we find a
-                    // non-foreign one.
-                    None => break,
-                };
-
-            let pkgid = resolve
-                .package_names
-                .get(pkg_name)
-                .copied()
-                .ok_or_else(|| {
-                    ResolveError::from(ResolveErrorKind::PackageNotFound {
-                        span,
-                        requested: pkg_name.clone(),
-                        known: resolve.package_names.keys().cloned().collect(),
-                    })
-                })?;
-            let pkg = &resolve.packages[pkgid];
-            let world_span = unresolved_world.span;
-
-            let mut enabled = false;
-            for stability in stabilities {
-                if resolve.include_stability(stability, parent_pkg_id, world_span)? {
-                    enabled = true;
-                    break;
-                }
-            }
-
-            if !enabled {
-                self.worlds.push(None);
-                continue;
-            }
-
-            let world_id = pkg.worlds.get(world).copied().ok_or_else(|| {
-                ResolveError::new_semantic(world_span, "world not found in package")
-            })?;
-            assert_eq!(self.worlds.len(), unresolved_world_id.index());
-            self.worlds.push(Some(world_id));
+            let pkg = match world_to_package.get(&unresolved_world_id) {
+                Some(items) => *items,
+                // Same as above, all worlds are foreign until we find a
+                // non-foreign one.
+                None => break,
+            };
+            self.process_foreign_world(
+                pkg,
+                unresolved_world_id,
+                unresolved_world,
+                resolve,
+                parent_pkg_id,
+            )?;
         }
         for (id, _) in unresolved.worlds.iter().skip(self.worlds.len()) {
             assert!(
@@ -3851,6 +3828,53 @@ impl Remap {
                 "found foreign world after local world"
             );
         }
+        Ok(())
+    }
+
+    fn process_foreign_world(
+        &mut self,
+        (pkg_name, world, span, stabilities): (&PackageName, &String, Span, &Vec<Stability>),
+        unresolved_world_id: Id<World>,
+        unresolved_world: &World,
+        resolve: &mut Resolve,
+        parent_pkg_id: &PackageId,
+    ) -> ResolveResult<()> {
+        let pkgid = resolve
+            .package_names
+            .get(pkg_name)
+            .copied()
+            .ok_or_else(|| {
+                ResolveError::from(ResolveErrorKind::PackageNotFound {
+                    span,
+                    requested: pkg_name.clone(),
+                    known: resolve.package_names.keys().cloned().collect(),
+                })
+            })?;
+        let pkg = &resolve.packages[pkgid];
+        let world_span = unresolved_world.span;
+
+        let mut enabled = false;
+        for stability in stabilities {
+            if resolve.include_stability(stability, parent_pkg_id, world_span)? {
+                enabled = true;
+                break;
+            }
+        }
+
+        if !enabled {
+            self.worlds.push(None);
+            return Ok(());
+        }
+
+        let world_id = pkg.worlds.get(world).copied().ok_or_else(|| {
+            ResolveError::from(ResolveErrorKind::WorldNotFound {
+                span: world_span,
+                requested: world.to_string(),
+                package: pkg.name.clone(),
+            })
+        })?;
+        assert_eq!(self.worlds.len(), unresolved_world_id.index());
+        self.worlds.push(Some(world_id));
         Ok(())
     }
 

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
@@ -1,4 +1,4 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg2]: interface not found in package
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg2]: interface 'nonexistent' not found in package 'foo:bar'
      --> tests/ui/parse-fail/bad-pkg2/root.wit:4:15
       |
     4 |   use foo:bar/nonexistent.{};

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
@@ -1,4 +1,4 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg3]: interface not found in package
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg3]: interface 'baz' not found in package 'foo:bar'
      --> tests/ui/parse-fail/bad-pkg3/root.wit:4:15
       |
     4 |   use foo:bar/baz.{};

--- a/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
@@ -1,4 +1,4 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/include-foreign]: world not found in package
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/include-foreign]: world 'bar' not found in package 'foo:bar'
      --> tests/ui/parse-fail/include-foreign/root.wit:4:19
       |
     4 |   include foo:bar/bar;

--- a/crates/wit-parser/tests/ui/parse-fail/non-existence-world-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/non-existence-world-include.wit.result
@@ -1,4 +1,4 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/non-existence-world-include]: world not found in package
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/non-existence-world-include]: world 'non-existence' not found in package 'foo:baz'
      --> tests/ui/parse-fail/non-existence-world-include/root.wit:4:19
       |
     4 |   include foo:baz/non-existence;

--- a/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
@@ -1,4 +1,4 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-world]: interface not found in package
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-world]: interface 'bar' not found in package 'foo:baz'
      --> tests/ui/parse-fail/use-world/root.wit:3:13
       |
     3 | use foo:baz/bar;

--- a/tests/cli/component-model/custom-page-sizes.wast
+++ b/tests/cli/component-model/custom-page-sizes.wast
@@ -20,7 +20,7 @@
     (core func (canon lower (func $f) (memory (core memory $i "m"))))
 )
 
-;; subtyping works with explict page sizes
+;; subtyping works with explicit page sizes
 (component
   (core module $a (memory (export "m") 1 (pagesize 65536)))
   (core module $b (import "a" "m" (memory 1 (pagesize 65536))))


### PR DESCRIPTION
Attempt to add more not-found variants to `ResolveErrorKind` to address ambiguous errors generated upstream:
https://github.com/bytecodealliance/wasm-pkg-tools/issues/246