### PR TITLE
Generalize `__wasm_init_task` to a "task hook"

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -762,8 +762,7 @@ impl<'a> EncodingState<'a> {
                 | Export::Initialize
                 | Export::ReallocForAdapter
                 | Export::IndirectFunctionTable
-                | Export::WasmInitTask
-                | Export::WasmInitAsyncTask => continue,
+                | Export::WasmTaskHook => continue,
             }
         }
 
@@ -1113,14 +1112,18 @@ impl<'a> EncodingState<'a> {
         let resolve = &self.info.encoder.metadata.resolve;
         let metadata = self.info.module_metadata_for(module);
         let instance_index = self.instance_for(module);
-        // If we generated an init task wrapper for this export, use that,
-        // otherwise alias the original export.
-        let core_func_index =
-            if let Some(&wrapper_idx) = self.export_task_initialization_wrappers.get(core_name) {
+
+        let core_alias_export = |me: &mut Self, core_name: &str| {
+            // If a hook was generated for this function, use that, otherwise
+            // use the original export.
+            if let Some(&wrapper_idx) = me.export_task_initialization_wrappers.get(core_name) {
                 wrapper_idx
             } else {
-                self.core_alias_export(Some(core_name), instance_index, core_name, ExportKind::Func)
-            };
+                me.core_alias_export(Some(core_name), instance_index, core_name, ExportKind::Func)
+            }
+        };
+
+        let core_func_index = core_alias_export(self, core_name);
         let exports = self.info.exports_for(module);
 
         let options = RequiredOptions::for_export(
@@ -1144,17 +1147,11 @@ impl<'a> EncodingState<'a> {
             .collect::<Vec<_>>();
 
         if let Some(post_return) = exports.post_return(key, func) {
-            let post_return = self.core_alias_export(
-                Some(post_return),
-                instance_index,
-                post_return,
-                ExportKind::Func,
-            );
+            let post_return = core_alias_export(self, post_return);
             options.push(CanonicalOption::PostReturn(post_return));
         }
         if let Some(callback) = exports.callback(key, func) {
-            let callback =
-                self.core_alias_export(Some(callback), instance_index, callback, ExportKind::Func);
+            let callback = core_alias_export(self, callback);
             options.push(CanonicalOption::Callback(callback));
         }
         let func_index = self

--- a/crates/wit-component/src/encoding/fixup.rs
+++ b/crates/wit-component/src/encoding/fixup.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::mem;
 use wasm_encoder::*;
 use wit_parser::WorldItem;
-use wit_parser::abi::WasmSignature;
+use wit_parser::abi::{AbiVariant, WasmSignature};
 
 #[derive(Default)]
 pub struct FixupModule {
@@ -83,6 +83,8 @@ pub enum StartAction {
         export: u32,
         dest: AddressDest,
     },
+    /// Invoke the `func` hook with the `hook` argument.
+    CallHook { func: u32, hook: TaskHook },
 }
 
 pub enum AddressDest {
@@ -113,19 +115,56 @@ enum DefinedFunction {
     /// A function which wraps a core export to ensure that task state is set up
     /// before the core export is called.
     HookedCoreExport {
-        /// The hook to call first.
-        before: u32,
-        /// The core export to call after the hook.
-        export: u32,
+        /// The task hook function.
+        task_hook: u32,
+        /// The core function to call and delegate to.
+        to_wrap: u32,
         /// The number of parameters to forward to `export`.
         params: usize,
         /// The debug-related core name of this function it's hooking.
         core_name: String,
+        /// Whether or not to export this function.
+        export: bool,
+        /// The kind of hook to use at the start of this function.
+        start: TaskHook,
+        /// The kind of hook to use at the end of this function.
+        end: EndTaskHook,
     },
+}
 
-    /// Similar to `HookedCoreExport` except that this is specifically for
-    /// resource destructors which don't need to be reexported.
-    HookedResourceDtor { before: u32, export: u32 },
+#[derive(Copy, Clone)]
+pub enum TaskHook {
+    /// A synchronous task has started.
+    SyncStart = 0,
+    /// A synchronous task has finished.
+    SyncFinish = 1,
+    /// An async task has started.
+    AsyncStart = 2,
+    /// An async has resumed in its `callback` option.
+    AsyncResume = 3,
+    /// An async blocked, but not yet completed, and it's returning from either
+    /// the main entrypoint or the `callback` option.
+    AsyncBlock = 4,
+    /// An async task has finished, returning from either the main entrypoint or
+    /// the `callback` option.
+    AsyncFinish = 5,
+    /// The `_initialize` function and other ctors are being called.
+    InitializeStart = 6,
+    /// The `_initialize` function and other ctors are finished.
+    InitializeFinish = 7,
+    /// A resource destructor is starting.
+    ResourceDtorStart = 8,
+    /// A resource destructor is finished.
+    ResourceDtorFinish = 9,
+    /// A call to post-return is starting.
+    PostReturnStart = 10,
+    /// A call to post-return is finished.
+    PostReturnFinish = 11,
+}
+
+enum EndTaskHook {
+    AsyncCode,
+    Normal(TaskHook),
 }
 
 impl FixupModule {
@@ -334,7 +373,11 @@ impl FixupModule {
         // `state` that they should be preferred over their raw brethren.
         for (i, (_ty, func)) in self.defined_functions.iter().enumerate() {
             match func {
-                DefinedFunction::HookedCoreExport { core_name, .. } => {
+                DefinedFunction::HookedCoreExport {
+                    core_name,
+                    export: true,
+                    ..
+                } => {
                     let name = format!("hook{i}");
                     let wrapper =
                         state.core_alias_export(Some(&name), instance, &name, ExportKind::Func);
@@ -342,7 +385,7 @@ impl FixupModule {
                         .export_task_initialization_wrappers
                         .insert(core_name.clone(), wrapper);
                 }
-                DefinedFunction::HookedResourceDtor { .. } => {}
+                DefinedFunction::HookedCoreExport { export: false, .. } => {}
             }
         }
         Ok(())
@@ -372,34 +415,60 @@ impl FixupModule {
             functions.function(*ty);
             let index = inc(&mut self.funcs);
             defined_func_indices.push(index);
-            let func = match func {
+            let mut func = match func {
                 DefinedFunction::HookedCoreExport {
-                    before,
-                    export,
+                    task_hook,
+                    to_wrap,
                     params,
                     core_name,
+                    export,
+                    start,
+                    end,
                 } => {
-                    let mut f = Function::new(Vec::new());
-                    f.instructions().call(*before);
+                    let mut locals = Vec::new();
+                    if let EndTaskHook::AsyncCode = end {
+                        locals.push((1, ValType::I32));
+                    }
+                    let mut f = Function::new(locals);
+                    f.instructions().i32_const(*start as i32).call(*task_hook);
                     for i in 0..*params {
                         f.instructions().local_get(i as u32);
                     }
-                    f.instructions().call(*export).end();
-                    exports.export(&format!("hook{i}"), ExportKind::Func, index);
+                    f.instructions().call(*to_wrap);
+                    match end {
+                        EndTaskHook::AsyncCode => {
+                            f.instructions()
+                                .local_set(*params as u32)
+                                // 0 == EXIT, 1/2 == yield/wait, so delegate to
+                                // appropriate code.
+                                //
+                                // First thing pushed on the stack is "if true",
+                                // which in this case nonzero means blocking.
+                                // Second thing is "if false" meaning if 0
+                                // meaning EXIT meaning "done". Final thing is
+                                // what to test, the return code.
+                                .i32_const(TaskHook::AsyncBlock as i32)
+                                .i32_const(TaskHook::AsyncFinish as i32)
+                                .local_get(*params as u32)
+                                .select()
+                                .call(*task_hook)
+                                // put the return code back on the stack to
+                                // actually return
+                                .local_get(*params as u32);
+                        }
+                        EndTaskHook::Normal(hook) => {
+                            f.instructions().i32_const(*hook as i32).call(*task_hook);
+                        }
+                    }
+                    if *export {
+                        exports.export(&format!("hook{i}"), ExportKind::Func, index);
+                    }
                     self.function_names
                         .append(index, &format!("hook-{core_name}"));
                     f
                 }
-                DefinedFunction::HookedResourceDtor { before, export } => {
-                    let mut f = Function::new(Vec::new());
-                    f.instructions()
-                        .call(*before)
-                        .local_get(0)
-                        .call(*export)
-                        .end();
-                    f
-                }
             };
+            func.instructions().end();
             code.function(&func);
         }
 
@@ -455,6 +524,9 @@ impl FixupModule {
                         }
                         StartAction::Call(func) => {
                             start.instructions().call(*func);
+                        }
+                        StartAction::CallHook { func, hook } => {
+                            start.instructions().i32_const(*hook as i32).call(*func);
                         }
                         StartAction::InitializeAddress {
                             memory_base,
@@ -554,23 +626,6 @@ impl FixupModule {
         Ok(Some(module))
     }
 
-    fn lazy_import_task_hook(
-        &mut self,
-        cache: &mut Option<u32>,
-        name: Option<&str>,
-    ) -> Result<Option<u32>> {
-        let Some(name) = name else {
-            return Ok(None);
-        };
-        if let Some(i) = cache {
-            return Ok(Some(*i));
-        }
-        let ty = self.type_thunk();
-        let ret = self.import_func(&ImportedInstance::Main, name, ty)?;
-        *cache = Some(ret);
-        Ok(Some(ret))
-    }
-
     /// Prepares task hooks, like `__wasm_init_task`, to be configured in
     /// various locations throughout this fixup module.
     ///
@@ -580,40 +635,32 @@ impl FixupModule {
     /// * Hooks for all exports which are lifted.
     fn prepare_task_hooks(&mut self, state: &mut EncodingState<'_>) -> Result<()> {
         let info_main = state.info.exports_for(CustomModule::Main);
-        let init_task = info_main.wasm_init_task();
-        let async_init_task = info_main.wasm_init_async_task();
-        if init_task.is_none() && async_init_task.is_none() {
+        let Some(task_hook) = info_main.wasm_task_hook() else {
             return Ok(());
-        }
-
-        let mut init_index = None;
-        let mut async_init_index = None;
-        let mut init_index = |me: &mut Self| me.lazy_import_task_hook(&mut init_index, init_task);
-        let mut async_init_index =
-            |me: &mut Self| me.lazy_import_task_hook(&mut async_init_index, async_init_task);
+        };
+        let ty = self.type_intern(vec![ValType::I32], Vec::new());
+        let task_hook = self.import_func(&ImportedInstance::Main, task_hook, ty)?;
 
         // Handle the start function first where if there's something registered
         // in the "user function" area we need to configure that to work.
         if !self.start_user_funcs.is_empty() {
-            if let Some(init) = init_index(self)? {
-                self.start_user_funcs.insert(0, StartAction::Call(init));
-            }
+            self.start_user_funcs.insert(
+                0,
+                StartAction::CallHook {
+                    func: task_hook,
+                    hook: TaskHook::InitializeStart,
+                },
+            );
+            self.start_user_funcs.push(StartAction::CallHook {
+                func: task_hook,
+                hook: TaskHook::InitializeFinish,
+            });
         }
 
         // Afterwards handle all exports for the main/adapter modules.
-        self.prepare_export_task_hooks_for(
-            state,
-            CustomModule::Main,
-            &mut init_index,
-            &mut async_init_index,
-        )?;
+        self.prepare_export_task_hooks_for(state, CustomModule::Main, task_hook)?;
         for adapter in state.info.adapters.keys() {
-            self.prepare_export_task_hooks_for(
-                state,
-                CustomModule::Adapter(adapter),
-                &mut init_index,
-                &mut async_init_index,
-            )?;
+            self.prepare_export_task_hooks_for(state, CustomModule::Adapter(adapter), task_hook)?;
         }
 
         // And finally redirect all resource destructors to a local hook which
@@ -625,16 +672,18 @@ impl FixupModule {
                 ShimFill::ImportedResourceDtor(func) => *func,
                 ShimFill::Import(_) | ShimFill::DefinedFunction(_) => continue,
             };
-            let Some(init) = init_index(self)? else {
-                continue;
-            };
             let ty = self.type_intern(vec![ValType::I32], Vec::new());
             *shim = ShimFill::DefinedFunction(self.defined_functions.len());
             self.defined_functions.push((
                 ty,
-                DefinedFunction::HookedResourceDtor {
-                    before: init,
-                    export,
+                DefinedFunction::HookedCoreExport {
+                    task_hook,
+                    to_wrap: export,
+                    params: 1,
+                    start: TaskHook::ResourceDtorStart,
+                    end: EndTaskHook::Normal(TaskHook::ResourceDtorFinish),
+                    export: false,
+                    core_name: format!("resource-dtor"),
                 },
             ));
         }
@@ -652,8 +701,7 @@ impl FixupModule {
         &mut self,
         state: &mut EncodingState<'_>,
         for_module: CustomModule<'_>,
-        init_task: &mut dyn FnMut(&mut Self) -> Result<Option<u32>>,
-        async_init_task: &mut dyn FnMut(&mut Self) -> Result<Option<u32>>,
+        task_hook: u32,
     ) -> Result<()> {
         let resolve = &state.info.encoder.metadata.resolve;
         let world = &resolve.worlds[state.info.encoder.metadata.world];
@@ -664,38 +712,81 @@ impl FixupModule {
         };
 
         for (core_name, export) in info.iter() {
-            let (f, abi) = match export {
+            let (key, f, abi) = match export {
                 Export::WorldFunc(key, _, abi) => match &world.exports[key] {
-                    WorldItem::Function(f) => (f, abi),
+                    WorldItem::Function(f) => (key, f, abi),
                     _ => continue,
                 },
-                Export::InterfaceFunc(_, id, func_name, abi) => {
+                Export::InterfaceFunc(key, id, func_name, abi) => {
                     let func = &resolve.interfaces[*id].functions[func_name.as_str()];
-                    (func, abi)
+                    (key, func, abi)
                 }
                 _ => continue,
             };
 
-            let hook = if abi.is_async() {
-                async_init_task(self)?
-            } else {
-                init_task(self)?
-            };
-            let Some(hook) = hook else {
-                continue;
-            };
             let sig = resolve.wasm_signature(*abi, f);
             let ty = self.type_index(&sig);
             let func = self.import_func(&imported_instance, core_name, ty)?;
             self.defined_functions.push((
                 ty,
                 DefinedFunction::HookedCoreExport {
-                    before: hook,
-                    export: func,
+                    task_hook,
+                    to_wrap: func,
+                    export: true,
                     params: sig.params.len(),
                     core_name: core_name.to_string(),
+                    start: if abi.is_async() {
+                        TaskHook::AsyncStart
+                    } else {
+                        TaskHook::SyncStart
+                    },
+                    end: if abi.is_async() {
+                        if *abi == AbiVariant::GuestExportAsyncStackful {
+                            EndTaskHook::Normal(TaskHook::AsyncFinish)
+                        } else {
+                            EndTaskHook::AsyncCode
+                        }
+                    } else {
+                        EndTaskHook::Normal(TaskHook::SyncFinish)
+                    },
                 },
             ));
+
+            if let Some(post_return) = info.post_return(key, f) {
+                let mut post_return_sig = sig.clone();
+                post_return_sig.params = mem::take(&mut post_return_sig.results);
+                let ty = self.type_index(&post_return_sig);
+                let func = self.import_func(&imported_instance, post_return, ty)?;
+                self.defined_functions.push((
+                    ty,
+                    DefinedFunction::HookedCoreExport {
+                        task_hook,
+                        to_wrap: func,
+                        export: true,
+                        params: post_return_sig.params.len(),
+                        core_name: post_return.to_string(),
+                        start: TaskHook::PostReturnStart,
+                        end: EndTaskHook::Normal(TaskHook::PostReturnFinish),
+                    },
+                ));
+            }
+
+            if let Some(callback) = info.callback(key, f) {
+                let ty = self.type_intern(vec![ValType::I32; 3], vec![ValType::I32]);
+                let func = self.import_func(&imported_instance, callback, ty)?;
+                self.defined_functions.push((
+                    ty,
+                    DefinedFunction::HookedCoreExport {
+                        task_hook,
+                        to_wrap: func,
+                        export: true,
+                        params: 3,
+                        core_name: callback.to_string(),
+                        start: TaskHook::AsyncResume,
+                        end: EndTaskHook::AsyncCode,
+                    },
+                ));
+            }
         }
 
         Ok(())

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -29,6 +29,7 @@ use {
     indexmap::{IndexMap, IndexSet, map::Entry},
     metadata::{Export, ExportKey, FunctionType, GlobalType, Metadata, Type, ValueType},
     std::{
+        borrow::Cow,
         collections::{BTreeMap, HashMap, HashSet},
         fmt::Debug,
         hash::Hash,
@@ -41,7 +42,7 @@ use {
     wasmparser::SymbolFlags,
 };
 
-mod metadata;
+pub(crate) mod metadata;
 
 const PAGE_SIZE_BYTES: u32 = 65536;
 // This matches the default stack size LLVM produces:
@@ -50,16 +51,12 @@ const HEAP_ALIGNMENT_BYTES: u32 = 16;
 const STUB_LIBRARY_NAME: &str = "wit-component:stubs";
 const CABI_REALLOC: &str = "cabi_realloc";
 
-static EMPTY_FUNCTION_TYPE: FunctionType = FunctionType {
-    parameters: Vec::new(),
-    results: Vec::new(),
-};
-
 /// Symbols to re-export from the `env` module regardless of whether any
 /// libraries import them, since
 /// `EncodingState::create_export_task_initialization_wrappers` needs to be able
 /// to call them.
-static ENV_REEXPORTS: &[&str] = &[metadata::INIT_TASK, metadata::INIT_ASYNC_TASK];
+static ENV_REEXPORTS: &[(&str, &[ValueType], &[ValueType])] =
+    &[(metadata::TASK_HOOK, &[ValueType::I32], &[])];
 
 enum Address<'a> {
     Function(u32),
@@ -1236,11 +1233,14 @@ fn resolve_symbols<'a>(
     // `env` module so that
     // `EncodingState::create_export_task_initialization_wrappers` can find
     // and use them:
-    for &name in ENV_REEXPORTS {
+    for (name, params, results) in ENV_REEXPORTS {
         let export = Export {
             key: ExportKey {
                 name,
-                ty: Type::Function(EMPTY_FUNCTION_TYPE.clone()),
+                ty: Type::Function(FunctionType {
+                    parameters: params.to_vec(),
+                    results: results.to_vec(),
+                }),
             },
             flags: SymbolFlags::empty(),
         };
@@ -1371,7 +1371,7 @@ struct EnvExports<'a> {
 
 struct EnvExport<'a> {
     name: &'a str,
-    ty: &'a FunctionType,
+    ty: Cow<'a, FunctionType>,
     exporter: usize,
 }
 
@@ -1421,7 +1421,7 @@ fn env_exports<'a>(
 
                 result.push(EnvExport {
                     name: *name,
-                    ty: *ty,
+                    ty: Cow::Borrowed(*ty),
                     exporter: indexes[exporter],
                 });
                 exported.insert(*name);
@@ -1436,7 +1436,7 @@ fn env_exports<'a>(
                 if !seen.contains(&exporter) {
                     result.push(EnvExport {
                         name: *import_name,
-                        ty,
+                        ty: Cow::Borrowed(ty),
                         exporter,
                     });
                     exported.insert(*import_name);
@@ -1451,15 +1451,19 @@ fn env_exports<'a>(
     // `env` module so that
     // `EncodingState::create_export_task_initialization_wrappers` can find
     // and use them:
-    for &name in ENV_REEXPORTS {
+    for (name, params, results) in ENV_REEXPORTS {
         if !exported.contains(name) {
+            let ty = FunctionType {
+                parameters: params.to_vec(),
+                results: results.to_vec(),
+            };
             if let Some(exporter) = exporters.get(&ExportKey {
                 name,
-                ty: Type::Function(EMPTY_FUNCTION_TYPE.clone()),
+                ty: Type::Function(ty.clone()),
             }) {
                 result.push(EnvExport {
                     name,
-                    ty: &EMPTY_FUNCTION_TYPE,
+                    ty: Cow::Owned(ty),
                     exporter: indexes[exporter.0],
                 });
                 exported.insert(name);

--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -33,8 +33,7 @@ pub const CALL_CTORS: &str = "__wasm_call_ctors";
 pub const INITIALIZE: &str = "_initialize";
 pub const START: &str = "_start";
 pub const LIBDL_LIBRARIES: &str = "__wasm_libdl_libraries";
-pub const INIT_TASK: &str = "__wasm_init_task";
-pub const INIT_ASYNC_TASK: &str = "__wasm_init_async_task";
+pub const TASK_HOOK: &str = "__wasm_task_hook";
 pub const ROOT: &str = "$root";
 pub const THREAD_NEW_INDIRECT: &str = "[thread-new-indirect-v0]";
 pub const CONTEXT_GET_1: &str = "[context-get-1]";
@@ -222,9 +221,6 @@ pub struct Metadata<'a> {
     /// Whether this module imports `__wasm_libdl_libraries`
     pub needs_libdl_libraries: bool,
 
-    /// Whether this module exports `__wasm_init_task`
-    pub has_init_task: bool,
-
     /// Whether this module includes any `component-type*` custom sections which include exports
     pub has_component_exports: bool,
 
@@ -312,7 +308,6 @@ impl<'a> Metadata<'a> {
             has_initialize: false,
             has_wasi_start: false,
             needs_libdl_libraries: false,
-            has_init_task: false,
             has_component_exports,
             is_asyncified: false,
             needs_stack_pointer: false,
@@ -608,9 +603,6 @@ impl<'a> Metadata<'a> {
                             self::START => result.has_wasi_start = true,
                             self::LIBRARY_TLS_INFO => result.has_library_tls_info = true,
                             _ => {
-                                if export.name == self::INIT_TASK {
-                                    result.has_init_task = true;
-                                }
                                 let ty = match export.kind {
                                     ExternalKind::Func => Type::Function(FunctionType::try_from(
                                         &types[function_types

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -1164,11 +1164,8 @@ pub enum Export {
     /// __indirect_function_table, used for `thread.new-indirect`
     IndirectFunctionTable,
 
-    /// __wasm_init_task, used for initializing export tasks
-    WasmInitTask,
-
-    /// __wasm_init_async_task, used for initializing export tasks for async-lifted exports
-    WasmInitAsyncTask,
+    /// Used to hook lifecycle events for tasks.
+    WasmTaskHook,
 }
 
 impl ExportMap {
@@ -1267,14 +1264,10 @@ impl ExportMap {
             let expected = FuncType::new([], []);
             validate_func_sig(name, &expected, ty)?;
             return Ok(Some(Export::Initialize));
-        } else if Some(name) == names.export_wasm_init_task() {
-            let expected = FuncType::new([], []);
+        } else if Some(name) == names.export_wasm_task_hook() {
+            let expected = FuncType::new([ValType::I32], []);
             validate_func_sig(name, &expected, ty)?;
-            return Ok(Some(Export::WasmInitTask));
-        } else if Some(name) == names.export_wasm_init_async_task() {
-            let expected = FuncType::new([], []);
-            validate_func_sig(name, &expected, ty)?;
-            return Ok(Some(Export::WasmInitAsyncTask));
+            return Ok(Some(Export::WasmTaskHook));
         }
 
         let full_name = name;
@@ -1438,14 +1431,9 @@ impl ExportMap {
         self.find(|t| matches!(t, Export::IndirectFunctionTable))
     }
 
-    /// Returns the `__wasm_init_task` function, if exported, for this module.
-    pub fn wasm_init_task(&self) -> Option<&str> {
-        self.find(|t| matches!(t, Export::WasmInitTask))
-    }
-
-    /// Returns the `__wasm_init_async_task` function, if exported, for this module.
-    pub fn wasm_init_async_task(&self) -> Option<&str> {
-        self.find(|t| matches!(t, Export::WasmInitAsyncTask))
+    /// Returns the hook for tasks, if exported.
+    pub fn wasm_task_hook(&self) -> Option<&str> {
+        self.find(|t| matches!(t, Export::WasmTaskHook))
     }
 
     /// Returns the `_initialize` intrinsic, if exported, for this module.
@@ -1605,8 +1593,7 @@ trait NameMangling {
     fn export_initialize(&self) -> &str;
     fn export_realloc(&self) -> &str;
     fn export_indirect_function_table(&self) -> Option<&str>;
-    fn export_wasm_init_task(&self) -> Option<&str>;
-    fn export_wasm_init_async_task(&self) -> Option<&str>;
+    fn export_wasm_task_hook(&self) -> Option<&str>;
     fn resource_drop_name<'a>(&self, name: &'a str) -> Option<&'a str>;
     fn resource_new_name<'a>(&self, name: &'a str) -> Option<&'a str>;
     fn resource_rep_name<'a>(&self, name: &'a str) -> Option<&'a str>;
@@ -1754,10 +1741,7 @@ impl NameMangling for Standard {
     fn export_indirect_function_table(&self) -> Option<&str> {
         None
     }
-    fn export_wasm_init_task(&self) -> Option<&str> {
-        None
-    }
-    fn export_wasm_init_async_task(&self) -> Option<&str> {
+    fn export_wasm_task_hook(&self) -> Option<&str> {
         None
     }
     fn resource_drop_name<'a>(&self, name: &'a str) -> Option<&'a str> {
@@ -2226,11 +2210,8 @@ impl NameMangling for Legacy {
     fn export_indirect_function_table(&self) -> Option<&str> {
         Some("__indirect_function_table")
     }
-    fn export_wasm_init_task(&self) -> Option<&str> {
-        Some("__wasm_init_task")
-    }
-    fn export_wasm_init_async_task(&self) -> Option<&str> {
-        Some("__wasm_init_async_task")
+    fn export_wasm_task_hook(&self) -> Option<&str> {
+        Some(crate::linking::metadata::TASK_HOOK)
     }
     fn resource_drop_name<'a>(&self, name: &'a str) -> Option<&'a str> {
         name.strip_prefix("[resource-drop]")

--- a/crates/wit-component/tests/components/link-wasip3-abi/component.wat
+++ b/crates/wit-component/tests/components/link-wasip3-abi/component.wat
@@ -7,9 +7,8 @@
   )
   (import "test:test/test" (instance $test:test/test (;0;) (type $ty-test:test/test)))
   (core module $main (;0;)
-    (type (;0;) (func))
-    (type (;1;) (func))
-    (table (;0;) 3 funcref)
+    (type (;0;) (func (param i32)))
+    (table (;0;) 2 funcref)
     (memory (;0;) 17)
     (global (;0;) i32 i32.const 1048592)
     (global (;1;) i32 i32.const 1)
@@ -31,17 +30,13 @@
     (export "foo:um" (global 7))
     (export "__heap_base" (global 8))
     (export "__heap_end" (global 9))
-    (export "__wasm_init_task" (func 0))
-    (export "__wasm_init_async_task" (func 1))
+    (export "__wasm_task_hook" (func 0))
     (export "__indirect_function_table" (table 0))
     (export "memory" (memory 0))
-    (func (;0;) (type 0)
+    (func (;0;) (type 0) (param i32)
+      local.get 0
       i32.const 1
       call_indirect (type 0)
-    )
-    (func (;1;) (type 1)
-      i32.const 2
-      call_indirect (type 1)
     )
     (@producers
       (processed-by "wit-component" "$CARGO_PKG_VERSION")
@@ -58,10 +53,9 @@
     (import "GOT.mem" "__heap_base" (global $__heap_base (;0;) (mut i32)))
     (import "GOT.mem" "__heap_end" (global $__heap_end (;1;) (mut i32)))
     (global $heap (;2;) (mut i32) i32.const 0)
+    (export "__wasm_task_hook" (func 5))
     (export "malloc" (func $malloc))
     (export "abort" (func $abort))
-    (export "__wasm_init_task" (func $init_task))
-    (export "__wasm_init_async_task" (func $init_task))
     (export "__wasm_get_stack_pointer" (func $get_stack_pointer))
     (export "__wasm_set_stack_pointer" (func $set_stack_pointer))
     (start $start)
@@ -79,13 +73,13 @@
     (func $abort (;2;) (type 0)
       unreachable
     )
-    (func $init_task (;3;) (type 0)
+    (func $get_stack_pointer (;3;) (type 2) (result i32)
       unreachable
     )
-    (func $get_stack_pointer (;4;) (type 2) (result i32)
+    (func $set_stack_pointer (;4;) (type 3) (param i32)
       unreachable
     )
-    (func $set_stack_pointer (;5;) (type 3) (param i32)
+    (func (;5;) (type 3) (param i32)
       unreachable
     )
   )
@@ -236,7 +230,8 @@
   )
   (core module $wit-component-fixup (;4;)
     (type (;0;) (func))
-    (type (;1;) (func (param i32) (result i32)))
+    (type (;1;) (func (param i32)))
+    (type (;2;) (func (param i32) (result i32)))
     (import "main" "memory" (memory (;0;) 0))
     (import "main" "__indirect_function_table" (table (;0;) 0 funcref))
     (import "main" "foo:memory_base" (global $foo:memory_base (;0;) i32))
@@ -249,20 +244,22 @@
     (import "foo" "__wasm_apply_data_relocs" (func $"#func1 __wasm_apply_data_relocs" (@name "__wasm_apply_data_relocs") (;1;) (type 0)))
     (import "bar" "__wasm_call_ctors" (func $__wasm_call_ctors (;2;) (type 0)))
     (import "foo" "__wasm_call_ctors" (func $"#func3 __wasm_call_ctors" (@name "__wasm_call_ctors") (;3;) (type 0)))
-    (import "c" "__wasm_init_task" (func $__wasm_init_task (;4;) (type 0)))
-    (import "c" "__wasm_init_async_task" (func $__wasm_init_async_task (;5;) (type 0)))
-    (import "main" "__wasm_init_task" (func $"#func6 __wasm_init_task" (@name "__wasm_init_task") (;6;) (type 0)))
-    (import "bar" "test:test/test#bar" (func $test:test/test#bar (;7;) (type 1)))
+    (import "c" "__wasm_task_hook" (func $__wasm_task_hook (;4;) (type 1)))
+    (import "main" "__wasm_task_hook" (func $"#func5 __wasm_task_hook" (@name "__wasm_task_hook") (;5;) (type 1)))
+    (import "bar" "test:test/test#bar" (func $test:test/test#bar (;6;) (type 2)))
     (export "hook0" (func $hook-test:test/test#bar))
     (start $start)
     (elem (;0;) (i32.const 1) func)
-    (elem (;1;) (i32.const 1) func $__wasm_init_task $__wasm_init_async_task)
-    (func $hook-test:test/test#bar (;8;) (type 1) (param i32) (result i32)
-      call $"#func6 __wasm_init_task"
+    (elem (;1;) (i32.const 1) func $__wasm_task_hook)
+    (func $hook-test:test/test#bar (;7;) (type 2) (param i32) (result i32)
+      i32.const 0
+      call $"#func5 __wasm_task_hook"
       local.get 0
       call $test:test/test#bar
+      i32.const 1
+      call $"#func5 __wasm_task_hook"
     )
-    (func $start (;9;) (type 0)
+    (func $start (;8;) (type 0)
       global.get $foo:memory_base
       global.get $well
       i32.add
@@ -273,9 +270,12 @@
       global.set $foo:um
       call $__wasm_apply_data_relocs
       call $"#func1 __wasm_apply_data_relocs"
-      call $"#func6 __wasm_init_task"
+      i32.const 6
+      call $"#func5 __wasm_task_hook"
       call $__wasm_call_ctors
       call $"#func3 __wasm_call_ctors"
+      i32.const 7
+      call $"#func5 __wasm_task_hook"
     )
     (data (;0;) (i32.const 1048576) "\00\00\00\00\00\00\10\00")
     (@producers

--- a/crates/wit-component/tests/components/link-wasip3-abi/lib-c.wat
+++ b/crates/wit-component/tests/components/link-wasip3-abi/lib-c.wat
@@ -21,19 +21,15 @@
   (func $abort (type 0)
     unreachable
   )
-  (func $init_task (type 0)
-    unreachable
-  )
   (func $get_stack_pointer (result i32)
     unreachable
   )
   (func $set_stack_pointer (param i32)
     unreachable
   )
+  (func (export "__wasm_task_hook") (param i32) unreachable)
   (export "malloc" (func $malloc))
   (export "abort" (func $abort))
-  (export "__wasm_init_task" (func $init_task))
-  (export "__wasm_init_async_task" (func $init_task))
   (export "__wasm_get_stack_pointer" (func $get_stack_pointer))
   (export "__wasm_set_stack_pointer" (func $set_stack_pointer))
   (start $start)

--- a/crates/wit-component/tests/components/wasm-init-task/component.wat
+++ b/crates/wit-component/tests/components/wasm-init-task/component.wat
@@ -1,19 +1,19 @@
 (component
   (core module $main (;0;)
-    (type (;0;) (func))
-    (type (;1;) (func (result i32)))
-    (type (;2;) (func (param i32 i32 i32) (result i32)))
-    (type (;3;) (func (param i32 i32)))
-    (type (;4;) (func (param i32 i32) (result i32)))
-    (type (;5;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;6;) (func (param i32)))
+    (type (;0;) (func (param i32)))
+    (type (;1;) (func))
+    (type (;2;) (func (result i32)))
+    (type (;3;) (func (param i32 i32 i32) (result i32)))
+    (type (;4;) (func (param i32 i32)))
+    (type (;5;) (func (param i32 i32) (result i32)))
+    (type (;6;) (func (param i32 i32 i32 i32) (result i32)))
     (memory (;0;) 1)
-    (export "__wasm_init_task" (func 0))
-    (export "__wasm_init_async_task" (func 1))
-    (export "[async-lift-stackful]async-stackful" (func 2))
-    (export "[async-lift]async-callback" (func 3))
-    (export "[callback][async-lift]async-callback" (func 4))
-    (export "sync" (func 5))
+    (export "__wasm_task_hook" (func 0))
+    (export "[async-lift-stackful]async-stackful" (func 1))
+    (export "[async-lift]async-callback" (func 2))
+    (export "[callback][async-lift]async-callback" (func 3))
+    (export "sync" (func 4))
+    (export "cabi_post_sync" (func 5))
     (export "_initialize" (func 6))
     (export "[async-lift-stackful]async-stackful-argret" (func 7))
     (export "[async-lift]async-callback-argret" (func 8))
@@ -23,44 +23,44 @@
     (export "cabi_realloc" (func 11))
     (export "x#sync" (func 12))
     (export "x#[dtor]r" (func 13))
-    (func (;0;) (type 0)
+    (func (;0;) (type 0) (param i32)
       unreachable
     )
-    (func (;1;) (type 0)
+    (func (;1;) (type 1)
       unreachable
     )
-    (func (;2;) (type 0)
+    (func (;2;) (type 2) (result i32)
       unreachable
     )
-    (func (;3;) (type 1) (result i32)
+    (func (;3;) (type 3) (param i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;4;) (type 2) (param i32 i32 i32) (result i32)
+    (func (;4;) (type 1)
       unreachable
     )
-    (func (;5;) (type 0)
+    (func (;5;) (type 1)
       unreachable
     )
-    (func (;6;) (type 0))
-    (func (;7;) (type 3) (param i32 i32)
+    (func (;6;) (type 1))
+    (func (;7;) (type 4) (param i32 i32)
       unreachable
     )
-    (func (;8;) (type 4) (param i32 i32) (result i32)
+    (func (;8;) (type 5) (param i32 i32) (result i32)
       unreachable
     )
-    (func (;9;) (type 2) (param i32 i32 i32) (result i32)
+    (func (;9;) (type 3) (param i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;10;) (type 4) (param i32 i32) (result i32)
+    (func (;10;) (type 5) (param i32 i32) (result i32)
       unreachable
     )
-    (func (;11;) (type 5) (param i32 i32 i32 i32) (result i32)
+    (func (;11;) (type 6) (param i32 i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;12;) (type 0)
+    (func (;12;) (type 1)
       unreachable
     )
-    (func (;13;) (type 6) (param i32)
+    (func (;13;) (type 0) (param i32)
       unreachable
     )
     (@producers
@@ -91,71 +91,155 @@
     (type (;0;) (func (param i32)))
     (type (;1;) (func))
     (type (;2;) (func (result i32)))
-    (type (;3;) (func (param i32 i32)))
-    (type (;4;) (func (param i32 i32) (result i32)))
+    (type (;3;) (func (param i32 i32 i32) (result i32)))
+    (type (;4;) (func (param i32 i32)))
+    (type (;5;) (func (param i32 i32) (result i32)))
     (import "actual" "0" (func $0 (;0;) (type 0)))
     (import "main" "_initialize" (func $_initialize (;1;) (type 1)))
-    (import "main" "__wasm_init_task" (func $__wasm_init_task (;2;) (type 1)))
-    (import "main" "__wasm_init_async_task" (func $__wasm_init_async_task (;3;) (type 1)))
-    (import "main" "[async-lift-stackful]async-stackful" (func $"[async-lift-stackful]async-stackful" (;4;) (type 1)))
-    (import "main" "[async-lift]async-callback" (func $"[async-lift]async-callback" (;5;) (type 2)))
+    (import "main" "__wasm_task_hook" (func $__wasm_task_hook (;2;) (type 0)))
+    (import "main" "[async-lift-stackful]async-stackful" (func $"[async-lift-stackful]async-stackful" (;3;) (type 1)))
+    (import "main" "[async-lift]async-callback" (func $"[async-lift]async-callback" (;4;) (type 2)))
+    (import "main" "[callback][async-lift]async-callback" (func $"[callback][async-lift]async-callback" (;5;) (type 3)))
     (import "main" "sync" (func $sync (;6;) (type 1)))
-    (import "main" "[async-lift-stackful]async-stackful-argret" (func $"[async-lift-stackful]async-stackful-argret" (;7;) (type 3)))
-    (import "main" "[async-lift]async-callback-argret" (func $"[async-lift]async-callback-argret" (;8;) (type 4)))
-    (import "main" "sync-argret" (func $sync-argret (;9;) (type 4)))
-    (import "main" "x#sync" (func $x#sync (;10;) (type 1)))
+    (import "main" "cabi_post_sync" (func $cabi_post_sync (;7;) (type 1)))
+    (import "main" "[async-lift-stackful]async-stackful-argret" (func $"[async-lift-stackful]async-stackful-argret" (;8;) (type 4)))
+    (import "main" "[async-lift]async-callback-argret" (func $"[async-lift]async-callback-argret" (;9;) (type 5)))
+    (import "main" "[callback][async-lift]async-callback-argret" (func $"[callback][async-lift]async-callback-argret" (;10;) (type 3)))
+    (import "main" "sync-argret" (func $sync-argret (;11;) (type 5)))
+    (import "main" "x#sync" (func $x#sync (;12;) (type 1)))
     (import "shim" "$imports" (table (;0;) 1 1 funcref))
     (export "hook0" (func $"hook-[async-lift-stackful]async-stackful"))
     (export "hook1" (func $"hook-[async-lift]async-callback"))
-    (export "hook2" (func $hook-sync))
-    (export "hook3" (func $"hook-[async-lift-stackful]async-stackful-argret"))
-    (export "hook4" (func $"hook-[async-lift]async-callback-argret"))
-    (export "hook5" (func $hook-sync-argret))
-    (export "hook6" (func $hook-x#sync))
+    (export "hook2" (func $"hook-[callback][async-lift]async-callback"))
+    (export "hook3" (func $hook-sync))
+    (export "hook4" (func $hook-cabi_post_sync))
+    (export "hook5" (func $"hook-[async-lift-stackful]async-stackful-argret"))
+    (export "hook6" (func $"hook-[async-lift]async-callback-argret"))
+    (export "hook7" (func $"hook-[callback][async-lift]async-callback-argret"))
+    (export "hook8" (func $hook-sync-argret))
+    (export "hook9" (func $hook-x#sync))
     (start $start)
-    (elem (;0;) (i32.const 0) func 18)
-    (func $"hook-[async-lift-stackful]async-stackful" (;11;) (type 1)
-      call $__wasm_init_async_task
+    (elem (;0;) (i32.const 0) func $hook-resource-dtor)
+    (func $"hook-[async-lift-stackful]async-stackful" (;13;) (type 1)
+      i32.const 2
+      call $__wasm_task_hook
       call $"[async-lift-stackful]async-stackful"
+      i32.const 5
+      call $__wasm_task_hook
     )
-    (func $"hook-[async-lift]async-callback" (;12;) (type 2) (result i32)
-      call $__wasm_init_async_task
+    (func $"hook-[async-lift]async-callback" (;14;) (type 2) (result i32)
+      (local i32)
+      i32.const 2
+      call $__wasm_task_hook
       call $"[async-lift]async-callback"
+      local.set 0
+      i32.const 4
+      i32.const 5
+      local.get 0
+      select
+      call $__wasm_task_hook
+      local.get 0
     )
-    (func $hook-sync (;13;) (type 1)
-      call $__wasm_init_task
+    (func $"hook-[callback][async-lift]async-callback" (;15;) (type 3) (param i32 i32 i32) (result i32)
+      (local i32)
+      i32.const 3
+      call $__wasm_task_hook
+      local.get 0
+      local.get 1
+      local.get 2
+      call $"[callback][async-lift]async-callback"
+      local.set 3
+      i32.const 4
+      i32.const 5
+      local.get 3
+      select
+      call $__wasm_task_hook
+      local.get 3
+    )
+    (func $hook-sync (;16;) (type 1)
+      i32.const 0
+      call $__wasm_task_hook
       call $sync
+      i32.const 1
+      call $__wasm_task_hook
     )
-    (func $"hook-[async-lift-stackful]async-stackful-argret" (;14;) (type 3) (param i32 i32)
-      call $__wasm_init_async_task
+    (func $hook-cabi_post_sync (;17;) (type 1)
+      i32.const 10
+      call $__wasm_task_hook
+      call $cabi_post_sync
+      i32.const 11
+      call $__wasm_task_hook
+    )
+    (func $"hook-[async-lift-stackful]async-stackful-argret" (;18;) (type 4) (param i32 i32)
+      i32.const 2
+      call $__wasm_task_hook
       local.get 0
       local.get 1
       call $"[async-lift-stackful]async-stackful-argret"
+      i32.const 5
+      call $__wasm_task_hook
     )
-    (func $"hook-[async-lift]async-callback-argret" (;15;) (type 4) (param i32 i32) (result i32)
-      call $__wasm_init_async_task
+    (func $"hook-[async-lift]async-callback-argret" (;19;) (type 5) (param i32 i32) (result i32)
+      (local i32)
+      i32.const 2
+      call $__wasm_task_hook
       local.get 0
       local.get 1
       call $"[async-lift]async-callback-argret"
+      local.set 2
+      i32.const 4
+      i32.const 5
+      local.get 2
+      select
+      call $__wasm_task_hook
+      local.get 2
     )
-    (func $hook-sync-argret (;16;) (type 4) (param i32 i32) (result i32)
-      call $__wasm_init_task
+    (func $"hook-[callback][async-lift]async-callback-argret" (;20;) (type 3) (param i32 i32 i32) (result i32)
+      (local i32)
+      i32.const 3
+      call $__wasm_task_hook
+      local.get 0
+      local.get 1
+      local.get 2
+      call $"[callback][async-lift]async-callback-argret"
+      local.set 3
+      i32.const 4
+      i32.const 5
+      local.get 3
+      select
+      call $__wasm_task_hook
+      local.get 3
+    )
+    (func $hook-sync-argret (;21;) (type 5) (param i32 i32) (result i32)
+      i32.const 0
+      call $__wasm_task_hook
       local.get 0
       local.get 1
       call $sync-argret
+      i32.const 1
+      call $__wasm_task_hook
     )
-    (func $hook-x#sync (;17;) (type 1)
-      call $__wasm_init_task
+    (func $hook-x#sync (;22;) (type 1)
+      i32.const 0
+      call $__wasm_task_hook
       call $x#sync
+      i32.const 1
+      call $__wasm_task_hook
     )
-    (func (;18;) (type 0) (param i32)
-      call $__wasm_init_task
+    (func $hook-resource-dtor (;23;) (type 0) (param i32)
+      i32.const 8
+      call $__wasm_task_hook
       local.get 0
       call $0
+      i32.const 9
+      call $__wasm_task_hook
     )
-    (func $start (;19;) (type 1)
-      call $__wasm_init_task
+    (func $start (;24;) (type 1)
+      i32.const 6
+      call $__wasm_task_hook
       call $_initialize
+      i32.const 7
+      call $__wasm_task_hook
     )
     (@producers
       (processed-by "wit-component" "$CARGO_PKG_VERSION")
@@ -178,26 +262,27 @@
   (alias core export $fixup "hook4" (core func $hook4 (;6;)))
   (alias core export $fixup "hook5" (core func $hook5 (;7;)))
   (alias core export $fixup "hook6" (core func $hook6 (;8;)))
+  (alias core export $fixup "hook7" (core func $hook7 (;9;)))
+  (alias core export $fixup "hook8" (core func $hook8 (;10;)))
+  (alias core export $fixup "hook9" (core func $hook9 (;11;)))
   (type (;1;) (func async))
-  (alias core export $main "cabi_realloc" (core func $cabi_realloc (;9;)))
+  (alias core export $main "cabi_realloc" (core func $cabi_realloc (;12;)))
   (func $async-stackful (;0;) (type 1) (canon lift (core func $hook0) async))
   (export $"#func1 async-stackful" (@name "async-stackful") (;1;) "async-stackful" (func $async-stackful))
-  (alias core export $main "[callback][async-lift]async-callback" (core func $"[callback][async-lift]async-callback" (;10;)))
-  (func $async-callback (;2;) (type 1) (canon lift (core func $hook1) async (callback $"[callback][async-lift]async-callback")))
+  (func $async-callback (;2;) (type 1) (canon lift (core func $hook1) async (callback $hook2)))
   (export $"#func3 async-callback" (@name "async-callback") (;3;) "async-callback" (func $async-callback))
   (type (;2;) (func))
-  (func $sync (;4;) (type 2) (canon lift (core func $hook2)))
+  (func $sync (;4;) (type 2) (canon lift (core func $hook3) (post-return $hook4)))
   (export $"#func5 sync" (@name "sync") (;5;) "sync" (func $sync))
   (type (;3;) (func async (param "s" string) (result string)))
-  (func $async-stackful-argret (;6;) (type 3) (canon lift (core func $hook3) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8 async))
+  (func $async-stackful-argret (;6;) (type 3) (canon lift (core func $hook5) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8 async))
   (export $"#func7 async-stackful-argret" (@name "async-stackful-argret") (;7;) "async-stackful-argret" (func $async-stackful-argret))
-  (alias core export $main "[callback][async-lift]async-callback-argret" (core func $"[callback][async-lift]async-callback-argret" (;11;)))
-  (func $async-callback-argret (;8;) (type 3) (canon lift (core func $hook4) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8 async (callback $"[callback][async-lift]async-callback-argret")))
+  (func $async-callback-argret (;8;) (type 3) (canon lift (core func $hook6) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8 async (callback $hook7)))
   (export $"#func9 async-callback-argret" (@name "async-callback-argret") (;9;) "async-callback-argret" (func $async-callback-argret))
   (type (;4;) (func (param "s" string) (result string)))
-  (func $sync-argret (;10;) (type 4) (canon lift (core func $hook5) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8))
+  (func $sync-argret (;10;) (type 4) (canon lift (core func $hook8) (memory $memory) (realloc $cabi_realloc) string-encoding=utf8))
   (export $"#func11 sync-argret" (@name "sync-argret") (;11;) "sync-argret" (func $sync-argret))
-  (func $"#func12 sync" (@name "sync") (;12;) (type 2) (canon lift (core func $hook6)))
+  (func $"#func12 sync" (@name "sync") (;12;) (type 2) (canon lift (core func $hook9)))
   (component $x-shim-component (;0;)
     (import "import-type-r" (type (;0;) (sub resource)))
     (type (;1;) (func))

--- a/crates/wit-component/tests/components/wasm-init-task/module.wat
+++ b/crates/wit-component/tests/components/wasm-init-task/module.wat
@@ -1,10 +1,10 @@
 (module
-  (func (export "__wasm_init_task") unreachable)
-  (func (export "__wasm_init_async_task") unreachable)
+  (func (export "__wasm_task_hook") (param i32) unreachable)
   (func (export "[async-lift-stackful]async-stackful") unreachable)
   (func (export "[async-lift]async-callback") (result i32) unreachable)
   (func (export "[callback][async-lift]async-callback") (param i32 i32 i32) (result i32) unreachable)
   (func (export "sync") unreachable)
+  (func (export "cabi_post_sync") unreachable)
   (func (export "_initialize"))
   (func (export "[async-lift-stackful]async-stackful-argret") (param i32 i32) unreachable)
   (func (export "[async-lift]async-callback-argret") (param i32 i32) (result i32) unreachable)


### PR DESCRIPTION
This commit refactors `wit-component`'s handling of `__wasm_init_task` and `__wasm_init_async_task` into a "task hook" and adds it to more locations. The purpose of this refactor is to enable correct stack management in wasi-libc in the wasip3 ABI where stacks may need to be dynamically allocated in some situations. For this use case the previous init hooks were not sufficient because they didn't run in all contexts (such as post-return) nor did they hook completion of a task to deallocate a stack.

The new `__wasm_task_hook` function is still invoked in the same place as the previous initialization hooks, but it's additionally invoked at the end of a task and in more places. This intrinsic takes a single `i32` parameter which is where the hook is being invoked. The locations are:

* 0 - at the start of a synchronously lifted function.
* 1 - at the end of a synchronously lifted function (before post-return if that's specified).
* 2 - at the start of an async-lifted function, either stackful or not.
* 3 - at the start of an async-lifted's `callback` option.
* 4 - when an async-lifted entrypoint returns, or a `callback` option returns, and the task is blocking or yielding.
* 5 - when an async-lifted function completes.
* 6 - when `_initialize` is originally invoked.
* 7 - when `_initialize` completes.
* 8 - when a resource destructor is invoked.
* 9 - when a resource destructor completes.
* 10 - when a post-return hook is invoked.
* 11 - when a post-return hook completes.

The goal of this change is to enable wasi-libc to correctly manage stacks in a WASIp3 world. This isn't necessary in a WASIp2 world with a `global` stack pointer because everything "falls out" of the stack pointer being in the main module, threads not existing, and the component model's reentrancy/blocking rules enable safe usage of the global. For WASIp3, however, a `global` stack pointer cannot be used due to threads, and so `context.{get,set}` slots are used instead, and these are fresh for all tasks and need initialization. The above hooks enable wasi-libc to primarily use the "main stack" where possible, but there are scenarios where that isn't possible such as for `cabi_realloc` and for sync-reentrant tasks.

The majority of this implementation is in the `fixup` module and this has additionally been tested against a local copy of wasi-libc. I've written previously-failing tests in wasi-libc which expose where stack management today is insufficient, and with this change, and an updated wasi-libc with this new intrinsic, all the tests now pass.

One final change I plan to do after this is to additionally add hooks for the `cabi_realloc` function. Right now that's required to do its own stack management, but it would be more consistent if it were folded into the same infrastructure for hooks. That'll be a bit of a broader change, though, so it's deferred to a future commit.