### PR TITLE
Add wasip3 compat to `wit-dylib`

### DIFF
--- a/crates/wit-dylib/src/bindgen.rs
+++ b/crates/wit-dylib/src/bindgen.rs
@@ -1,5 +1,5 @@
-use crate::Adapter;
 use crate::metadata;
+use crate::{Adapter, ImportedStackPointer};
 use std::collections::HashMap;
 use std::slice;
 use wasm_encoder::{BlockType, Function, InstructionSink, MemArg, ValType};
@@ -331,12 +331,11 @@ pub fn export(
         // into the stack-local memory. This also stores the dynamic number of lists
         // to deallocate if that was generated during this function.
 
-        let sp = c.adapter.stack_pointer();
-        c.ins().global_get(sp);
+        c.get_sp();
         c.ins().i32_const(8);
         c.ins().i32_sub();
         let l_scratch = c.local_tee_new_tmp(ValType::I32);
-        c.ins().global_set(sp);
+        c.set_sp();
 
         let l_ctx = c.ctx.take().unwrap();
         c.ins().local_get(l_scratch.idx);
@@ -366,9 +365,8 @@ pub fn post_return(
     let sig = resolve.wasm_signature(abi, func);
     let mut c = FunctionCompiler::new(adapter, resolve, sig.results.len() as u32);
     let frame = c.stack_frame(func, &sig, abi);
-    let sp = c.adapter.stack_pointer();
 
-    c.ins().global_get(sp);
+    c.get_sp();
     let l_sp = c.local_set_new_tmp(ValType::I32);
 
     // Load the `ctx` pointer for the export allocated during the originally
@@ -387,7 +385,7 @@ pub fn post_return(
     c.free_temp_local(l_sp);
     c.ins().i32_const(8);
     c.ins().i32_add();
-    c.ins().global_set(sp);
+    c.set_sp();
 
     // Tell the interpreter that the export has now finished.
     let export_finish = c.adapter.intrinsics().export_finish;
@@ -400,7 +398,7 @@ pub fn post_return(
 
     // And finally deallocate the stack frame, if present.
     if frame.size > 0 {
-        c.ins().global_get(sp);
+        c.get_sp();
         c.fp = Some(c.local_set_new_tmp(ValType::I32));
         c.deallocate_stack_frame(&frame);
     }
@@ -603,11 +601,10 @@ impl<'a> FunctionCompiler<'a> {
         }
         let fp = self.fp.take().unwrap();
         self.stack_temp_offset = None;
-        let sp = self.adapter.stack_pointer();
         self.ins().local_get(fp.idx);
         self.ins().i32_const(frame.size as i32);
         self.ins().i32_add();
-        self.ins().global_set(sp);
+        self.set_sp();
         self.free_temp_local(fp);
     }
 
@@ -699,13 +696,12 @@ impl<'a> FunctionCompiler<'a> {
         }
         // CABI for wasm is 16-byte alignment for stack at all times.
         assert!(frame.size % 16 == 0);
-        let sp = self.adapter.stack_pointer();
-        self.ins().global_get(sp);
+        self.get_sp();
         self.ins().i32_const(frame.size as i32);
         self.ins().i32_sub();
         self.fp = Some(self.local_tee_new_tmp(ValType::I32));
         self.stack_temp_offset = frame.stack_temp_offset;
-        self.ins().global_set(sp);
+        self.set_sp();
     }
 
     fn lower_import_params(
@@ -1957,6 +1953,28 @@ impl<'a> FunctionCompiler<'a> {
             self.ins().call(dealloc_bytes);
         }
         self.ins().end();
+    }
+
+    fn get_sp(&mut self) {
+        match self.adapter.stack_pointer.unwrap() {
+            ImportedStackPointer::Global(g) => {
+                self.ins().global_get(g);
+            }
+            ImportedStackPointer::TaskContext { get, .. } => {
+                self.ins().call(get);
+            }
+        }
+    }
+
+    fn set_sp(&mut self) {
+        match self.adapter.stack_pointer.unwrap() {
+            ImportedStackPointer::Global(g) => {
+                self.ins().global_set(g);
+            }
+            ImportedStackPointer::TaskContext { set, .. } => {
+                self.ins().call(set);
+            }
+        }
     }
 }
 

--- a/crates/wit-dylib/src/lib.rs
+++ b/crates/wit-dylib/src/lib.rs
@@ -26,11 +26,29 @@ pub const C_HEADER: &'static str = include_str!("../wit_dylib.h");
 pub struct DylibOpts {
     /// The interpreter name to insert into the `WASM_DYLINK_NEEDED` section
     /// encoded as `dylink.0`.
-    #[cfg_attr(feature = "clap", clap(long))]
+    #[cfg_attr(feature = "clap", clap(long, value_name = "name"))]
     pub interpreter: Option<String>,
 
     #[cfg_attr(feature = "clap", clap(flatten))]
     pub async_: AsyncFilterSet,
+
+    /// Where the stack pointer is located in the ABI of the generated dylib.
+    ///
+    /// For WASIp2-and-prior the `global` option should be used, and for
+    /// WASIp3-and-later the `task-context` option should be used.
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, value_name = "loc", default_value = "global")
+    )]
+    pub stack_pointer: StackPointer,
+}
+
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum StackPointer {
+    #[default]
+    Global,
+    TaskContext,
 }
 
 pub fn create(resolve: &Resolve, world_id: WorldId, opts: Option<&mut DylibOpts>) -> Vec<u8> {
@@ -62,7 +80,7 @@ struct Adapter {
     global_index: u32,
     table_base: Option<u32>,
     memory_base: Option<u32>,
-    stack_pointer: Option<u32>,
+    stack_pointer: Option<ImportedStackPointer>,
     func_index: u32,
     functions: FunctionSection,
     exports: ExportSection,
@@ -83,6 +101,12 @@ struct Adapter {
     /// Elements of this list are function indices in this module which will be
     /// placed into the element segment.
     elem_segment: Vec<u32>,
+}
+
+#[derive(Copy, Clone)]
+enum ImportedStackPointer {
+    Global(u32),
+    TaskContext { get: u32, set: u32 },
 }
 
 #[derive(Default)]
@@ -401,7 +425,21 @@ impl Adapter {
 
         self.table_base = Some(self.import_global("env", "__table_base", const_i32_global));
         self.memory_base = Some(self.import_global("env", "__memory_base", const_i32_global));
-        self.stack_pointer = Some(self.import_global("env", "__stack_pointer", mut_i32_global));
+        self.stack_pointer = Some(match self.opts.stack_pointer {
+            StackPointer::Global => ImportedStackPointer::Global(self.import_global(
+                "env",
+                "__stack_pointer",
+                mut_i32_global,
+            )),
+            StackPointer::TaskContext => {
+                let get_ty = self.define_ty([], [ValType::I32]);
+                let set_ty = self.define_ty([ValType::I32], []);
+                ImportedStackPointer::TaskContext {
+                    get: self.import_func("$root", "[context-get-0]", get_ty),
+                    set: self.import_func("$root", "[context-set-0]", set_ty),
+                }
+            }
+        });
 
         self.imports.import(
             "env",
@@ -1200,10 +1238,6 @@ impl Adapter {
 
     fn intrinsics(&self) -> &bindgen::WitInterpreterIntrinsics {
         self.intrinsics.as_ref().unwrap()
-    }
-
-    fn stack_pointer(&self) -> u32 {
-        self.stack_pointer.unwrap()
     }
 
     fn memory_base(&self) -> u32 {

--- a/tests/cli/wit-dylib-smoke.wit
+++ b/tests/cli/wit-dylib-smoke.wit
@@ -1,4 +1,5 @@
 // RUN: wit-dylib --validate % | strip -t
+// RUN[task-context]: wit-dylib --validate % --stack-pointer task-context | strip -t
 
 package the:test;
 

--- a/tests/cli/wit-dylib-smoke.wit.task-context.stdout
+++ b/tests/cli/wit-dylib-smoke.wit.task-context.stdout
@@ -1,0 +1,189 @@
+(module
+  (@dylink.0
+    (mem-info (memory 200 2) (table 1 0))
+  )
+  (type (;0;) (func (param i32)))
+  (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+  (type (;2;) (func (param i32 i32 i32 i32 i32)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func (param i32 i32)))
+  (type (;5;) (func (param i32 i32) (result i32)))
+  (type (;6;) (func (param i32) (result i64)))
+  (type (;7;) (func (param i32) (result f32)))
+  (type (;8;) (func (param i32) (result f64)))
+  (type (;9;) (func (param i32 i32 i32) (result i32)))
+  (type (;10;) (func (param i32 i64)))
+  (type (;11;) (func (param i32 f32)))
+  (type (;12;) (func (param i32 f64)))
+  (type (;13;) (func (param i32 i32 i32)))
+  (type (;14;) (func))
+  (type (;15;) (func (result i32)))
+  (import "env" "wit_dylib_initialize" (func $wit_dylib_initialize (;0;) (type 0)))
+  (import "env" "cabi_realloc" (func $cabi_realloc (;1;) (type 1)))
+  (import "env" "wit_dylib_dealloc_bytes" (func $wit_dylib_dealloc_bytes (;2;) (type 2)))
+  (import "env" "wit_dylib_export_start" (func $wit_dylib_export_start (;3;) (type 3)))
+  (import "env" "wit_dylib_export_call" (func $wit_dylib_export_call (;4;) (type 4)))
+  (import "env" "wit_dylib_export_async_call" (func $wit_dylib_export_async_call (;5;) (type 5)))
+  (import "env" "wit_dylib_export_async_callback" (func $wit_dylib_export_async_callback (;6;) (type 1)))
+  (import "env" "wit_dylib_export_finish" (func $wit_dylib_export_finish (;7;) (type 4)))
+  (import "env" "wit_dylib_resource_dtor" (func $wit_dylib_resource_dtor (;8;) (type 4)))
+  (import "env" "wit_dylib_pop_u8" (func $wit_dylib_pop_u8 (;9;) (type 3)))
+  (import "env" "wit_dylib_pop_u16" (func $wit_dylib_pop_u16 (;10;) (type 3)))
+  (import "env" "wit_dylib_pop_u32" (func $wit_dylib_pop_u32 (;11;) (type 3)))
+  (import "env" "wit_dylib_pop_u64" (func $wit_dylib_pop_u64 (;12;) (type 6)))
+  (import "env" "wit_dylib_pop_s8" (func $wit_dylib_pop_s8 (;13;) (type 3)))
+  (import "env" "wit_dylib_pop_s16" (func $wit_dylib_pop_s16 (;14;) (type 3)))
+  (import "env" "wit_dylib_pop_s32" (func $wit_dylib_pop_s32 (;15;) (type 3)))
+  (import "env" "wit_dylib_pop_s64" (func $wit_dylib_pop_s64 (;16;) (type 6)))
+  (import "env" "wit_dylib_pop_bool" (func $wit_dylib_pop_bool (;17;) (type 3)))
+  (import "env" "wit_dylib_pop_char" (func $wit_dylib_pop_char (;18;) (type 3)))
+  (import "env" "wit_dylib_pop_f32" (func $wit_dylib_pop_f32 (;19;) (type 7)))
+  (import "env" "wit_dylib_pop_f64" (func $wit_dylib_pop_f64 (;20;) (type 8)))
+  (import "env" "wit_dylib_pop_flags" (func $wit_dylib_pop_flags (;21;) (type 5)))
+  (import "env" "wit_dylib_pop_enum" (func $wit_dylib_pop_enum (;22;) (type 5)))
+  (import "env" "wit_dylib_pop_borrow" (func $wit_dylib_pop_borrow (;23;) (type 5)))
+  (import "env" "wit_dylib_pop_own" (func $wit_dylib_pop_own (;24;) (type 5)))
+  (import "env" "wit_dylib_pop_future" (func $wit_dylib_pop_future (;25;) (type 5)))
+  (import "env" "wit_dylib_pop_stream" (func $wit_dylib_pop_stream (;26;) (type 5)))
+  (import "env" "wit_dylib_pop_record" (func $wit_dylib_pop_record (;27;) (type 4)))
+  (import "env" "wit_dylib_pop_tuple" (func $wit_dylib_pop_tuple (;28;) (type 4)))
+  (import "env" "wit_dylib_pop_variant" (func $wit_dylib_pop_variant (;29;) (type 5)))
+  (import "env" "wit_dylib_pop_option" (func $wit_dylib_pop_option (;30;) (type 5)))
+  (import "env" "wit_dylib_pop_result" (func $wit_dylib_pop_result (;31;) (type 5)))
+  (import "env" "wit_dylib_pop_string" (func $wit_dylib_pop_string (;32;) (type 5)))
+  (import "env" "wit_dylib_pop_list" (func $wit_dylib_pop_list (;33;) (type 9)))
+  (import "env" "wit_dylib_pop_list_iter_next" (func $wit_dylib_pop_list_iter_next (;34;) (type 4)))
+  (import "env" "wit_dylib_pop_list_iter" (func $wit_dylib_pop_list_iter (;35;) (type 4)))
+  (import "env" "wit_dylib_pop_map" (func $wit_dylib_pop_map (;36;) (type 5)))
+  (import "env" "wit_dylib_pop_map_iter_next" (func $wit_dylib_pop_map_iter_next (;37;) (type 4)))
+  (import "env" "wit_dylib_pop_map_iter" (func $wit_dylib_pop_map_iter (;38;) (type 4)))
+  (import "env" "wit_dylib_push_bool" (func $wit_dylib_push_bool (;39;) (type 4)))
+  (import "env" "wit_dylib_push_char" (func $wit_dylib_push_char (;40;) (type 4)))
+  (import "env" "wit_dylib_push_u8" (func $wit_dylib_push_u8 (;41;) (type 4)))
+  (import "env" "wit_dylib_push_s8" (func $wit_dylib_push_s8 (;42;) (type 4)))
+  (import "env" "wit_dylib_push_u16" (func $wit_dylib_push_u16 (;43;) (type 4)))
+  (import "env" "wit_dylib_push_s16" (func $wit_dylib_push_s16 (;44;) (type 4)))
+  (import "env" "wit_dylib_push_u32" (func $wit_dylib_push_u32 (;45;) (type 4)))
+  (import "env" "wit_dylib_push_s32" (func $wit_dylib_push_s32 (;46;) (type 4)))
+  (import "env" "wit_dylib_push_u64" (func $wit_dylib_push_u64 (;47;) (type 10)))
+  (import "env" "wit_dylib_push_s64" (func $wit_dylib_push_s64 (;48;) (type 10)))
+  (import "env" "wit_dylib_push_f32" (func $wit_dylib_push_f32 (;49;) (type 11)))
+  (import "env" "wit_dylib_push_f64" (func $wit_dylib_push_f64 (;50;) (type 12)))
+  (import "env" "wit_dylib_push_string" (func $wit_dylib_push_string (;51;) (type 13)))
+  (import "env" "wit_dylib_push_record" (func $wit_dylib_push_record (;52;) (type 4)))
+  (import "env" "wit_dylib_push_tuple" (func $wit_dylib_push_tuple (;53;) (type 4)))
+  (import "env" "wit_dylib_push_flags" (func $wit_dylib_push_flags (;54;) (type 13)))
+  (import "env" "wit_dylib_push_enum" (func $wit_dylib_push_enum (;55;) (type 13)))
+  (import "env" "wit_dylib_push_borrow" (func $wit_dylib_push_borrow (;56;) (type 13)))
+  (import "env" "wit_dylib_push_own" (func $wit_dylib_push_own (;57;) (type 13)))
+  (import "env" "wit_dylib_push_future" (func $wit_dylib_push_future (;58;) (type 13)))
+  (import "env" "wit_dylib_push_stream" (func $wit_dylib_push_stream (;59;) (type 13)))
+  (import "env" "wit_dylib_push_variant" (func $wit_dylib_push_variant (;60;) (type 13)))
+  (import "env" "wit_dylib_push_option" (func $wit_dylib_push_option (;61;) (type 13)))
+  (import "env" "wit_dylib_push_result" (func $wit_dylib_push_result (;62;) (type 13)))
+  (import "env" "wit_dylib_push_list" (func $wit_dylib_push_list (;63;) (type 1)))
+  (import "env" "wit_dylib_list_append" (func $wit_dylib_list_append (;64;) (type 4)))
+  (import "env" "wit_dylib_push_map" (func $wit_dylib_push_map (;65;) (type 13)))
+  (import "env" "wit_dylib_map_append" (func $wit_dylib_map_append (;66;) (type 4)))
+  (import "$root" "x" (func $x (;67;) (type 14)))
+  (import "env" "__table_base" (global $__table_base (;0;) i32))
+  (import "env" "__memory_base" (global $__memory_base (;1;) i32))
+  (import "$root" "[context-get-0]" (func $"[context-get-0]" (;68;) (type 15)))
+  (import "$root" "[context-set-0]" (func $"[context-set-0]" (;69;) (type 0)))
+  (import "env" "memory" (memory (;0;) 0))
+  (import "env" "__indirect_function_table" (table (;0;) 0 funcref))
+  (export "cabi_realloc" (func $cabi_realloc))
+  (export "y" (func $y))
+  (export "cabi_post_y" (func $cabi_post_y))
+  (export "__wasm_apply_data_relocs" (func $__wasm_apply_data_relocs))
+  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+  (elem (;0;) (table 0) (global.get $__table_base) func $"adapter x")
+  (func $"adapter x" (;70;) (type 0) (param i32)
+    (local i32)
+    call $"[context-get-0]"
+    i32.const 16
+    i32.sub
+    local.tee 1
+    call $"[context-set-0]"
+    call $x
+    local.get 1
+    i32.const 16
+    i32.add
+    call $"[context-set-0]"
+  )
+  (func $y (;71;) (type 14)
+    (local i32 i32 i32)
+    call $"[context-get-0]"
+    i32.const 16
+    i32.sub
+    local.tee 0
+    call $"[context-set-0]"
+    i32.const 0
+    call $wit_dylib_export_start
+    local.set 1
+    local.get 1
+    i32.const 0
+    call $wit_dylib_export_call
+    call $"[context-get-0]"
+    i32.const 8
+    i32.sub
+    local.tee 2
+    call $"[context-set-0]"
+    local.get 2
+    local.get 1
+    i32.store
+  )
+  (func $cabi_post_y (;72;) (type 14)
+    (local i32 i32)
+    call $"[context-get-0]"
+    local.set 0
+    local.get 0
+    i32.load
+    local.set 1
+    local.get 0
+    i32.const 8
+    i32.add
+    call $"[context-set-0]"
+    local.get 1
+    i32.const 0
+    call $wit_dylib_export_finish
+    call $"[context-get-0]"
+    local.set 1
+    local.get 1
+    i32.const 16
+    i32.add
+    call $"[context-set-0]"
+  )
+  (func $__wasm_apply_data_relocs (;73;) (type 14)
+    global.get $__memory_base
+    global.get $__memory_base
+    i32.const 196
+    i32.add
+    i32.store offset=4
+    global.get $__memory_base
+    global.get $__table_base
+    i32.store offset=8
+    global.get $__memory_base
+    global.get $__memory_base
+    i32.const 198
+    i32.add
+    i32.store offset=44
+    global.get $__memory_base
+    global.get $__memory_base
+    i32.const 0
+    i32.add
+    i32.store offset=72
+    global.get $__memory_base
+    global.get $__memory_base
+    i32.const 40
+    i32.add
+    i32.store offset=80
+  )
+  (func $__wasm_call_ctors (;74;) (type 14)
+    i32.const 64
+    global.get $__memory_base
+    i32.add
+    call $wit_dylib_initialize
+  )
+  (data (;0;) (global.get $__memory_base) "/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/ff/ff/ff/ff/03/00/00/00/01/00/00/00/00/00/00/00/01/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00/00x/00y/00")
+)


### PR DESCRIPTION
Add an option to use the stack pointer in task-context slots instead of an imported global to match the wasip3 ABI. This'll require manually setting this flag unfortunately, but otherwise I'm not sure of a great way to auto-detect.