### PR TITLE
Expand wit-component's heuristic for context slot 1

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1178,7 +1178,7 @@ impl<'a> EncodingState<'a> {
 
         // Determine if a TLS global needs to be synthesized here by seeing if
         // it was imported into any module.
-        let tls_base_global_type = if self.info.uses_cooperative_threading() {
+        let tls_base_global_type = if self.info.can_use_context_slot_1() {
             None
         } else {
             let infos = [&self.info.info]
@@ -2200,7 +2200,7 @@ impl<'a> EncodingState<'a> {
     ///
     /// For more information on this see WebAssembly/wasi-libc#857
     fn materialize_tls_base_import(&mut self, set: bool, ty: ValType) -> u32 {
-        if self.info.uses_cooperative_threading() {
+        if self.info.can_use_context_slot_1() {
             if set {
                 self.component.context_set(ty, 1)
             } else {

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -92,17 +92,20 @@ impl<'a> ComponentWorld<'a> {
         Ok(ret)
     }
 
-    /// Returns whether any module in this component may spawn a thread, and
-    /// thus whether the program is using cooperative threading.
+    /// Returns whether the component encoding process should use context slot 1
+    /// in tasks, generally reserved for TLS.
     ///
     /// This is a heuristic which should go away once component-model-threading
     /// has been stable for awhile and the return value of this function should
     /// be const-propagated as `true`.
-    pub fn uses_cooperative_threading(&self) -> bool {
+    pub fn can_use_context_slot_1(&self) -> bool {
         let uses = |info: &ValidatedModule| {
-            info.imports
-                .imports()
-                .any(|(_, _, import)| matches!(import, Import::ThreadNewIndirect))
+            info.imports.imports().any(|(_, _, import)| match import {
+                Import::ThreadNewIndirect
+                | Import::ContextGet { slot: 1, .. }
+                | Import::ContextSet { slot: 1, .. } => true,
+                _ => false,
+            })
         };
         uses(&self.info) || self.adapters.values().any(|a| uses(&a.info))
     }


### PR DESCRIPTION
In addition to spawning a thread test to see whether context slot 1 is explicitly used anywhere, and if so go ahead and continue to use that.