### PR TITLE
fix: remap type indices of `{stream,future}.cancel-{read,write}`

### DIFF
--- a/crates/wasm-encoder/src/reencode/component.rs
+++ b/crates/wasm-encoder/src/reencode/component.rs
@@ -1031,10 +1031,10 @@ pub mod component_utils {
                 section.stream_write(reencoder.component_type_index(ty), options);
             }
             wasmparser::CanonicalFunction::StreamCancelRead { ty, async_ } => {
-                section.stream_cancel_read(ty, async_);
+                section.stream_cancel_read(reencoder.component_type_index(ty), async_);
             }
             wasmparser::CanonicalFunction::StreamCancelWrite { ty, async_ } => {
-                section.stream_cancel_write(ty, async_);
+                section.stream_cancel_write(reencoder.component_type_index(ty), async_);
             }
             wasmparser::CanonicalFunction::StreamDropReadable { ty } => {
                 section.stream_drop_readable(reencoder.component_type_index(ty));
@@ -1060,10 +1060,10 @@ pub mod component_utils {
                 section.future_write(reencoder.component_type_index(ty), options);
             }
             wasmparser::CanonicalFunction::FutureCancelRead { ty, async_ } => {
-                section.future_cancel_read(ty, async_);
+                section.future_cancel_read(reencoder.component_type_index(ty), async_);
             }
             wasmparser::CanonicalFunction::FutureCancelWrite { ty, async_ } => {
-                section.future_cancel_write(ty, async_);
+                section.future_cancel_write(reencoder.component_type_index(ty), async_);
             }
             wasmparser::CanonicalFunction::FutureDropReadable { ty } => {
                 section.future_drop_readable(reencoder.component_type_index(ty));


### PR DESCRIPTION
The `ty` operand of the four `{stream,future}.cancel-{read,write}` intrinsics was passed straight from `wasmparser` to `wasm-encoder` in `parse_component_canonical`, bypassing the `component_type_index` remap hook that every other type-carrying canonical function goes through.