### PR TITLE
Refactor configuration of wit-component builders

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -47,21 +47,21 @@ runs:
       shell: bash
 
     - run: |
-        curl -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz
+        curl --retry 5 --retry-all-errors -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz
         tar xf wasi-sdk.tar.gz
         echo "WASI_SDK_PATH=`pwd`/wasi-sdk-33.0-x86_64-linux" >> $GITHUB_ENV
       if: runner.os == 'Linux'
       shell: bash
       working-directory: ${{ runner.tool_cache }}
     - run: |
-        curl -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-macos.tar.gz
+        curl --retry 5 --retry-all-errors -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-macos.tar.gz
         tar xf wasi-sdk.tar.gz
         echo "WASI_SDK_PATH=`pwd`/wasi-sdk-33.0-x86_64-macos" >> $GITHUB_ENV
       if: runner.os == 'macOS'
       shell: bash
       working-directory: ${{ runner.tool_cache }}
     - run: |
-        curl -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-windows.tar.gz
+        curl --retry 5 --retry-all-errors -L -o wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-windows.tar.gz
         tar xf wasi-sdk.tar.gz
         echo "WASI_SDK_PATH=`pwd`/wasi-sdk-33.0-x86_64-windows" >> $GITHUB_ENV
       if: runner.os == 'Windows'

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -3311,18 +3311,18 @@ impl ComponentEncoder {
     /// inside the module and add them as the interface, imports, and exports.
     /// It will also add any producers information inside the component type information to the
     /// core module.
-    pub fn module(mut self, module: &[u8]) -> Result<Self> {
+    pub fn module(&mut self, module: &[u8]) -> Result<&mut Self> {
         let (wasm, metadata) = self.decode(module.as_ref())?;
         let (wasm, module_import_map) = ModuleImportMap::new(wasm)?;
-        let exports = self
-            .merge_metadata(metadata)
-            .context("failed merge WIT metadata for module with previous metadata")?;
-        self.main_module_exports.extend(exports);
-        self.module = if let Some(producers) = &self.metadata.producers {
+        self.module = if let Some(producers) = &metadata.producers {
             producers.add_to_wasm(&wasm)?
         } else {
             wasm.to_vec()
         };
+        let exports = self
+            .merge_metadata(metadata)
+            .context("failed merge WIT metadata for module with previous metadata")?;
+        self.main_module_exports.extend(exports);
         self.module_import_map = module_import_map;
         Ok(self)
     }
@@ -3340,13 +3340,13 @@ impl ComponentEncoder {
     }
 
     /// Sets whether or not the encoder will validate its output.
-    pub fn validate(mut self, validate: bool) -> Self {
+    pub fn validate(&mut self, validate: bool) -> &mut Self {
         self.validate = validate;
         self
     }
 
     /// Sets whether or not to generate debug names in the output component.
-    pub fn debug_names(mut self, debug_names: bool) -> Self {
+    pub fn debug_names(&mut self, debug_names: bool) -> &mut Self {
         self.debug_names = debug_names;
         self
     }
@@ -3358,7 +3358,7 @@ impl ComponentEncoder {
     /// semver version ranges for interface allow it.
     ///
     /// This is enabled by default.
-    pub fn merge_imports_based_on_semver(mut self, merge: bool) -> Self {
+    pub fn merge_imports_based_on_semver(&mut self, merge: bool) -> &mut Self {
         self.merge_imports_based_on_semver = Some(merge);
         self
     }
@@ -3371,7 +3371,7 @@ impl ComponentEncoder {
     /// support.
     ///
     /// This is disabled by default.
-    pub fn reject_legacy_names(mut self, reject: bool) -> Self {
+    pub fn reject_legacy_names(&mut self, reject: bool) -> &mut Self {
         self.reject_legacy_names = reject;
         self
     }
@@ -3393,7 +3393,7 @@ impl ComponentEncoder {
     /// wasm module specified by `bytes` imports. The `bytes` will then import
     /// `interface` and export functions to get imported from the module `name`
     /// in the core wasm that's being wrapped.
-    pub fn adapter(self, name: &str, bytes: &[u8]) -> Result<Self> {
+    pub fn adapter(&mut self, name: &str, bytes: &[u8]) -> Result<&mut Self> {
         self.library_or_adapter(name, bytes, None)
     }
 
@@ -3409,16 +3409,21 @@ impl ComponentEncoder {
     /// Libraries are treated similarly to adapters, except that they are not
     /// "minified" the way adapters are, and instantiation is controlled
     /// declaratively via the `library_info` parameter.
-    pub fn library(self, name: &str, bytes: &[u8], library_info: LibraryInfo) -> Result<Self> {
+    pub fn library(
+        &mut self,
+        name: &str,
+        bytes: &[u8],
+        library_info: LibraryInfo,
+    ) -> Result<&mut Self> {
         self.library_or_adapter(name, bytes, Some(library_info))
     }
 
     fn library_or_adapter(
-        mut self,
+        &mut self,
         name: &str,
         bytes: &[u8],
         library_info: Option<LibraryInfo>,
-    ) -> Result<Self> {
+    ) -> Result<&mut Self> {
         let (wasm, mut metadata) = self.decode(bytes)?;
         // Merge the adapter's document into our own document to have one large
         // document, and then afterwards merge worlds as well.
@@ -3471,7 +3476,7 @@ impl ComponentEncoder {
     /// The default is to use the main module realloc
     /// Can be useful if cabi_realloc cannot be called before the host
     /// runtime is initialized.
-    pub fn realloc_via_memory_grow(mut self, value: bool) -> Self {
+    pub fn realloc_via_memory_grow(&mut self, value: bool) -> &mut Self {
         self.realloc_via_memory_grow = value;
         self
     }
@@ -3486,7 +3491,7 @@ impl ComponentEncoder {
     ///
     /// Note: the replacement names are not validated during encoding unless
     /// the `validate` option is set to true.
-    pub fn import_name_map(mut self, map: HashMap<String, String>) -> Self {
+    pub fn import_name_map(&mut self, map: HashMap<String, String>) -> &mut Self {
         self.import_name_map = map;
         self
     }

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -1647,30 +1647,18 @@ pub struct Linker {
     /// The order of this list determines priority in cases where more than one library exports the same symbol.
     libraries: Vec<(String, Vec<u8>, bool)>,
 
-    /// The set of adapters to use when generating the component
-    adapters: Vec<(String, Vec<u8>)>,
-
-    /// Whether to validate the resulting component prior to returning it
-    validate: bool,
-
     /// Whether to generate trapping stubs for any unresolved imports
     stub_missing_functions: bool,
 
     /// Whether to use a built-in implementation of `dlopen`/`dlsym`.
     use_built_in_libdl: bool,
 
-    /// Whether to generate debug `name` sections.
-    debug_names: bool,
-
     /// Size of stack (in bytes) to allocate in the synthesized main module
     ///
     /// If `None`, use `DEFAULT_STACK_SIZE_BYTES`.
     stack_size: Option<u32>,
 
-    /// This affects how when to WIT worlds are merged together, for example
-    /// from two different libraries, whether their imports are unified when the
-    /// semver version ranges for interface allow it.
-    merge_imports_based_on_semver: Option<bool>,
+    encoder: ComponentEncoder,
 }
 
 impl Linker {
@@ -1678,78 +1666,50 @@ impl Linker {
     ///
     /// If `dl_openable` is true, all of the library's exports will be added to the `dlopen`/`dlsym` lookup table
     /// for runtime resolution.
-    pub fn library(mut self, name: &str, module: &[u8], dl_openable: bool) -> Result<Self> {
+    pub fn library(&mut self, name: &str, module: &[u8], dl_openable: bool) -> Result<&mut Self> {
         self.libraries
             .push((name.to_owned(), module.to_vec(), dl_openable));
 
         Ok(self)
     }
 
-    /// Add an adapter to this linker.
-    ///
-    /// See [crate::encoding::ComponentEncoder::adapter] for details.
-    pub fn adapter(mut self, name: &str, module: &[u8]) -> Result<Self> {
-        self.adapters.push((name.to_owned(), module.to_vec()));
-
-        Ok(self)
-    }
-
-    /// Specify whether to validate the resulting component prior to returning it
-    pub fn validate(mut self, validate: bool) -> Self {
-        self.validate = validate;
-        self
-    }
-
     /// Specify size of stack to allocate in the synthesized main module
-    pub fn stack_size(mut self, stack_size: u32) -> Self {
+    pub fn stack_size(&mut self, stack_size: u32) -> &mut Self {
         self.stack_size = Some(stack_size);
         self
     }
 
     /// Specify whether to generate trapping stubs for any unresolved imports
-    pub fn stub_missing_functions(mut self, stub_missing_functions: bool) -> Self {
+    pub fn stub_missing_functions(&mut self, stub_missing_functions: bool) -> &mut Self {
         self.stub_missing_functions = stub_missing_functions;
         self
     }
 
     /// Specify whether to use a built-in implementation of `dlopen`/`dlsym`.
-    pub fn use_built_in_libdl(mut self, use_built_in_libdl: bool) -> Self {
+    pub fn use_built_in_libdl(&mut self, use_built_in_libdl: bool) -> &mut Self {
         self.use_built_in_libdl = use_built_in_libdl;
         self
     }
 
-    /// Whether or not to generate debug name sections.
-    pub fn debug_names(mut self, enable: bool) -> Self {
-        self.debug_names = enable;
-        self
-    }
-
-    /// This affects how when to WIT worlds are merged together, for example
-    /// from two different libraries, whether their imports are unified when the
-    /// semver version ranges for interface allow it.
-    ///
-    /// This is enabled by default.
-    pub fn merge_imports_based_on_semver(mut self, merge: bool) -> Self {
-        self.merge_imports_based_on_semver = Some(merge);
-        self
+    /// Returns a reference to the internal [`ComponentEncoder`] that can be
+    /// configured.
+    pub fn encoder(&mut self) -> &mut ComponentEncoder {
+        &mut self.encoder
     }
 
     /// Encode the component and return the bytes
     pub fn encode(mut self) -> Result<Vec<u8>> {
         if self.use_built_in_libdl {
             self.use_built_in_libdl = false;
-            self = self.library("libdl.so", include_bytes!("../libdl.so"), false)?;
+            self.library("libdl.so", include_bytes!("../libdl.so"), false)?;
         }
 
         let adapter_names = self
+            .encoder
             .adapters
-            .iter()
-            .map(|(name, _)| name.as_str())
-            .collect_unique::<HashSet<_>>();
-
-        if adapter_names.len() != self.adapters.len() {
-            bail!("duplicate adapter name");
-        }
+            .keys()
+            .map(|name| name.as_str())
+            .collect::<HashSet<_>>();
 
         let metadata = self
             .libraries
@@ -1877,17 +1837,7 @@ impl Linker {
             self.stack_size.unwrap_or(DEFAULT_STACK_SIZE_BYTES),
         );
 
-        let mut encoder = ComponentEncoder::default()
-            .validate(self.validate)
-            .debug_names(self.debug_names);
-        if let Some(merge) = self.merge_imports_based_on_semver {
-            encoder = encoder.merge_imports_based_on_semver(merge);
-        };
-        encoder = encoder.module(&env_module)?;
-
-        for (name, module) in &self.adapters {
-            encoder = encoder.adapter(name, module)?;
-        }
+        self.encoder.module(&env_module)?;
 
         let default_env_items = [
             Item {
@@ -2068,7 +2018,7 @@ impl Linker {
                 });
             }
 
-            encoder = encoder.library(
+            self.encoder.library(
                 name,
                 module,
                 LibraryInfo {
@@ -2091,7 +2041,7 @@ impl Linker {
             seen.insert(name.as_str());
         }
 
-        encoder
+        self.encoder
             .library(
                 "__init",
                 &make_init_module(

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Error, Result, bail};
+use anyhow::{Context, Result, bail};
 use libtest_mimic::{Arguments, Trial};
 use pretty_assertions::assert_eq;
 use std::{borrow::Cow, fs, path::Path};
@@ -85,21 +85,19 @@ fn run_test(path: &Path) -> Result<()> {
     let path = path.to_path_buf();
 
     let module_path = path.join("module.wat");
-    let mut adapters = glob::glob(path.join("adapt-*.wat").to_str().unwrap())?;
+    let adapters = glob::glob(path.join("adapt-*.wat").to_str().unwrap())?;
     let result = if module_path.is_file() {
-        let module = read_core_module(&module_path, &resolve, pkg_id)
-            .with_context(|| format!("failed to read core module at {module_path:?}"))?;
-        adapters
-            .try_fold(
-                ComponentEncoder::default()
-                    .debug_names(true)
-                    .module(&module)?,
-                |encoder, path| {
-                    let (name, wasm) = read_name_and_module("adapt-", &path?, &resolve, pkg_id)?;
-                    Ok::<_, Error>(encoder.adapter(&name, &wasm)?)
-                },
-            )?
-            .encode()
+        let mut encoder = ComponentEncoder::default();
+        (|| -> Result<_> {
+            let module = read_core_module(&module_path, &resolve, pkg_id)
+                .with_context(|| format!("failed to read core module at {module_path:?}"))?;
+            encoder.debug_names(true).module(&module)?;
+            for adapter in adapters {
+                let (name, wasm) = read_name_and_module("adapt-", &adapter?, &resolve, pkg_id)?;
+                encoder.adapter(&name, &wasm)?;
+            }
+            encoder.encode()
+        })()
     } else {
         let mut libs = glob::glob(path.join("lib-*.wat").to_str().unwrap())?
             .map(|path| Ok(("lib-", path?, false)))
@@ -112,29 +110,29 @@ fn run_test(path: &Path) -> Result<()> {
         // Sort list to ensure deterministic order, which determines priority in cases of duplicate symbols:
         libs.sort_by(|(_, a, _), (_, b, _)| a.cmp(b));
 
-        let mut linker = Linker::default().validate(false).debug_names(true);
+        let mut linker = Linker::default();
+        linker.encoder().validate(false).debug_names(true);
 
         if path.join("stub-missing-functions").is_file() {
-            linker = linker.stub_missing_functions(true);
+            linker.stub_missing_functions(true);
         }
 
         if path.join("use-built-in-libdl").is_file() {
-            linker = linker.use_built_in_libdl(true);
+            linker.use_built_in_libdl(true);
         }
 
-        let linker = libs
-            .into_iter()
-            .try_fold(linker, |linker, (prefix, path, dl_openable)| {
+        (|| -> Result<_> {
+            for (prefix, path, dl_openable) in libs {
                 let (name, wasm) = read_name_and_module(prefix, &path, &resolve, pkg_id)?;
-                Ok::<_, Error>(linker.library(&name, &wasm, dl_openable)?)
-            })?;
-
-        adapters
-            .try_fold(linker, |linker, path| {
+                linker.library(&name, &wasm, dl_openable)?;
+            }
+            for path in adapters {
                 let (name, wasm) = read_name_and_module("adapt-", &path?, &resolve, pkg_id)?;
-                Ok::<_, Error>(linker.adapter(&name, &wasm)?)
-            })?
-            .encode()
+                linker.encoder().adapter(&name, &wasm)?;
+            }
+
+            linker.encode()
+        })()
     };
     let component_path = path.join("component.wat");
     let component_wit_path = path.join("component.wit.print");

--- a/crates/wit-component/tests/linking.rs
+++ b/crates/wit-component/tests/linking.rs
@@ -158,23 +158,20 @@ fn encode(wat: &str, wit: Option<&str>) -> Result<Vec<u8>> {
 
 #[test]
 fn linking() -> Result<()> {
-    let component = [
+    let mut linker = wit_component::Linker::default();
+    linker.encoder().validate(true);
+    for (name, wat, wit) in [
         ("libfoo.so", FOO, None),
         ("libbar.so", BAR, Some(WIT)),
         ("libc.so", LIBC, None),
-    ]
-    .into_iter()
-    .try_fold(
-        wit_component::Linker::default().validate(true),
-        |linker, (name, wat, wit)| {
-            linker.library(
-                name,
-                &encode(wat, wit).with_context(|| name.to_owned())?,
-                false,
-            )
-        },
-    )?
-    .encode()?;
+    ] {
+        linker.library(
+            name,
+            &encode(wat, wit).with_context(|| name.to_owned())?,
+            false,
+        )?;
+    }
+    let component = linker.encode()?;
 
     #[cfg(target_family = "wasm")]
     {
@@ -250,22 +247,19 @@ world bar {
 
 #[test]
 fn linking_got_weak() -> Result<()> {
-    let component = [
+    let mut linker = wit_component::Linker::default();
+    linker.encoder().validate(true);
+    for (name, wat, wit) in [
         ("libfoo.so", GOT_IMPORT, Some(GOT_IMPORT_WIT)),
         ("libc.so", LIBC, None),
-    ]
-    .into_iter()
-    .try_fold(
-        wit_component::Linker::default().validate(true),
-        |linker, (name, wat, wit)| {
-            linker.library(
-                name,
-                &encode(wat, wit).with_context(|| name.to_owned())?,
-                false,
-            )
-        },
-    )?
-    .encode()?;
+    ] {
+        linker.library(
+            name,
+            &encode(wat, wit).with_context(|| name.to_owned())?,
+            false,
+        )?;
+    }
+    let component = linker.encode()?;
 
     #[cfg(target_family = "wasm")]
     {

--- a/crates/wit-dylib/test-programs/artifacts/src/lib.rs
+++ b/crates/wit-dylib/test-programs/artifacts/src/lib.rs
@@ -61,7 +61,7 @@ fn create_component(
     let mut linker = Linker::default();
 
     // First define our caller/callee component with its own filename.
-    linker = linker
+    linker
         .library(
             wasm.0.file_name().unwrap().to_str().unwrap(),
             &std::fs::read(wasm.0).context("failed to read wasm")?,
@@ -71,13 +71,13 @@ fn create_component(
 
     // Next insert the synthesized adapter that is what we're primarily testing
     // in this file.
-    linker = linker
+    linker
         .library(&format!("{name}-interpreter-adapter.wasm"), &adapter, false)
         .context("failed to link adapter as library")?;
 
     // Next load up `libc.so` as we specified in the compilation of the original
     // file that it should be linked dynamically.
-    linker = linker
+    linker
         .library(
             "libc.so",
             &std::fs::read(LIBC_SO).context("failed to read libc.so")?,
@@ -87,7 +87,8 @@ fn create_component(
 
     // Rust-sourced compiles still, as of the time of this writing, require the
     // WASIp1 adapter. Load that in here.
-    linker = linker
+    linker
+        .encoder()
         .adapter(
             "wasi_snapshot_preview1",
             wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -106,7 +106,7 @@ Examples:
 
     # Create a component and print it to stdout in in text format, skipping validation of
     # the output component.
-    $ wasm-tools component new foo.wasm -t --skip-validation
+    $ wasm-tools component new foo.wasm -t --validate=false
 
     # Create a component, using memory.grow to reallocate memory.
     # This can be useful if `cabi_realloc` cannot be called before the host runtime
@@ -115,9 +115,6 @@ Examples:
         --adapt wasi_snapshot_preview1.reactor.wasm -o foo.component.wasm
 ")]
 pub struct NewOpts {
-    #[clap(flatten)]
-    adapters: wasm_tools::AdaptersArg,
-
     /// Rename an instance import in the output component.
     ///
     /// This may be used to rename instance imports in the final component.
@@ -136,13 +133,64 @@ pub struct NewOpts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,
 
-    /// Skip validation of the output component.
-    #[clap(long)]
-    skip_validation: bool,
+    #[clap(flatten)]
+    encoder_opts: ComponentEncoderOpts,
 
     /// Print the output in the WebAssembly text format instead of binary.
     #[clap(long, short = 't')]
     wat: bool,
+}
+
+impl NewOpts {
+    fn general_opts(&self) -> &wasm_tools::GeneralOpts {
+        self.io.general_opts()
+    }
+
+    /// Executes the application.
+    fn run(self) -> Result<()> {
+        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
+        let mut encoder = ComponentEncoder::default();
+        self.encoder_opts.configure(&mut encoder)?;
+        encoder.module(&wasm)?;
+
+        let bytes = encoder
+            .import_name_map(self.import_names.into_iter().collect())
+            .encode()
+            .context("failed to encode a component from module")?;
+
+        self.io.output_wasm(&bytes, self.wat)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Parser)]
+struct ComponentEncoderOpts {
+    /// The path to an adapter module to satisfy imports not otherwise bound to
+    /// WIT interfaces.
+    ///
+    /// An adapter module can be used to translate the `wasi_snapshot_preview1`
+    /// ABI, for example, to one that uses the component model. The first
+    /// `[NAME=]` specified in the argument is inferred from the name of file
+    /// specified by `MODULE` if not present and is the name of the import
+    /// module that's being implemented (e.g. `wasi_snapshot_preview1.wasm`).
+    ///
+    /// The second part of this argument is the path to the adapter module.
+    #[clap(long = "adapt", value_name = "[NAME=]MODULE", value_parser = parse_adapter)]
+    pub adapters: Vec<(String, Vec<u8>)>,
+
+    /// Deprecated, use `--validate=false` instead.
+    #[clap(long, hide = true, conflicts_with = "validate")]
+    skip_validation: bool,
+
+    /// Whether or not to validate the output component
+    #[arg(
+        long,
+        conflicts_with = "skip_validation",
+        require_equals = true,
+        value_name = "true|false"
+    )]
+    validate: Option<Option<bool>>,
 
     /// Use memory.grow to realloc memory and stack allocation.
     #[clap(long)]
@@ -152,8 +200,8 @@ pub struct NewOpts {
     /// semver ranges.
     ///
     /// This is enabled by default.
-    #[clap(long, value_name = "<true|false>")]
-    merge_imports_based_on_semver: Option<bool>,
+    #[arg(long, require_equals = true, value_name = "true|false")]
+    merge_imports_based_on_semver: Option<Option<bool>>,
 
     /// Reject usage of the "legacy" naming scheme of `wit-component` and
     /// require the new naming scheme to be used.
@@ -165,38 +213,56 @@ pub struct NewOpts {
     /// removal of the old scheme in the future.
     #[clap(long)]
     reject_legacy_names: bool,
+
+    /// Whether or not to add debug names to the generated binary.
+    #[arg(long, require_equals = true, value_name = "true|false")]
+    debug_names: Option<Option<bool>>,
 }
 
-impl NewOpts {
-    fn general_opts(&self) -> &wasm_tools::GeneralOpts {
-        self.io.general_opts()
+fn parse_optionally_name_file(s: &str) -> (&str, &str) {
+    let mut parts = s.splitn(2, '=');
+    let name_or_path = parts.next().unwrap();
+    match parts.next() {
+        Some(path) => (name_or_path, path),
+        None => {
+            let name = Path::new(name_or_path)
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap();
+            let name = match name.find('.') {
+                Some(i) => &name[..i],
+                None => name,
+            };
+            (name, name_or_path)
+        }
     }
+}
 
-    /// Executes the application.
-    fn run(self) -> Result<()> {
-        let wasm = self.io.get_input_wasm(Some(&self.generate_dwarf))?;
-        let mut encoder = ComponentEncoder::default()
-            .validate(!self.skip_validation)
-            .reject_legacy_names(self.reject_legacy_names);
+fn parse_adapter(s: &str) -> Result<(String, Vec<u8>)> {
+    let (name, path) = parse_optionally_name_file(s);
+    let wasm = wat::parse_file(path)?;
+    Ok((name.to_string(), wasm))
+}
 
-        if let Some(merge) = self.merge_imports_based_on_semver {
-            encoder = encoder.merge_imports_based_on_semver(merge);
+impl ComponentEncoderOpts {
+    fn configure(&self, encoder: &mut ComponentEncoder) -> Result<()> {
+        encoder
+            .validate(if self.skip_validation {
+                false
+            } else {
+                optional_flag_with_default(self.validate, true)
+            })
+            .reject_legacy_names(self.reject_legacy_names)
+            .debug_names(optional_flag_with_default(self.debug_names, true))
+            .merge_imports_based_on_semver(optional_flag_with_default(
+                self.merge_imports_based_on_semver,
+                false,
+            ))
+            .realloc_via_memory_grow(self.realloc_via_memory_grow);
+        for (name, wasm) in self.adapters.iter() {
+            encoder.adapter(name, wasm)?;
         }
-        encoder = encoder.module(&wasm)?;
-
-        for (name, wasm) in self.adapters.adapters.iter() {
-            encoder = encoder.adapter(name, wasm)?;
-        }
-
-        encoder = encoder.realloc_via_memory_grow(self.realloc_via_memory_grow);
-
-        let bytes = encoder
-            .import_name_map(self.import_names.into_iter().collect())
-            .encode()
-            .context("failed to encode a component from module")?;
-
-        self.io.output_wasm(&bytes, self.wat)?;
-
         Ok(())
     }
 }
@@ -479,9 +545,6 @@ pub struct LinkOpts {
     #[clap(long, value_name = "[NAME=]MODULE", value_parser = parse_library)]
     dl_openable: Vec<(String, Vec<u8>)>,
 
-    #[clap(flatten)]
-    adapters: wasm_tools::AdaptersArg,
-
     /// Size of stack (in bytes) to allocate in the synthesized main module
     #[clap(long)]
     stack_size: Option<u32>,
@@ -491,19 +554,6 @@ pub struct LinkOpts {
 
     #[clap(flatten)]
     general: wasm_tools::GeneralOpts,
-
-    /// Deprecated, use `--validate=false` instead.
-    #[clap(long, hide = true, conflicts_with = "validate")]
-    skip_validation: bool,
-
-    /// Whether or not to validate the output component
-    #[arg(
-        long,
-        conflicts_with = "skip_validation",
-        require_equals = true,
-        value_name = "true|false"
-    )]
-    validate: Option<Option<bool>>,
 
     /// Print the output in the WebAssembly text format instead of binary.
     #[clap(long, short = 't')]
@@ -517,16 +567,8 @@ pub struct LinkOpts {
     #[clap(long)]
     use_built_in_libdl: bool,
 
-    /// Indicates whether imports into the final component are merged based on
-    /// semver ranges.
-    ///
-    /// This is enabled by default.
-    #[arg(long, require_equals = true, value_name = "true|false")]
-    merge_imports_based_on_semver: Option<Option<bool>>,
-
-    /// Whether or not to add debug names to the generated binary.
-    #[arg(long, require_equals = true, value_name = "true|false")]
-    debug_names: Option<Option<bool>>,
+    #[clap(flatten)]
+    encoder_opts: ComponentEncoderOpts,
 }
 
 fn optional_flag_with_default(flag: Option<Option<bool>>, default: bool) -> bool {
@@ -544,30 +586,22 @@ impl LinkOpts {
 
     /// Executes the application.
     fn run(self) -> Result<()> {
-        let mut linker = Linker::default()
-            .validate(!self.skip_validation)
+        let mut linker = Linker::default();
+        linker
             .stub_missing_functions(self.stub_missing_functions)
-            .use_built_in_libdl(self.use_built_in_libdl)
-            .debug_names(optional_flag_with_default(self.debug_names, true));
+            .use_built_in_libdl(self.use_built_in_libdl);
+        self.encoder_opts.configure(linker.encoder())?;
 
         if let Some(stack_size) = self.stack_size {
-            linker = linker.stack_size(stack_size);
-        }
-
-        if let Some(merge) = self.merge_imports_based_on_semver {
-            linker = linker.merge_imports_based_on_semver(merge.unwrap_or(true));
+            linker.stack_size(stack_size);
         }
 
         for (name, wasm) in &self.inputs {
-            linker = linker.library(name, wasm, false)?;
+            linker.library(name, wasm, false)?;
         }
 
         for (name, wasm) in &self.dl_openable {
-            linker = linker.library(name, wasm, true)?;
-        }
-
-        for (name, wasm) in &self.adapters.adapters {
-            linker = linker.adapter(name, wasm)?;
+            linker.library(name, wasm, true)?;
         }
 
         let bytes = linker
@@ -654,7 +688,7 @@ Writing: out/component.wit
 
    # With the same foo.wasm file, print a textual WAT representation
    # of the interface to stdout, skipping validation of the WAT code.
-   $ wasm-tools component wit foo.wasm -t --skip-validation
+   $ wasm-tools component wit foo.wasm -t --validate=false
 
    # With the same foo.wasm file, print a JSON representation
    # of the interface to stdout.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,48 +62,6 @@ pub struct InputOutput {
     general: GeneralOpts,
 }
 
-fn parse_optionally_name_file(s: &str) -> (&str, &str) {
-    let mut parts = s.splitn(2, '=');
-    let name_or_path = parts.next().unwrap();
-    match parts.next() {
-        Some(path) => (name_or_path, path),
-        None => {
-            let name = Path::new(name_or_path)
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap();
-            let name = match name.find('.') {
-                Some(i) => &name[..i],
-                None => name,
-            };
-            (name, name_or_path)
-        }
-    }
-}
-
-fn parse_adapter(s: &str) -> Result<(String, Vec<u8>)> {
-    let (name, path) = parse_optionally_name_file(s);
-    let wasm = wat::parse_file(path)?;
-    Ok((name.to_string(), wasm))
-}
-
-#[derive(clap::Parser)]
-pub struct AdaptersArg {
-    /// The path to an adapter module to satisfy imports not otherwise bound to
-    /// WIT interfaces.
-    ///
-    /// An adapter module can be used to translate the `wasi_snapshot_preview1`
-    /// ABI, for example, to one that uses the component model. The first
-    /// `[NAME=]` specified in the argument is inferred from the name of file
-    /// specified by `MODULE` if not present and is the name of the import
-    /// module that's being implemented (e.g. `wasi_snapshot_preview1.wasm`).
-    ///
-    /// The second part of this argument is the path to the adapter module.
-    #[clap(long = "adapt", value_name = "[NAME=]MODULE", value_parser = parse_adapter)]
-    pub adapters: Vec<(String, Vec<u8>)>,
-}
-
 #[derive(clap::Parser)]
 pub struct GenerateDwarfArg {
     /// Optionally generate DWARF debugging information from WebAssembly text

--- a/tests/cli/help-component-new-short.wat.stdout
+++ b/tests/cli/help-component-new-short.wat.stdout
@@ -6,9 +6,6 @@ Arguments:
   [INPUT]  Input file to process
 
 Options:
-      --adapt <[NAME=]MODULE>
-          The path to an adapter module to satisfy imports not otherwise bound
-          to WIT interfaces
       --import-name <OLD=NEW>
           Rename an instance import in the output component
       --generate-dwarf <lines|full>
@@ -23,18 +20,25 @@ Options:
       --color <COLOR>
           Configuration over whether terminal colors are used in output
           [default: auto]
-      --skip-validation
-          Skip validation of the output component
-  -t, --wat
-          Print the output in the WebAssembly text format instead of binary
+      --adapt <[NAME=]MODULE>
+          The path to an adapter module to satisfy imports not otherwise bound
+          to WIT interfaces
+      --validate[=<true|false>]
+          Whether or not to validate the output component [possible values:
+          true, false]
       --realloc-via-memory-grow
           Use memory.grow to realloc memory and stack allocation
-      --merge-imports-based-on-semver <<true|false>>
+      --merge-imports-based-on-semver[=<true|false>]
           Indicates whether imports into the final component are merged based on
           semver ranges [possible values: true, false]
       --reject-legacy-names
           Reject usage of the "legacy" naming scheme of `wit-component` and
           require the new naming scheme to be used
+      --debug-names[=<true|false>]
+          Whether or not to add debug names to the generated binary [possible
+          values: true, false]
+  -t, --wat
+          Print the output in the WebAssembly text format instead of binary
   -h, --help
           Print help (see more with '--help')
 
@@ -73,7 +77,7 @@ Examples:
     # Create a component and print it to stdout in in text format, skipping
     validation of
     # the output component.
-    $ wasm-tools component new foo.wasm -t --skip-validation
+    $ wasm-tools component new foo.wasm -t --validate=false
 
     # Create a component, using memory.grow to reallocate memory.
     # This can be useful if `cabi_realloc` cannot be called before the host

--- a/tests/cli/help-component-new.wat.stdout
+++ b/tests/cli/help-component-new.wat.stdout
@@ -21,19 +21,6 @@ Arguments:
           binary `*.wasm` file or a textual format `*.wat` file.
 
 Options:
-      --adapt <[NAME=]MODULE>
-          The path to an adapter module to satisfy imports not otherwise bound
-          to WIT interfaces.
-          
-          An adapter module can be used to translate the
-          `wasi_snapshot_preview1` ABI, for example, to one that uses the
-          component model. The first `[NAME=]` specified in the argument is
-          inferred from the name of file specified by `MODULE` if not present
-          and is the name of the import module that's being implemented (e.g.
-          `wasi_snapshot_preview1.wasm`).
-          
-          The second part of this argument is the path to the adapter module.
-
       --import-name <OLD=NEW>
           Rename an instance import in the output component.
           
@@ -78,16 +65,28 @@ Options:
           
           [default: auto]
 
-      --skip-validation
-          Skip validation of the output component
+      --adapt <[NAME=]MODULE>
+          The path to an adapter module to satisfy imports not otherwise bound
+          to WIT interfaces.
+          
+          An adapter module can be used to translate the
+          `wasi_snapshot_preview1` ABI, for example, to one that uses the
+          component model. The first `[NAME=]` specified in the argument is
+          inferred from the name of file specified by `MODULE` if not present
+          and is the name of the import module that's being implemented (e.g.
+          `wasi_snapshot_preview1.wasm`).
+          
+          The second part of this argument is the path to the adapter module.
 
-  -t, --wat
-          Print the output in the WebAssembly text format instead of binary
+      --validate[=<true|false>]
+          Whether or not to validate the output component
+          
+          [possible values: true, false]
 
       --realloc-via-memory-grow
           Use memory.grow to realloc memory and stack allocation
 
-      --merge-imports-based-on-semver <<true|false>>
+      --merge-imports-based-on-semver[=<true|false>]
           Indicates whether imports into the final component are merged based on
           semver ranges.
           
@@ -104,6 +103,14 @@ Options:
           compatibility `wit-component`'s historical naming scheme. This is
           intended to be used to test if a tool is compatible with a
           hypothetical removal of the old scheme in the future.
+
+      --debug-names[=<true|false>]
+          Whether or not to add debug names to the generated binary
+          
+          [possible values: true, false]
+
+  -t, --wat
+          Print the output in the WebAssembly text format instead of binary
 
   -h, --help
           Print help (see a summary with '-h')
@@ -143,7 +150,7 @@ Examples:
     # Create a component and print it to stdout in in text format, skipping
     validation of
     # the output component.
-    $ wasm-tools component new foo.wasm -t --skip-validation
+    $ wasm-tools component new foo.wasm -t --validate=false
 
     # Create a component, using memory.grow to reallocate memory.
     # This can be useful if `cabi_realloc` cannot be called before the host

--- a/tests/cli/help-component-wit-short.wat.stdout
+++ b/tests/cli/help-component-wit-short.wat.stdout
@@ -126,7 +126,7 @@ Writing: out/component.wit
 
    # With the same foo.wasm file, print a textual WAT representation
    # of the interface to stdout, skipping validation of the WAT code.
-   $ wasm-tools component wit foo.wasm -t --skip-validation
+   $ wasm-tools component wit foo.wasm -t --validate=false
 
    # With the same foo.wasm file, print a JSON representation
    # of the interface to stdout.

--- a/tests/cli/help-component-wit.wat.stdout
+++ b/tests/cli/help-component-wit.wat.stdout
@@ -224,7 +224,7 @@ Writing: out/component.wit
 
    # With the same foo.wasm file, print a textual WAT representation
    # of the interface to stdout, skipping validation of the WAT code.
-   $ wasm-tools component wit foo.wasm -t --skip-validation
+   $ wasm-tools component wit foo.wasm -t --validate=false
 
    # With the same foo.wasm file, print a JSON representation
    # of the interface to stdout.


### PR DESCRIPTION
This commit makes a few changes to share more configuration options between the `wasm-tools component link` and `wasm-tools component new` subcommands. Specifically:

* Builder methods now are `&mut self -> &mut Self`.
* `Linker` now stores a `ComponentEncoder` internally to avoid duplicating configuration.
* Options are now in a shared structure across these subcommands with a shared configuration of `ComponentEncoder`.

This ensures that options are uniformly added to `wasm-tools component link` in addition to `wasm-tools component new`.