### PR TITLE
add `map` support to `wit-dylib`

### DIFF
--- a/crates/wit-dylib/ffi/src/ffi.rs
+++ b/crates/wit-dylib/ffi/src/ffi.rs
@@ -24,12 +24,13 @@ pub const WIT_TYPE_ENUM: u32 = 20;
 pub const WIT_TYPE_OPTION: u32 = 21;
 pub const WIT_TYPE_RESULT: u32 = 22;
 pub const WIT_TYPE_LIST: u32 = 23;
-pub const WIT_TYPE_FIXED_LENGTH_LIST: u32 = 24;
-pub const WIT_TYPE_FUTURE: u32 = 25;
-pub const WIT_TYPE_STREAM: u32 = 26;
-pub const WIT_TYPE_ALIAS: u32 = 27;
+pub const WIT_TYPE_MAP: u32 = 24;
+pub const WIT_TYPE_FIXED_LENGTH_LIST: u32 = 25;
+pub const WIT_TYPE_FUTURE: u32 = 26;
+pub const WIT_TYPE_STREAM: u32 = 27;
+pub const WIT_TYPE_ALIAS: u32 = 28;
 pub const WIT_TYPE_EMPTY: u32 = 255;
-pub const WIT_CURRENT_VERSION: u32 = 2;
+pub const WIT_CURRENT_VERSION: u32 = 3;
 pub type wit_type_t = u32;
 pub type wit_import_fn_t =
     ::std::option::Option<unsafe extern "C" fn(cx: *mut ::std::os::raw::c_void)>;
@@ -169,6 +170,15 @@ pub struct wit_list {
 pub type wit_list_t = wit_list;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct wit_map {
+    pub interface: *const ::std::os::raw::c_char,
+    pub name: *const ::std::os::raw::c_char,
+    pub key_type: wit_type_t,
+    pub value_type: wit_type_t,
+}
+pub type wit_map_t = wit_map;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct wit_fixed_length_list {
     pub interface: *const ::std::os::raw::c_char,
     pub name: *const ::std::os::raw::c_char,
@@ -280,6 +290,8 @@ pub struct wit {
     pub results: *const wit_result_t,
     pub num_lists: usize,
     pub lists: *const wit_list_t,
+    pub num_maps: usize,
+    pub maps: *const wit_map_t,
     pub num_fixed_length_lists: usize,
     pub fixed_length_lists: *const wit_fixed_length_list_t,
     pub num_futures: usize,

--- a/crates/wit-dylib/ffi/src/lib.rs
+++ b/crates/wit-dylib/ffi/src/lib.rs
@@ -329,13 +329,13 @@ macro_rules! export {
         }
 
         #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn wit_dylib_pop_iter_next(cx: *mut u8, ty: usize) {
-            unsafe { <$name as $crate::RawInterpreter>::raw_pop_iter_next(cx, ty) }
+        pub unsafe extern "C" fn wit_dylib_pop_list_iter_next(cx: *mut u8, ty: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_pop_list_iter_next(cx, ty) }
         }
 
         #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn wit_dylib_pop_iter(cx: *mut u8, ty: usize) {
-            unsafe { <$name as $crate::RawInterpreter>::raw_pop_iter(cx, ty) }
+        pub unsafe extern "C" fn wit_dylib_pop_list_iter(cx: *mut u8, ty: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_pop_list_iter(cx, ty) }
         }
 
         #[unsafe(no_mangle)]
@@ -351,6 +351,31 @@ macro_rules! export {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn wit_dylib_list_append(cx: *mut u8, ty: usize) {
             unsafe { <$name as $crate::RawInterpreter>::raw_list_append(cx, ty) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wit_dylib_pop_map(cx: *mut u8, ty: usize) -> usize {
+            unsafe { <$name as $crate::RawInterpreter>::raw_pop_map(cx, ty) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wit_dylib_pop_map_iter_next(cx: *mut u8, ty: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_pop_map_iter_next(cx, ty) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wit_dylib_pop_map_iter(cx: *mut u8, ty: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_pop_map_iter(cx, ty) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wit_dylib_push_map(cx: *mut u8, ty: usize, len: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_push_map(cx, ty, len) }
+        }
+
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn wit_dylib_map_append(cx: *mut u8, ty: usize) {
+            unsafe { <$name as $crate::RawInterpreter>::raw_map_append(cx, ty) }
         }
 
         fn main() {
@@ -434,8 +459,12 @@ pub trait Call {
         None
     }
     fn pop_list(&mut self, ty: List) -> usize;
-    fn pop_iter_next(&mut self, ty: List);
-    fn pop_iter(&mut self, ty: List);
+    fn pop_list_iter_next(&mut self, ty: List);
+    fn pop_list_iter(&mut self, ty: List);
+
+    fn pop_map(&mut self, ty: Map) -> usize;
+    fn pop_map_iter_next(&mut self, ty: Map);
+    fn pop_map_iter(&mut self, ty: Map);
 
     fn push_bool(&mut self, val: bool);
     fn push_char(&mut self, val: char);
@@ -467,6 +496,8 @@ pub trait Call {
     }
     fn push_list(&mut self, ty: List, capacity: usize);
     fn list_append(&mut self, ty: List);
+    fn push_map(&mut self, ty: Map, capacity: usize);
+    fn map_append(&mut self, ty: Map);
 }
 
 static mut WIT_T: *const ffi::wit_t = ptr::null_mut();
@@ -764,19 +795,43 @@ pub trait RawInterpreter: Interpreter {
         }
     }
 
-    unsafe fn raw_pop_iter_next(cx: *mut u8, ty: usize) {
-        debug_println!("pop_iter_next({cx:?}, {ty})");
+    unsafe fn raw_pop_list_iter_next(cx: *mut u8, ty: usize) {
+        debug_println!("pop_list_iter_next({cx:?}, {ty})");
         unsafe {
             let wit = Wit::from_raw(WIT_T);
-            Self::cx_mut(cx).pop_iter_next(wit.list(ty))
+            Self::cx_mut(cx).pop_list_iter_next(wit.list(ty))
         }
     }
 
-    unsafe fn raw_pop_iter(cx: *mut u8, ty: usize) {
-        debug_println!("pop_iter({cx:?}, {ty})");
+    unsafe fn raw_pop_list_iter(cx: *mut u8, ty: usize) {
+        debug_println!("pop_list_iter({cx:?}, {ty})");
         unsafe {
             let wit = Wit::from_raw(WIT_T);
-            Self::cx_mut(cx).pop_iter(wit.list(ty))
+            Self::cx_mut(cx).pop_list_iter(wit.list(ty))
+        }
+    }
+
+    unsafe fn raw_pop_map(cx: *mut u8, ty: usize) -> usize {
+        debug_println!("pop_map({cx:?}, {ty})");
+        unsafe {
+            let wit = Wit::from_raw(WIT_T);
+            Self::cx_mut(cx).pop_map(wit.map(ty))
+        }
+    }
+
+    unsafe fn raw_pop_map_iter_next(cx: *mut u8, ty: usize) {
+        debug_println!("pop_map_iter_next({cx:?}, {ty})");
+        unsafe {
+            let wit = Wit::from_raw(WIT_T);
+            Self::cx_mut(cx).pop_map_iter_next(wit.map(ty))
+        }
+    }
+
+    unsafe fn raw_pop_map_iter(cx: *mut u8, ty: usize) {
+        debug_println!("pop_map_iter({cx:?}, {ty})");
+        unsafe {
+            let wit = Wit::from_raw(WIT_T);
+            Self::cx_mut(cx).pop_map_iter(wit.map(ty))
         }
     }
 
@@ -957,6 +1012,22 @@ pub trait RawInterpreter: Interpreter {
         unsafe {
             let wit = Wit::from_raw(WIT_T);
             Self::cx_mut(cx).list_append(wit.list(ty))
+        }
+    }
+
+    unsafe fn raw_push_map(cx: *mut u8, ty: usize, len: usize) {
+        debug_println!("push_map({cx:?}, {ty}, {len})");
+        unsafe {
+            let wit = Wit::from_raw(WIT_T);
+            Self::cx_mut(cx).push_map(wit.map(ty), len);
+        }
+    }
+
+    unsafe fn raw_map_append(cx: *mut u8, ty: usize) {
+        debug_println!("map_append({cx:?}, {ty})");
+        unsafe {
+            let wit = Wit::from_raw(WIT_T);
+            Self::cx_mut(cx).map_append(wit.map(ty))
         }
     }
 }

--- a/crates/wit-dylib/ffi/src/types.rs
+++ b/crates/wit-dylib/ffi/src/types.rs
@@ -250,6 +250,21 @@ impl Wit {
         self.raw_lists().iter().map(|e| List { wit: *self, ptr: e })
     }
 
+    fn raw_maps(&self) -> &'static [ffi::wit_map_t] {
+        unsafe { slice(self.ptr.maps, self.ptr.num_maps) }
+    }
+
+    pub fn map(&self, index: usize) -> Map {
+        Map {
+            wit: *self,
+            ptr: &self.raw_maps()[index],
+        }
+    }
+
+    pub fn iter_maps(&self) -> impl ExactSizeIterator<Item = Map> + Clone + '_ {
+        self.raw_maps().iter().map(|e| Map { wit: *self, ptr: e })
+    }
+
     fn raw_fixed_length_lists(&self) -> &'static [ffi::wit_fixed_length_list_t] {
         unsafe { slice(self.ptr.fixed_length_lists, self.ptr.num_fixed_length_lists) }
     }
@@ -582,6 +597,7 @@ pub enum Type {
     Option(WitOption),
     Result(WitResult),
     List(List),
+    Map(Map),
     FixedLengthList(FixedLengthList),
     Future(Future),
     Stream(Stream),
@@ -616,6 +632,7 @@ impl Type {
             ffi::WIT_TYPE_OPTION => Self::Option(wit.option(index)),
             ffi::WIT_TYPE_RESULT => Self::Result(wit.result(index)),
             ffi::WIT_TYPE_LIST => Self::List(wit.list(index)),
+            ffi::WIT_TYPE_MAP => Self::Map(wit.map(index)),
             ffi::WIT_TYPE_FIXED_LENGTH_LIST => Self::FixedLengthList(wit.fixed_length_list(index)),
             ffi::WIT_TYPE_FUTURE => Self::Future(wit.future(index)),
             ffi::WIT_TYPE_STREAM => Self::Stream(wit.stream(index)),
@@ -995,6 +1012,47 @@ impl fmt::Debug for List {
             .field("interface", &self.interface())
             .field("name", &self.name())
             .field("ty", &self.ty())
+            .finish()
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Map {
+    wit: Wit,
+    ptr: &'static ffi::wit_map_t,
+}
+
+impl_extra_traits!(Map);
+
+impl Map {
+    pub fn index(&self) -> usize {
+        unsafe { (&raw const *self.ptr).offset_from_unsigned(self.wit.ptr.maps) }
+    }
+
+    pub fn interface(&self) -> Option<&'static str> {
+        unsafe { opt_str(self.ptr.interface) }
+    }
+
+    pub fn name(&self) -> Option<&'static str> {
+        unsafe { opt_str(self.ptr.name) }
+    }
+
+    pub fn key_type(&self) -> Type {
+        Type::from_raw(self.wit, self.ptr.key_type)
+    }
+
+    pub fn value_type(&self) -> Type {
+        Type::from_raw(self.wit, self.ptr.value_type)
+    }
+}
+
+impl fmt::Debug for Map {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Map")
+            .field("interface", &self.interface())
+            .field("name", &self.name())
+            .field("key_type", &self.key_type())
+            .field("value_type", &self.value_type())
             .finish()
     }
 }

--- a/crates/wit-dylib/src/bindgen.rs
+++ b/crates/wit-dylib/src/bindgen.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::slice;
 use wasm_encoder::{BlockType, Function, InstructionSink, MemArg, ValType};
 use wit_parser::abi::{AbiVariant, FlatTypes, WasmSignature, WasmType};
-use wit_parser::{FlagsRepr, Handle, Int, Resolve, Type, TypeDefKind, TypeId};
+use wit_parser::{
+    Alignment, ArchitectureSize, FlagsRepr, Handle, Int, Resolve, Type, TypeDefKind, TypeId,
+};
 
 macro_rules! intrinsics {
     ($(
@@ -67,8 +69,12 @@ intrinsics! {
     pop_string : [ValType::I32; 2] -> [ValType::I32] = "wit_dylib_pop_string",
 
     pop_list : [ValType::I32; 3] -> [ValType::I32] = "wit_dylib_pop_list",
-    pop_iter_next : [ValType::I32; 2] -> [] = "wit_dylib_pop_iter_next",
-    pop_iter : [ValType::I32; 2] -> [] = "wit_dylib_pop_iter",
+    pop_list_iter_next : [ValType::I32; 2] -> [] = "wit_dylib_pop_list_iter_next",
+    pop_list_iter : [ValType::I32; 2] -> [] = "wit_dylib_pop_list_iter",
+
+    pop_map : [ValType::I32; 2] -> [ValType::I32] = "wit_dylib_pop_map",
+    pop_map_iter_next : [ValType::I32; 2] -> [] = "wit_dylib_pop_map_iter_next",
+    pop_map_iter : [ValType::I32; 2] -> [] = "wit_dylib_pop_map_iter",
 
     push_bool : [ValType::I32; 2] -> [] = "wit_dylib_push_bool",
     push_char : [ValType::I32; 2] -> [] = "wit_dylib_push_char",
@@ -96,6 +102,14 @@ intrinsics! {
     push_result : [ValType::I32; 3] -> [] = "wit_dylib_push_result",
     push_list : [ValType::I32; 4] -> [ValType::I32] = "wit_dylib_push_list",
     list_append : [ValType::I32; 2] -> [] = "wit_dylib_list_append",
+    push_map : [ValType::I32; 3] -> [] = "wit_dylib_push_map",
+    map_append : [ValType::I32; 2] -> [] = "wit_dylib_map_append",
+}
+
+struct ElementInfo {
+    increments: Vec<usize>,
+    size: usize,
+    align: usize,
 }
 
 pub fn import(
@@ -967,11 +981,8 @@ impl<'a> FunctionCompiler<'a> {
                     unreachable!()
                 };
                 let pop_list = self.adapter.intrinsics().pop_list;
-                let pop_iter_next = self.adapter.intrinsics().pop_iter_next;
-                let pop_iter = self.adapter.intrinsics().pop_iter;
-                let cabi_realloc = self.adapter.intrinsics().cabi_realloc;
-                let size = self.adapter.sizes.size(t).size_wasm32();
-                let align = self.adapter.sizes.align(t).align_wasm32();
+                let pop_iter_next = self.adapter.intrinsics().pop_list_iter_next;
+                let pop_iter = self.adapter.intrinsics().pop_list_iter;
                 let (dst_ptr, dst_len) = dest.split_ptr_len();
 
                 // Load the list ptr/len into locals
@@ -993,74 +1004,9 @@ impl<'a> FunctionCompiler<'a> {
                 // required to lower element-by-element.
                 self.ins().local_get(l_ptr.idx);
                 self.ins().i32_eqz();
+
                 self.ins().if_(BlockType::Empty);
-                {
-                    self.ins().i32_const(0);
-                    let l_index = self.local_set_new_tmp(ValType::I32);
-
-                    self.ins().i32_const(0);
-                    self.ins().i32_const(0);
-                    self.ins().i32_const(align.try_into().unwrap());
-                    self.ins().local_get(l_len.idx);
-                    self.ins().i32_const(size.try_into().unwrap());
-                    self.ins().i32_mul();
-                    let l_byte_size = self.local_tee_new_tmp(ValType::I32);
-                    self.ins().call(cabi_realloc);
-                    let l_elem_addr = self.local_tee_new_tmp(ValType::I32);
-                    self.ins().local_set(l_ptr.idx);
-
-                    // Loop over each element of the list.
-                    self.ins().loop_(BlockType::Empty);
-                    {
-                        // Entry loop condition, `l_index != l_len`
-                        self.ins().local_get(l_index.idx);
-                        self.ins().local_get(l_len.idx);
-                        self.ins().i32_ne();
-                        self.ins().if_(BlockType::Empty);
-                        {
-                            // Get the `l_index`th element from `l_list`
-                            self.local_get_ctx();
-                            self.ins().i32_const(list_index.try_into().unwrap());
-                            self.ins().call(pop_iter_next);
-
-                            // Lower the list element
-                            self.lower(
-                                *t,
-                                &AbiLoc::Memory(Memory {
-                                    addr: TempLocal::new(l_elem_addr.idx, ValType::I32),
-                                    offset: 0,
-                                }),
-                            );
-
-                            // Increment the `l_index` counter
-                            self.ins().local_get(l_index.idx);
-                            self.ins().i32_const(1);
-                            self.ins().i32_add();
-                            self.ins().local_set(l_index.idx);
-
-                            // Increment the `l_elem_addr` counter
-                            self.ins().local_get(l_elem_addr.idx);
-                            self.ins().i32_const(size.try_into().unwrap());
-                            self.ins().i32_add();
-                            self.ins().local_set(l_elem_addr.idx);
-
-                            // Continue the loop.
-                            self.ins().br(1);
-                        }
-                        self.ins().end();
-                    }
-                    self.ins().end();
-
-                    self.defer_deallocate_lowered_list(&l_ptr, &l_byte_size, align);
-
-                    self.local_get_ctx();
-                    self.ins().i32_const(list_index.try_into().unwrap());
-                    self.ins().call(pop_iter);
-
-                    self.free_temp_local(l_index);
-                    self.free_temp_local(l_elem_addr);
-                    self.free_temp_local(l_byte_size);
-                }
+                self.lower_list_or_map(list_index, &[*t], &l_ptr, &l_len, pop_iter_next, pop_iter);
                 self.ins().end();
 
                 self.ins().local_get(l_ptr.idx);
@@ -1112,14 +1058,153 @@ impl<'a> FunctionCompiler<'a> {
             }
 
             TypeDefKind::Map(k, v) => {
-                let _ = (k, v);
-                todo!("map")
+                let metadata::Type::Map(map_index) = ty else {
+                    unreachable!()
+                };
+                let pop_map = self.adapter.intrinsics().pop_map;
+                let pop_map_iter_next = self.adapter.intrinsics().pop_map_iter_next;
+                let pop_map_iter = self.adapter.intrinsics().pop_map_iter;
+                let (dst_ptr, dst_len) = dest.split_ptr_len();
+
+                self.local_get_ctx();
+                self.ins().i32_const(map_index.try_into().unwrap());
+                self.ins().call(pop_map);
+                let l_len = self.local_set_new_tmp(ValType::I32);
+                let l_ptr = self.gen_temp_local(ValType::I32);
+
+                self.lower_list_or_map(
+                    map_index,
+                    &[*k, *v],
+                    &l_ptr,
+                    &l_len,
+                    pop_map_iter_next,
+                    pop_map_iter,
+                );
+
+                self.ins().local_get(l_ptr.idx);
+                self.store_scalar_from_top_of_stack(&dst_ptr, ValType::I32, 2);
+                self.ins().local_get(l_len.idx);
+                self.store_scalar_from_top_of_stack(&dst_len, ValType::I32, 2);
+
+                self.free_temp_local(l_len);
+                self.free_temp_local(l_ptr);
             }
 
             // Should not be possible to hit during lowering.
             TypeDefKind::Resource => unreachable!(),
             TypeDefKind::Unknown => unreachable!(),
         }
+    }
+
+    fn element_info(&self, element_types: &[Type]) -> ElementInfo {
+        let mut increments = Vec::with_capacity(element_types.len());
+        let mut size = ArchitectureSize::default();
+        let mut align = Alignment::default();
+        let mut previous_size = None::<ArchitectureSize>;
+        for element_type in element_types {
+            let element_align = self.adapter.sizes.align(element_type);
+            size = wit_parser::align_to_arch(size, element_align);
+            if let Some(previous_size) = previous_size {
+                increments.push(size.size_wasm32() - previous_size.size_wasm32());
+            }
+            previous_size = Some(size);
+            size += self.adapter.sizes.size(element_type);
+            align = element_align.max(align);
+        }
+        size = wit_parser::align_to_arch(size, align);
+        if let Some(previous_size) = previous_size {
+            increments.push(size.size_wasm32() - previous_size.size_wasm32());
+        }
+        ElementInfo {
+            increments,
+            size: size.size_wasm32(),
+            align: align.align_wasm32(),
+        }
+    }
+
+    fn lower_list_or_map(
+        &mut self,
+        type_index: usize,
+        element_types: &[Type],
+        l_ptr: &TempLocal,
+        l_len: &TempLocal,
+        pop_iter_next: u32,
+        pop_iter: u32,
+    ) {
+        let cabi_realloc = self.adapter.intrinsics().cabi_realloc;
+        let ElementInfo {
+            increments,
+            size,
+            align,
+        } = self.element_info(element_types);
+
+        self.ins().i32_const(0);
+        let l_index = self.local_set_new_tmp(ValType::I32);
+
+        self.ins().i32_const(0);
+        self.ins().i32_const(0);
+        self.ins().i32_const(align.try_into().unwrap());
+        self.ins().local_get(l_len.idx);
+        self.ins().i32_const(size.try_into().unwrap());
+        self.ins().i32_mul();
+        let l_byte_size = self.local_tee_new_tmp(ValType::I32);
+        self.ins().call(cabi_realloc);
+        let l_elem_addr = self.local_tee_new_tmp(ValType::I32);
+        self.ins().local_set(l_ptr.idx);
+
+        // Loop over each element of the list or map.
+        self.ins().loop_(BlockType::Empty);
+        {
+            // Entry loop condition, `l_index != l_len`
+            self.ins().local_get(l_index.idx);
+            self.ins().local_get(l_len.idx);
+            self.ins().i32_ne();
+            self.ins().if_(BlockType::Empty);
+            {
+                // Get the `l_index`th elements from `l_list`
+                self.local_get_ctx();
+                self.ins().i32_const(type_index.try_into().unwrap());
+                self.ins().call(pop_iter_next);
+
+                // Lower the list elements
+                for (&ty, &increment) in element_types.iter().zip(&increments) {
+                    self.lower(
+                        ty,
+                        &AbiLoc::Memory(Memory {
+                            addr: TempLocal::new(l_elem_addr.idx, ValType::I32),
+                            offset: 0,
+                        }),
+                    );
+
+                    // Increment the `l_elem_addr` counter
+                    self.ins().local_get(l_elem_addr.idx);
+                    self.ins().i32_const(increment.try_into().unwrap());
+                    self.ins().i32_add();
+                    self.ins().local_set(l_elem_addr.idx);
+                }
+
+                // Increment the `l_index` counter
+                self.ins().local_get(l_index.idx);
+                self.ins().i32_const(1);
+                self.ins().i32_add();
+                self.ins().local_set(l_index.idx);
+
+                // Continue the loop.
+                self.ins().br(1);
+            }
+            self.ins().end();
+        }
+        self.ins().end();
+
+        self.defer_deallocate_lowered_list(&l_ptr, &l_byte_size, align);
+
+        self.local_get_ctx();
+        self.ins().i32_const(type_index.try_into().unwrap());
+        self.ins().call(pop_iter);
+
+        self.free_temp_local(l_index);
+        self.free_temp_local(l_elem_addr);
+        self.free_temp_local(l_byte_size);
     }
 
     fn pop_record<'b>(
@@ -1490,18 +1575,14 @@ impl<'a> FunctionCompiler<'a> {
                 let metadata::Type::List(list_index) = ty else {
                     unreachable!()
                 };
-                let elem_size = self.adapter.sizes.size(t).size_wasm32();
-                let elem_align = self.adapter.sizes.align(t).align_wasm32();
-                let list_index = i32::try_from(list_index).unwrap();
                 let push_list = i.push_list;
                 let list_append = i.list_append;
-                let dealloc_bytes = i.dealloc_bytes;
                 let (src_ptr, src_len) = src.split_ptr_len();
 
                 // Give the interpreter to lift the list exactly as-is and take
                 // ownership of the allocation.
                 self.local_get_ctx();
-                self.ins().i32_const(list_index);
+                self.ins().i32_const(list_index.try_into().unwrap());
                 self.load_abi_loc(&src_ptr, ValType::I32, 2, false);
                 let l_ptr = self.local_tee_new_tmp(ValType::I32);
                 self.load_abi_loc(&src_len, ValType::I32, 2, false);
@@ -1512,71 +1593,7 @@ impl<'a> FunctionCompiler<'a> {
                 // lifted manually element-by-element.
                 self.ins().i32_eqz();
                 self.ins().if_(BlockType::Empty);
-                {
-                    // Prep deallocation of the list after the loop by saving
-                    // off the pointer/byte size.
-                    self.ins().local_get(l_len.idx);
-                    self.ins().i32_const(elem_size.try_into().unwrap());
-                    self.ins().i32_mul();
-                    let l_byte_size = self.local_set_new_tmp(ValType::I32);
-                    self.ins().local_get(l_ptr.idx);
-                    let l_ptr_to_free = self.local_set_new_tmp(ValType::I32);
-
-                    // Using `l_len` as the loop counter, element-by-element
-                    // lift from the list and push into the list.
-                    self.ins().loop_(BlockType::Empty);
-                    {
-                        self.ins().local_get(l_len.idx);
-                        self.ins().if_(BlockType::Empty);
-                        {
-                            // Lift this list element from memory into a local
-                            let src = AbiLoc::Memory(Memory {
-                                addr: TempLocal::new(l_ptr.idx, l_ptr.ty),
-                                offset: 0,
-                            });
-                            self.lift(&src, *t);
-
-                            // Push the lifted element onto the list. Note that
-                            // this takes and returns the list.
-                            self.local_get_ctx();
-                            self.ins().i32_const(list_index);
-                            self.ins().call(list_append);
-
-                            // decrement the length counter
-                            self.ins().local_get(l_len.idx);
-                            self.ins().i32_const(1);
-                            self.ins().i32_sub();
-                            self.ins().local_set(l_len.idx);
-
-                            // increment the pointer
-                            self.ins().local_get(l_ptr.idx);
-                            self.ins().i32_const(elem_size.try_into().unwrap());
-                            self.ins().i32_add();
-                            self.ins().local_set(l_ptr.idx);
-
-                            self.ins().br(1);
-                        }
-                        self.ins().end();
-                    }
-                    self.ins().end();
-
-                    // The canonical ABI representation of this list is no
-                    // longer needed, so discard it.
-                    self.ins().local_get(l_byte_size.idx);
-                    self.ins().if_(BlockType::Empty);
-                    {
-                        self.local_get_ctx();
-                        self.ins().local_get(l_ptr_to_free.idx);
-                        self.ins().local_get(l_byte_size.idx);
-                        self.ins().i32_const(elem_align.try_into().unwrap());
-                        self.ins().i32_const(0);
-                        self.ins().call(dealloc_bytes);
-                    }
-                    self.ins().end();
-
-                    self.free_temp_local(l_byte_size);
-                    self.free_temp_local(l_ptr_to_free);
-                }
+                self.lift_list_or_map(list_index, &[*t], &l_ptr, &l_len, list_append);
                 self.ins().end();
 
                 self.free_temp_local(l_ptr);
@@ -1584,14 +1601,112 @@ impl<'a> FunctionCompiler<'a> {
             }
 
             TypeDefKind::Map(k, v) => {
-                let _ = (k, v);
-                todo!("map")
+                let metadata::Type::Map(map_index) = ty else {
+                    unreachable!()
+                };
+                let push_map = i.push_map;
+                let map_append = i.map_append;
+                let (src_ptr, src_len) = src.split_ptr_len();
+
+                self.local_get_ctx();
+                self.ins().i32_const(map_index.try_into().unwrap());
+                self.load_abi_loc(&src_ptr, ValType::I32, 2, false);
+                let l_ptr = self.local_set_new_tmp(ValType::I32);
+                self.load_abi_loc(&src_len, ValType::I32, 2, false);
+                let l_len = self.local_tee_new_tmp(ValType::I32);
+                self.ins().call(push_map);
+
+                self.lift_list_or_map(map_index, &[*k, *v], &l_ptr, &l_len, map_append);
+
+                self.free_temp_local(l_ptr);
+                self.free_temp_local(l_len);
             }
 
             // Should not be possible to hit during lifting.
             TypeDefKind::Resource => unreachable!(),
             TypeDefKind::Unknown => unreachable!(),
         }
+    }
+
+    fn lift_list_or_map(
+        &mut self,
+        type_index: usize,
+        element_types: &[Type],
+        l_ptr: &TempLocal,
+        l_len: &TempLocal,
+        list_append: u32,
+    ) {
+        let dealloc_bytes = self.adapter.intrinsics().dealloc_bytes;
+        let ElementInfo {
+            increments,
+            size,
+            align,
+        } = self.element_info(element_types);
+
+        // Prep deallocation of the list or map after the loop by saving off the
+        // pointer/byte size.
+        self.ins().local_get(l_len.idx);
+        self.ins().i32_const(size.try_into().unwrap());
+        self.ins().i32_mul();
+        let l_byte_size = self.local_set_new_tmp(ValType::I32);
+        self.ins().local_get(l_ptr.idx);
+        let l_ptr_to_free = self.local_set_new_tmp(ValType::I32);
+
+        // Using `l_len` as the loop counter, element-by-element lift from the
+        // list or map and push into it.
+        self.ins().loop_(BlockType::Empty);
+        {
+            self.ins().local_get(l_len.idx);
+            self.ins().if_(BlockType::Empty);
+            {
+                for (&ty, &increment) in element_types.iter().zip(&increments) {
+                    // Lift this list or map element from memory into a local
+                    let src = AbiLoc::Memory(Memory {
+                        addr: TempLocal::new(l_ptr.idx, l_ptr.ty),
+                        offset: 0,
+                    });
+                    self.lift(&src, ty);
+
+                    // increment the pointer
+                    self.ins().local_get(l_ptr.idx);
+                    self.ins().i32_const(increment.try_into().unwrap());
+                    self.ins().i32_add();
+                    self.ins().local_set(l_ptr.idx);
+                }
+
+                // Push the lifted elements onto the list or map.
+                self.local_get_ctx();
+                self.ins().i32_const(type_index.try_into().unwrap());
+                self.ins().call(list_append);
+
+                // decrement the length counter
+                self.ins().local_get(l_len.idx);
+                self.ins().i32_const(1);
+                self.ins().i32_sub();
+                self.ins().local_set(l_len.idx);
+
+                self.ins().br(1);
+            }
+            self.ins().end();
+        }
+        self.ins().end();
+
+        // The canonical ABI representation of this list or map is no longer
+        // needed, so discard it.
+        self.ins().local_get(l_byte_size.idx);
+        self.ins().if_(BlockType::Empty);
+        {
+            self.local_get_ctx();
+            self.ins().local_get(l_ptr_to_free.idx);
+            self.ins().local_get(l_byte_size.idx);
+            self.ins().i32_const(align.try_into().unwrap());
+            self.ins().i32_const(0);
+            self.ins().call(dealloc_bytes);
+        }
+        self.ins().end();
+
+        self.free_temp_local(l_byte_size);
+        self.free_temp_local(l_ptr_to_free);
     }
 
     fn push_record<'b>(

--- a/crates/wit-dylib/src/lib.rs
+++ b/crates/wit-dylib/src/lib.rs
@@ -938,8 +938,16 @@ impl Adapter {
             TypeDefKind::Handle(Handle::Borrow(t)) => {
                 metadata::Type::Borrow(self.resource_map[&dealias(resolve, *t)])
             }
-            TypeDefKind::Map(_, _) => {
-                todo!("map")
+            TypeDefKind::Map(k, v) => {
+                let index = self.metadata.maps.len();
+                self.metadata.maps.push(metadata::Map {
+                    id,
+                    interface,
+                    name,
+                    key_type: self.lookup_ty(k),
+                    value_type: self.lookup_ty(v),
+                });
+                metadata::Type::Map(index)
             }
             TypeDefKind::Unknown => unreachable!(),
         };

--- a/crates/wit-dylib/src/metadata.rs
+++ b/crates/wit-dylib/src/metadata.rs
@@ -3,7 +3,7 @@ use std::mem;
 use wasm_encoder::{Function, MemArg};
 use wit_parser::TypeId;
 
-const VERSION: u32 = 2;
+const VERSION: u32 = 3;
 
 #[derive(Default)]
 pub struct Metadata {
@@ -18,6 +18,7 @@ pub struct Metadata {
     pub options: Vec<WitOption>,
     pub results: Vec<WitResult>,
     pub lists: Vec<List>,
+    pub maps: Vec<Map>,
     pub fixed_length_lists: Vec<FixedLengthList>,
     pub futures: Vec<Future>,
     pub streams: Vec<Stream>,
@@ -117,6 +118,14 @@ pub struct FixedLengthList {
     pub ty: Type,
 }
 
+pub struct Map {
+    pub id: TypeId,
+    pub interface: Option<String>,
+    pub name: Option<String>,
+    pub key_type: Type,
+    pub value_type: Type,
+}
+
 pub struct Future {
     pub id: TypeId,
     pub interface: Option<String>,
@@ -187,6 +196,7 @@ pub enum Type {
     Result(usize),
     List(usize),
     FixedLengthList(usize),
+    Map(usize),
     Future(usize),
     Stream(usize),
     Alias(usize),
@@ -242,6 +252,7 @@ impl Metadata {
         let options = encoder.encode_list(&self.options, Encoder::encode_options);
         let results = encoder.encode_list(&self.results, Encoder::encode_results);
         let lists = encoder.encode_list(&self.lists, Encoder::encode_lists);
+        let maps = encoder.encode_list(&self.maps, Encoder::encode_maps);
         let fixed_length_lists =
             encoder.encode_list(&self.fixed_length_lists, Encoder::encode_fixed_length_lists);
         let futures = encoder.encode_list(&self.futures, Encoder::encode_futures);
@@ -263,6 +274,7 @@ impl Metadata {
             options,
             results,
             lists,
+            maps,
             fixed_length_lists,
             futures,
             streams,
@@ -538,6 +550,22 @@ impl Encoder {
         }
     }
 
+    fn encode_maps(&mut self, maps: &[Map]) {
+        for map in maps {
+            let Map {
+                id: _,
+                interface,
+                name,
+                key_type,
+                value_type,
+            } = map;
+            self.opt_string_ptr(interface.as_deref());
+            self.opt_string_ptr(name.as_deref());
+            self.ty(key_type);
+            self.ty(value_type);
+        }
+    }
+
     fn encode_fixed_length_lists(&mut self, lists: &[FixedLengthList]) {
         for list in lists {
             let FixedLengthList {
@@ -758,10 +786,11 @@ impl Encoder {
             Type::Option(i) => index(21, i),
             Type::Result(i) => index(22, i),
             Type::List(i) => index(23, i),
-            Type::FixedLengthList(i) => index(24, i),
-            Type::Future(i) => index(25, i),
-            Type::Stream(i) => index(26, i),
-            Type::Alias(i) => index(27, i),
+            Type::Map(i) => index(24, i),
+            Type::FixedLengthList(i) => index(25, i),
+            Type::Future(i) => index(26, i),
+            Type::Stream(i) => index(27, i),
+            Type::Alias(i) => index(28, i),
         };
         self.put_u32(val);
     }

--- a/crates/wit-dylib/test-programs/src/bin/maps.wit
+++ b/crates/wit-dylib/test-programs/src/bin/maps.wit
@@ -1,0 +1,21 @@
+package a:b;
+
+interface x {
+  echo-u8-string: func(a: map<u8, string>) -> map<u8, string>;
+  echo-u32-string: func(a: map<u32, string>) -> map<u32, string>;
+  echo-string-u8: func(a: map<string, u8>) -> map<string, u8>;
+
+  map-of-variants: func(
+    name1: map<u8, map<u8, option<s8>>>,
+  );
+}
+
+world caller {
+  import x;
+
+  export run: func();
+}
+
+world callee {
+  export x;
+}

--- a/crates/wit-dylib/test-programs/src/bin/maps_callee.rs
+++ b/crates/wit-dylib/test-programs/src/bin/maps_callee.rs
@@ -1,0 +1,53 @@
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        _wit: Wit,
+        func: ExportFunction,
+        mut args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        assert_eq!(func.interface(), Some("a:b/x"));
+        match func.name() {
+            name if name.starts_with("echo-") => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_some());
+                assert_eq!(args.len(), 1);
+                let arg = args.next().unwrap();
+                match arg {
+                    Val::Map(_) => {}
+                    _ => panic!(),
+                }
+                Some(arg)
+            }
+
+            "map-of-variants" => {
+                assert_eq!(func.params().len(), 1);
+                assert!(func.result().is_none());
+                assert_eq!(args.len(), 1);
+                let arg = args.next().unwrap();
+                assert_eq!(
+                    arg,
+                    Val::Map(
+                        [
+                            (
+                                Key::U8(42),
+                                Val::Map([(Key::U8(42), Val::Option(None))].into_iter().collect()),
+                            ),
+                            (
+                                Key::U8(43),
+                                Val::Map([(Key::U8(42), Val::Option(None))].into_iter().collect()),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )
+                );
+                None
+            }
+
+            other => panic!("unknown function {other:?}"),
+        }
+    }
+}

--- a/crates/wit-dylib/test-programs/src/bin/maps_caller.rs
+++ b/crates/wit-dylib/test-programs/src/bin/maps_caller.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+use test_programs::*;
+
+export_test!(struct MyInterpreter);
+
+impl TestCase for MyInterpreter {
+    fn call_export(
+        wit: Wit,
+        func: ExportFunction,
+        args: impl ExactSizeIterator<Item = Val>,
+    ) -> Option<Val> {
+        assert_eq!(func.interface(), None);
+        assert_eq!(func.name(), "run");
+        assert_eq!(func.params().len(), 0);
+        assert!(func.result().is_none());
+        assert_eq!(args.len(), 0);
+
+        {
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-u8-string",
+                &[Val::Map(BTreeMap::new())],
+            );
+            assert_eq!(ret, Some(Val::Map(BTreeMap::new())));
+
+            let map = b"abc"
+                .iter()
+                .map(|&v| (Key::U8(v), Val::String(v.to_string())))
+                .collect::<BTreeMap<_, _>>();
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-u8-string",
+                &[Val::Map(map.clone())],
+            );
+            assert_eq!(ret, Some(Val::Map(map)));
+
+            let map = b"abc"
+                .iter()
+                .map(|&v| (Key::U8(v), Val::String("42".into())))
+                .collect::<BTreeMap<_, _>>();
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-u8-string",
+                &[Val::Map(map.clone())],
+            );
+            assert_eq!(ret, Some(Val::Map(map)));
+        }
+
+        {
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-u32-string",
+                &[Val::Map(BTreeMap::new())],
+            );
+            assert_eq!(ret, Some(Val::Map(BTreeMap::new())));
+
+            let map = [1, 2]
+                .iter()
+                .map(|&v| (Key::U32(v), Val::String(v.to_string())))
+                .collect::<BTreeMap<_, _>>();
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-u32-string",
+                &[Val::Map(map.clone())],
+            );
+            assert_eq!(ret, Some(Val::Map(map)));
+        }
+
+        {
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-string-u8",
+                &[Val::Map(BTreeMap::new())],
+            );
+            assert_eq!(ret, Some(Val::Map(BTreeMap::new())));
+
+            let map = [1, 2]
+                .iter()
+                .map(|&v| (Key::String(v.to_string()), Val::U8(v)))
+                .collect::<BTreeMap<_, _>>();
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "echo-string-u8",
+                &[Val::Map(map.clone())],
+            );
+            assert_eq!(ret, Some(Val::Map(map)));
+        }
+
+        {
+            let ret = Self::call_import(
+                wit,
+                Some("a:b/x"),
+                "map-of-variants",
+                &[Val::Map(
+                    [
+                        (
+                            Key::U8(42),
+                            Val::Map([(Key::U8(42), Val::Option(None))].into_iter().collect()),
+                        ),
+                        (
+                            Key::U8(43),
+                            Val::Map([(Key::U8(42), Val::Option(None))].into_iter().collect()),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )],
+            );
+            assert_eq!(ret, None);
+        }
+
+        None
+    }
+}

--- a/crates/wit-dylib/test-programs/src/generate.rs
+++ b/crates/wit-dylib/test-programs/src/generate.rs
@@ -1,10 +1,11 @@
 use crate::{
-    Enum, Flags, ImportFunction, List, Own, Resource, Type, Val, Variant, Wit, WitOption, WitResult,
+    Enum, Flags, ImportFunction, Key, List, Map, Own, Resource, Type, Val, Variant, Wit, WitOption,
+    WitResult,
 };
 use rand::distr::{SampleString, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::mem;
 
 const MAX_SIZE: usize = 1 << 20;
@@ -70,6 +71,7 @@ impl Generator {
                     Val::GenericList(self.generic_list(t))
                 }
             }
+            Type::Map(t) => Val::Map(self.map(t)),
 
             Type::Own(ty) => Val::Own(self.own(ty)),
             Type::Borrow(_) => unimplemented!("should be handled at caller"),
@@ -78,6 +80,23 @@ impl Generator {
             Type::Stream(_) => todo!(),
             Type::Future(_) => todo!(),
             Type::FixedLengthList(_) => todo!(),
+        }
+    }
+
+    pub fn generate_key(&mut self, ty: Type) -> Key {
+        match ty {
+            Type::U8 => Key::U8(self.primitive()),
+            Type::U16 => Key::U16(self.primitive()),
+            Type::U32 => Key::U32(self.primitive()),
+            Type::U64 => Key::U64(self.primitive()),
+            Type::S8 => Key::S8(self.primitive()),
+            Type::S16 => Key::S16(self.primitive()),
+            Type::S32 => Key::S32(self.primitive()),
+            Type::S64 => Key::S64(self.primitive()),
+            Type::Bool => Key::Bool(self.primitive()),
+            Type::Char => Key::Char(self.primitive()),
+            Type::String => Key::String(self.string()),
+            _ => unimplemented!("unsupported map key type"),
         }
     }
 
@@ -161,6 +180,17 @@ impl Generator {
         let mut result = Vec::new();
         while self.remaining > 0 && self.rng.random_ratio(9, 10) {
             result.push(self.generate(ty.ty()));
+        }
+        result
+    }
+
+    fn map(&mut self, ty: Map) -> BTreeMap<Key, Val> {
+        let mut result = BTreeMap::new();
+        while self.remaining > 0 && self.rng.random_ratio(9, 10) {
+            result.insert(
+                self.generate_key(ty.key_type()),
+                self.generate(ty.value_type()),
+            );
         }
         result
     }

--- a/crates/wit-dylib/test-programs/src/lib.rs
+++ b/crates/wit-dylib/test-programs/src/lib.rs
@@ -14,7 +14,7 @@
 use std::alloc::Layout;
 use std::any::{Any, TypeId};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ffi::c_void;
 use std::mem;
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
@@ -104,7 +104,8 @@ pub struct Cx<'a> {
     stack: Vec<Cow<'a, Val>>,
     temp_strings: Vec<String>,
     temp_bytes: Vec<Vec<u8>>,
-    iterators: Vec<CowIter<'a>>,
+    list_iterators: Vec<CowListIter<'a>>,
+    map_iterators: Vec<CowMapIter<'a>>,
     deferred_deallocs: Vec<(*mut u8, Layout)>,
 }
 
@@ -118,19 +119,41 @@ impl Drop for Cx<'_> {
     }
 }
 
-enum CowIter<'a> {
+enum CowListIter<'a> {
     Borrowed(std::slice::Iter<'a, Val>),
     Owned(std::vec::IntoIter<Val>),
 }
 
-impl<'a> Iterator for CowIter<'a> {
+impl<'a> Iterator for CowListIter<'a> {
     type Item = Cow<'a, Val>;
 
     fn next(&mut self) -> Option<Cow<'a, Val>> {
         match self {
-            CowIter::Borrowed(i) => Some(Cow::Borrowed(i.next()?)),
-            CowIter::Owned(i) => Some(Cow::Owned(i.next()?)),
+            CowListIter::Borrowed(i) => Some(Cow::Borrowed(i.next()?)),
+            CowListIter::Owned(i) => Some(Cow::Owned(i.next()?)),
         }
+    }
+}
+
+enum CowMapIter<'a> {
+    Borrowed(std::collections::btree_map::Iter<'a, Key, Val>),
+    Owned(std::collections::btree_map::IntoIter<Key, Val>),
+}
+
+impl<'a> Iterator for CowMapIter<'a> {
+    type Item = (Cow<'a, Key>, Cow<'a, Val>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(match self {
+            CowMapIter::Borrowed(i) => {
+                let (a, b) = i.next()?;
+                (Cow::Borrowed(a), Cow::Borrowed(b))
+            }
+            CowMapIter::Owned(i) => {
+                let (a, b) = i.next()?;
+                (Cow::Owned(a), Cow::Owned(b))
+            }
+        })
     }
 }
 
@@ -562,25 +585,25 @@ impl Call for Cx<'_> {
         assert!(ty.ty() != Type::U8);
         match self.always_pop() {
             Cow::Borrowed(Val::GenericList(l)) => {
-                self.iterators.push(CowIter::Borrowed(l.iter()));
+                self.list_iterators.push(CowListIter::Borrowed(l.iter()));
                 l.len()
             }
             Cow::Owned(Val::GenericList(l)) => {
                 let ret = l.len();
-                self.iterators.push(CowIter::Owned(l.into_iter()));
+                self.list_iterators.push(CowListIter::Owned(l.into_iter()));
                 ret
             }
             _ => invalid(),
         }
     }
 
-    fn pop_iter_next(&mut self, _ty: List) {
-        let value = self.iterators.last_mut().unwrap().next().unwrap();
+    fn pop_list_iter_next(&mut self, _ty: List) {
+        let value = self.list_iterators.last_mut().unwrap().next().unwrap();
         self.stack.push(value);
     }
 
-    fn pop_iter(&mut self, _ty: List) {
-        self.iterators.pop();
+    fn pop_list_iter(&mut self, _ty: List) {
+        self.list_iterators.pop();
     }
 
     unsafe fn push_raw_list(&mut self, ty: List, ptr: *mut u8, len: usize) -> bool {
@@ -591,6 +614,7 @@ impl Call for Cx<'_> {
             false
         }
     }
+
     fn push_list(&mut self, ty: List, capacity: usize) {
         assert!(ty.ty() != Type::U8);
         self.push_own(Val::GenericList(Vec::with_capacity(capacity)));
@@ -604,6 +628,61 @@ impl Call for Cx<'_> {
             _ => invalid(),
         }
     }
+
+    fn pop_map(&mut self, _ty: Map) -> usize {
+        match self.always_pop() {
+            Cow::Borrowed(Val::Map(v)) => {
+                self.map_iterators.push(CowMapIter::Borrowed(v.iter()));
+                v.len()
+            }
+            Cow::Owned(Val::Map(v)) => {
+                let ret = v.len();
+                self.map_iterators.push(CowMapIter::Owned(v.into_iter()));
+                ret
+            }
+            _ => invalid(),
+        }
+    }
+
+    fn pop_map_iter_next(&mut self, _ty: Map) {
+        let (key, value) = self.map_iterators.last_mut().unwrap().next().unwrap();
+        self.stack.push(value);
+        self.stack.push(Cow::Owned(key.into_owned().into()));
+    }
+
+    fn pop_map_iter(&mut self, _ty: Map) {
+        self.map_iterators.pop();
+    }
+
+    fn push_map(&mut self, _ty: Map, _capacity: usize) {
+        self.push_own(Val::Map(BTreeMap::new()));
+    }
+
+    fn map_append(&mut self, _ty: Map) {
+        let value = self.always_pop().into_owned();
+        let key = self.always_pop().into_owned();
+        match self.stack.last_mut() {
+            Some(Cow::Owned(Val::Map(v))) => {
+                v.insert(key.try_into().unwrap(), value);
+            }
+            _ => invalid(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Key {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    S8(i8),
+    S16(i16),
+    S32(i32),
+    S64(i64),
+    Bool(bool),
+    Char(char),
+    String(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -634,6 +713,46 @@ pub enum Val {
     Variant(u32, Option<Box<Val>>),
     GenericList(Vec<Val>),
     ByteList(Vec<u8>),
+    Map(BTreeMap<Key, Val>),
+}
+
+impl TryFrom<Val> for Key {
+    type Error = ();
+
+    fn try_from(v: Val) -> Result<Self, Self::Error> {
+        Ok(match v {
+            Val::U8(v) => Self::U8(v),
+            Val::U16(v) => Self::U16(v),
+            Val::U32(v) => Self::U32(v),
+            Val::U64(v) => Self::U64(v),
+            Val::S8(v) => Self::S8(v),
+            Val::S16(v) => Self::S16(v),
+            Val::S32(v) => Self::S32(v),
+            Val::S64(v) => Self::S64(v),
+            Val::Bool(v) => Self::Bool(v),
+            Val::Char(v) => Self::Char(v),
+            Val::String(v) => Self::String(v),
+            _ => return Err(()),
+        })
+    }
+}
+
+impl From<Key> for Val {
+    fn from(v: Key) -> Self {
+        match v {
+            Key::U8(v) => Self::U8(v),
+            Key::U16(v) => Self::U16(v),
+            Key::U32(v) => Self::U32(v),
+            Key::U64(v) => Self::U64(v),
+            Key::S8(v) => Self::S8(v),
+            Key::S16(v) => Self::S16(v),
+            Key::S32(v) => Self::S32(v),
+            Key::S64(v) => Self::S64(v),
+            Key::Bool(v) => Self::Bool(v),
+            Key::Char(v) => Self::Char(v),
+            Key::String(v) => Self::String(v),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/wit-dylib/tests/all.rs
+++ b/crates/wit-dylib/tests/all.rs
@@ -56,6 +56,7 @@ fn run_test(tempdir: &TempDir, caller: &Path, callee: &Path, wit: &Path) -> Resu
         .arg("--invoke=run()")
         .arg("-Shttp")
         .arg("-Wcomponent-model-async")
+        .arg("-Wcomponent-model-map")
         .arg("-Wcomponent-model-error-context")
         .arg(&composition_file);
     let result = cmd.output().context("failed to run wasmtime")?;

--- a/crates/wit-dylib/wit_dylib.h
+++ b/crates/wit-dylib/wit_dylib.h
@@ -46,10 +46,11 @@ typedef uint32_t wit_type_t;
 #define WIT_TYPE_OPTION 21
 #define WIT_TYPE_RESULT 22
 #define WIT_TYPE_LIST 23
-#define WIT_TYPE_FIXED_LENGTH_LIST 24
-#define WIT_TYPE_FUTURE 25
-#define WIT_TYPE_STREAM 26
-#define WIT_TYPE_ALIAS 27
+#define WIT_TYPE_MAP 24
+#define WIT_TYPE_FIXED_LENGTH_LIST 25
+#define WIT_TYPE_FUTURE 26
+#define WIT_TYPE_STREAM 27
+#define WIT_TYPE_ALIAS 28
 #define WIT_TYPE_EMPTY 0xff
 
 typedef void(*wit_import_fn_t)(void* cx);
@@ -199,6 +200,13 @@ typedef struct wit_list {
      wit_type_t ty;
 } wit_list_t;
 
+typedef struct wit_map {
+     const char *interface;
+     const char *name;
+     wit_type_t key_type;
+     wit_type_t value_type;
+} wit_map_t;
+
 typedef struct wit_fixed_length_list {
      const char *interface;
      const char *name;
@@ -265,7 +273,7 @@ typedef struct wit_alias {
      wit_type_t ty;
 } wit_alias_t;
 
-#define WIT_CURRENT_VERSION 2
+#define WIT_CURRENT_VERSION 3
 
 typedef struct wit {
      uint32_t version; // `WIT_V*`
@@ -292,6 +300,8 @@ typedef struct wit {
      const wit_result_t *results;
      size_t num_lists;
      const wit_list_t *lists;
+     size_t num_maps;
+     const wit_map_t *maps;
      size_t num_fixed_length_lists;
      const wit_fixed_length_list_t *fixed_length_lists;
      size_t num_futures;
@@ -388,7 +398,7 @@ void wit_dylib_push_tuple(void *cx, size_t ty);
 void wit_dylib_push_option(void *cx, size_t ty, uint32_t discr);
 void wit_dylib_push_result(void *cx, size_t ty, uint32_t discr);
 void wit_dylib_push_variant(void *cx, size_t ty, uint32_t discr);
-// If this function returns 0 then it means that `bytes`/`len` need to be pushed
+// If this function returns false then it means that `bytes`/`len` need to be pushed
 // one-by-one. If a true value is returned then it's assume that `bytes` and
 // `len` is now owned by the engine.
 //
@@ -402,6 +412,15 @@ void wit_dylib_push_variant(void *cx, size_t ty, uint32_t discr);
 // it onto the list which is then at the top of the stack.
 bool wit_dylib_push_list(void *cx, size_t ty, uint8_t *bytes, size_t len);
 void wit_dylib_list_append(void *cx, size_t ty);
+
+// Pushing maps works mostly the same as pushing lists, with two differences:
+//
+// - There's no "fast-path" for pushing all the elements in one call
+//
+// - Each appended element consists of two values: the key and the value the key
+//   maps to.  The key is pushed first (meaning it should be popped last).
+bool wit_dylib_push_map(void *cx, size_t ty, size_t len);
+void wit_dylib_map_append(void *cx, size_t ty);
 
 uint8_t wit_dylib_pop_u8(void *cx);
 uint16_t wit_dylib_pop_u16(void *cx);
@@ -455,12 +474,22 @@ void wit_dylib_pop_tuple(void *cx, size_t ty);
 // means that the data for this list is not in the canonical ABI format. That
 // means that it's required to translate elements one-by-one. In this situation
 // the list is popped from the stack and an iterator over the list is pushed
-// to the stack.  Calls to `wit_dylib_pop_iter_next` are used to then extract
+// to the stack.  Calls to `wit_dylib_pop_list_iter_next` are used to then extract
 // a single element from the iterator and push it onto the stack. Once
-// translation of the list is finished `wit_dylib_pop_iter` will be used to
+// translation of the list is finished `wit_dylib_pop_list_iter` will be used to
 // remove the iterator from the stack.
 size_t wit_dylib_pop_list(void *cx, size_t ty, void **ptr);
-void wit_dylib_pop_iter_next(void *cx, size_t ty);
-void wit_dylib_pop_iter(void *cx, size_t ty);
+void wit_dylib_pop_list_iter_next(void *cx, size_t ty);
+void wit_dylib_pop_list_iter(void *cx, size_t ty);
+
+// Popping maps works mostly the same as popping lists, with two differences:
+//
+// - There's no "fast-path" for popping all the elements in one call
+//
+// - Each lowered element consists of two values: the key and the value the key
+//   maps to.  The key should be pushed last (and will be popped first).
+void wit_dylib_pop_map(void *cx, size_t ty);
+void wit_dylib_pop_map_iter_next(void *cx, size_t ty);
+void wit_dylib_pop_map_iter(void *cx, size_t ty);
 
 #endif

--- a/tests/cli/wit-dylib-smoke.wit.stdout
+++ b/tests/cli/wit-dylib-smoke.wit.stdout
@@ -1,6 +1,6 @@
 (module
   (@dylink.0
-    (mem-info (memory 192 2) (table 1 0))
+    (mem-info (memory 200 2) (table 1 0))
   )
   (type (;0;) (func (param i32)))
   (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
@@ -51,35 +51,40 @@
   (import "env" "wit_dylib_pop_result" (func $wit_dylib_pop_result (;31;) (type 5)))
   (import "env" "wit_dylib_pop_string" (func $wit_dylib_pop_string (;32;) (type 5)))
   (import "env" "wit_dylib_pop_list" (func $wit_dylib_pop_list (;33;) (type 9)))
-  (import "env" "wit_dylib_pop_iter_next" (func $wit_dylib_pop_iter_next (;34;) (type 4)))
-  (import "env" "wit_dylib_pop_iter" (func $wit_dylib_pop_iter (;35;) (type 4)))
-  (import "env" "wit_dylib_push_bool" (func $wit_dylib_push_bool (;36;) (type 4)))
-  (import "env" "wit_dylib_push_char" (func $wit_dylib_push_char (;37;) (type 4)))
-  (import "env" "wit_dylib_push_u8" (func $wit_dylib_push_u8 (;38;) (type 4)))
-  (import "env" "wit_dylib_push_s8" (func $wit_dylib_push_s8 (;39;) (type 4)))
-  (import "env" "wit_dylib_push_u16" (func $wit_dylib_push_u16 (;40;) (type 4)))
-  (import "env" "wit_dylib_push_s16" (func $wit_dylib_push_s16 (;41;) (type 4)))
-  (import "env" "wit_dylib_push_u32" (func $wit_dylib_push_u32 (;42;) (type 4)))
-  (import "env" "wit_dylib_push_s32" (func $wit_dylib_push_s32 (;43;) (type 4)))
-  (import "env" "wit_dylib_push_u64" (func $wit_dylib_push_u64 (;44;) (type 10)))
-  (import "env" "wit_dylib_push_s64" (func $wit_dylib_push_s64 (;45;) (type 10)))
-  (import "env" "wit_dylib_push_f32" (func $wit_dylib_push_f32 (;46;) (type 11)))
-  (import "env" "wit_dylib_push_f64" (func $wit_dylib_push_f64 (;47;) (type 12)))
-  (import "env" "wit_dylib_push_string" (func $wit_dylib_push_string (;48;) (type 13)))
-  (import "env" "wit_dylib_push_record" (func $wit_dylib_push_record (;49;) (type 4)))
-  (import "env" "wit_dylib_push_tuple" (func $wit_dylib_push_tuple (;50;) (type 4)))
-  (import "env" "wit_dylib_push_flags" (func $wit_dylib_push_flags (;51;) (type 13)))
-  (import "env" "wit_dylib_push_enum" (func $wit_dylib_push_enum (;52;) (type 13)))
-  (import "env" "wit_dylib_push_borrow" (func $wit_dylib_push_borrow (;53;) (type 13)))
-  (import "env" "wit_dylib_push_own" (func $wit_dylib_push_own (;54;) (type 13)))
-  (import "env" "wit_dylib_push_future" (func $wit_dylib_push_future (;55;) (type 13)))
-  (import "env" "wit_dylib_push_stream" (func $wit_dylib_push_stream (;56;) (type 13)))
-  (import "env" "wit_dylib_push_variant" (func $wit_dylib_push_variant (;57;) (type 13)))
-  (import "env" "wit_dylib_push_option" (func $wit_dylib_push_option (;58;) (type 13)))
-  (import "env" "wit_dylib_push_result" (func $wit_dylib_push_result (;59;) (type 13)))
-  (import "env" "wit_dylib_push_list" (func $wit_dylib_push_list (;60;) (type 1)))
-  (import "env" "wit_dylib_list_append" (func $wit_dylib_list_append (;61;) (type 4)))
-  (import "$root" "x" (func $x (;62;) (type 14)))
+  (import "env" "wit_dylib_pop_list_iter_next" (func $wit_dylib_pop_list_iter_next (;34;) (type 4)))
+  (import "env" "wit_dylib_pop_list_iter" (func $wit_dylib_pop_list_iter (;35;) (type 4)))
+  (import "env" "wit_dylib_pop_map" (func $wit_dylib_pop_map (;36;) (type 5)))
+  (import "env" "wit_dylib_pop_map_iter_next" (func $wit_dylib_pop_map_iter_next (;37;) (type 4)))
+  (import "env" "wit_dylib_pop_map_iter" (func $wit_dylib_pop_map_iter (;38;) (type 4)))
+  (import "env" "wit_dylib_push_bool" (func $wit_dylib_push_bool (;39;) (type 4)))
+  (import "env" "wit_dylib_push_char" (func $wit_dylib_push_char (;40;) (type 4)))
+  (import "env" "wit_dylib_push_u8" (func $wit_dylib_push_u8 (;41;) (type 4)))
+  (import "env" "wit_dylib_push_s8" (func $wit_dylib_push_s8 (;42;) (type 4)))
+  (import "env" "wit_dylib_push_u16" (func $wit_dylib_push_u16 (;43;) (type 4)))
+  (import "env" "wit_dylib_push_s16" (func $wit_dylib_push_s16 (;44;) (type 4)))
+  (import "env" "wit_dylib_push_u32" (func $wit_dylib_push_u32 (;45;) (type 4)))
+  (import "env" "wit_dylib_push_s32" (func $wit_dylib_push_s32 (;46;) (type 4)))
+  (import "env" "wit_dylib_push_u64" (func $wit_dylib_push_u64 (;47;) (type 10)))
+  (import "env" "wit_dylib_push_s64" (func $wit_dylib_push_s64 (;48;) (type 10)))
+  (import "env" "wit_dylib_push_f32" (func $wit_dylib_push_f32 (;49;) (type 11)))
+  (import "env" "wit_dylib_push_f64" (func $wit_dylib_push_f64 (;50;) (type 12)))
+  (import "env" "wit_dylib_push_string" (func $wit_dylib_push_string (;51;) (type 13)))
+  (import "env" "wit_dylib_push_record" (func $wit_dylib_push_record (;52;) (type 4)))
+  (import "env" "wit_dylib_push_tuple" (func $wit_dylib_push_tuple (;53;) (type 4)))
+  (import "env" "wit_dylib_push_flags" (func $wit_dylib_push_flags (;54;) (type 13)))
+  (import "env" "wit_dylib_push_enum" (func $wit_dylib_push_enum (;55;) (type 13)))
+  (import "env" "wit_dylib_push_borrow" (func $wit_dylib_push_borrow (;56;) (type 13)))
+  (import "env" "wit_dylib_push_own" (func $wit_dylib_push_own (;57;) (type 13)))
+  (import "env" "wit_dylib_push_future" (func $wit_dylib_push_future (;58;) (type 13)))
+  (import "env" "wit_dylib_push_stream" (func $wit_dylib_push_stream (;59;) (type 13)))
+  (import "env" "wit_dylib_push_variant" (func $wit_dylib_push_variant (;60;) (type 13)))
+  (import "env" "wit_dylib_push_option" (func $wit_dylib_push_option (;61;) (type 13)))
+  (import "env" "wit_dylib_push_result" (func $wit_dylib_push_result (;62;) (type 13)))
+  (import "env" "wit_dylib_push_list" (func $wit_dylib_push_list (;63;) (type 1)))
+  (import "env" "wit_dylib_list_append" (func $wit_dylib_list_append (;64;) (type 4)))
+  (import "env" "wit_dylib_push_map" (func $wit_dylib_push_map (;65;) (type 13)))
+  (import "env" "wit_dylib_map_append" (func $wit_dylib_map_append (;66;) (type 4)))
+  (import "$root" "x" (func $x (;67;) (type 14)))
   (import "env" "__table_base" (global $__table_base (;0;) i32))
   (import "env" "__memory_base" (global $__memory_base (;1;) i32))
   (import "env" "__stack_pointer" (global $__stack_pointer (;2;) (mut i32)))
@@ -91,7 +96,7 @@
   (export "__wasm_apply_data_relocs" (func $__wasm_apply_data_relocs))
   (export "__wasm_call_ctors" (func $__wasm_call_ctors))
   (elem (;0;) (table 0) (global.get $__table_base) func $"adapter x")
-  (func $"adapter x" (;63;) (type 0) (param i32)
+  (func $"adapter x" (;68;) (type 0) (param i32)
     (local i32)
     global.get $__stack_pointer
     i32.const 16
@@ -104,7 +109,7 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $y (;64;) (type 14)
+  (func $y (;69;) (type 14)
     (local i32 i32 i32)
     global.get $__stack_pointer
     i32.const 16
@@ -126,7 +131,7 @@
     local.get 1
     i32.store
   )
-  (func $cabi_post_y (;65;) (type 14)
+  (func $cabi_post_y (;70;) (type 14)
     (local i32 i32)
     global.get $__stack_pointer
     local.set 0
@@ -147,10 +152,10 @@
     i32.add
     global.set $__stack_pointer
   )
-  (func $__wasm_apply_data_relocs (;66;) (type 14)
+  (func $__wasm_apply_data_relocs (;71;) (type 14)
     global.get $__memory_base
     global.get $__memory_base
-    i32.const 188
+    i32.const 196
     i32.add
     i32.store offset=4
     global.get $__memory_base
@@ -158,7 +163,7 @@
     i32.store offset=8
     global.get $__memory_base
     global.get $__memory_base
-    i32.const 190
+    i32.const 198
     i32.add
     i32.store offset=44
     global.get $__memory_base
@@ -172,11 +177,11 @@
     i32.add
     i32.store offset=80
   )
-  (func $__wasm_call_ctors (;67;) (type 14)
+  (func $__wasm_call_ctors (;72;) (type 14)
     i32.const 64
     global.get $__memory_base
     i32.add
     call $wit_dylib_initialize
   )
-  (data (;0;) (global.get $__memory_base) "/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/02/00/00/00/01/00/00/00/00/00/00/00/01/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00x/00y/00")
+  (data (;0;) (global.get $__memory_base) "/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/03/00/00/00/01/00/00/00/00/00/00/00/01/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00x/00y/00")
 )


### PR DESCRIPTION
Pushing and popping maps and their elements follows the convention established for lists, except that each item involves two values instead of one, and there's no "fast path" for pushing or popping directly from or to the canonical ABI format.