### PR TITLE
Remove post-return hooks, adjust sync task hooks

### DIFF
--- a/crates/wit-component/src/encoding/fixup.rs
+++ b/crates/wit-component/src/encoding/fixup.rs
@@ -137,7 +137,7 @@ enum DefinedFunction {
         /// get inserted into `EncodingState`'s export wrapper map.
         export: Option<ImportedInstance>,
         /// The kind of hook to use at the start of this function.
-        start: TaskHook,
+        start: Option<TaskHook>,
         /// The kind of hook to use at the end of this function.
         end: EndTaskHook,
     },
@@ -167,10 +167,9 @@ pub enum TaskHook {
     ResourceDtorStart = 8,
     /// A resource destructor is finished.
     ResourceDtorFinish = 9,
-    /// A call to post-return is starting.
-    PostReturnStart = 10,
-    /// A call to post-return is finished.
-    PostReturnFinish = 11,
+    //
+    // 11/12 intentionally missing
+    //
     /// A `realloc` function used as a canonical ABI option is being invoked.
     ReallocStart = 12,
     /// A `realloc` function used as a canonical ABI option has finished.
@@ -178,6 +177,7 @@ pub enum TaskHook {
 }
 
 enum EndTaskHook {
+    None,
     AsyncCode,
     Normal(TaskHook),
 }
@@ -464,7 +464,9 @@ impl FixupModule {
                         locals.push((1, ValType::I32));
                     }
                     let mut f = Function::new(locals);
-                    f.instructions().i32_const(*start as i32).call(*task_hook);
+                    if let Some(start) = *start {
+                        f.instructions().i32_const(start as i32).call(*task_hook);
+                    }
                     for i in 0..*params {
                         f.instructions().local_get(i as u32);
                     }
@@ -493,6 +495,7 @@ impl FixupModule {
                         EndTaskHook::Normal(hook) => {
                             f.instructions().i32_const(*hook as i32).call(*task_hook);
                         }
+                        EndTaskHook::None => {}
                     }
                     if export.is_some() {
                         exports.export(&format!("hook{i}"), ExportKind::Func, index);
@@ -728,7 +731,7 @@ impl FixupModule {
                             task_hook,
                             to_wrap: func,
                             params: 1,
-                            start: TaskHook::ResourceDtorStart,
+                            start: Some(TaskHook::ResourceDtorStart),
                             end: EndTaskHook::Normal(TaskHook::ResourceDtorFinish),
                             export: None,
                             core_name: format!("resource-dtor"),
@@ -783,7 +786,7 @@ impl FixupModule {
                     task_hook,
                     to_wrap: func,
                     params: 4,
-                    start: TaskHook::ReallocStart,
+                    start: Some(TaskHook::ReallocStart),
                     end: EndTaskHook::Normal(TaskHook::ReallocFinish),
                     export: Some(instance.clone()),
                     core_name: name.to_string(),
@@ -824,6 +827,7 @@ impl FixupModule {
             let sig = resolve.wasm_signature(*abi, f);
             let ty = self.type_index(&sig);
             let func = self.import_func(&imported_instance, core_name, ty)?;
+            let post_return = info.post_return(key, f);
             self.defined_functions.push((
                 ty,
                 DefinedFunction::HookedCoreExport {
@@ -832,19 +836,24 @@ impl FixupModule {
                     export: Some(imported_instance.clone()),
                     params: sig.params.len(),
                     core_name: core_name.to_string(),
-                    start: if abi.is_async() {
+                    start: Some(if abi.is_async() {
                         TaskHook::AsyncStart
                     } else {
                         TaskHook::SyncStart
-                    },
+                    }),
                     end: if abi.is_async() {
+                        assert!(post_return.is_none());
                         if *abi == AbiVariant::GuestExportAsyncStackful {
                             EndTaskHook::Normal(TaskHook::AsyncFinish)
                         } else {
                             EndTaskHook::AsyncCode
                         }
                     } else {
-                        EndTaskHook::Normal(TaskHook::SyncFinish)
+                        if post_return.is_some() {
+                            EndTaskHook::None
+                        } else {
+                            EndTaskHook::Normal(TaskHook::SyncFinish)
+                        }
                     },
                 },
             ));
@@ -862,8 +871,8 @@ impl FixupModule {
                         export: Some(imported_instance.clone()),
                         params: post_return_sig.params.len(),
                         core_name: post_return.to_string(),
-                        start: TaskHook::PostReturnStart,
-                        end: EndTaskHook::Normal(TaskHook::PostReturnFinish),
+                        start: None,
+                        end: EndTaskHook::Normal(TaskHook::SyncFinish),
                     },
                 ));
             }
@@ -879,7 +888,7 @@ impl FixupModule {
                         export: Some(imported_instance.clone()),
                         params: 3,
                         core_name: callback.to_string(),
-                        start: TaskHook::AsyncResume,
+                        start: Some(TaskHook::AsyncResume),
                         end: EndTaskHook::AsyncCode,
                     },
                 ));

--- a/crates/wit-component/src/encoding/fixup.rs
+++ b/crates/wit-component/src/encoding/fixup.rs
@@ -168,7 +168,7 @@ pub enum TaskHook {
     /// A resource destructor is finished.
     ResourceDtorFinish = 9,
     //
-    // 11/12 intentionally missing
+    // 10/11 intentionally missing
     //
     /// A `realloc` function used as a canonical ABI option is being invoked.
     ReallocStart = 12,

--- a/crates/wit-component/tests/components/realloc-task-hook-link-no-cabi-realloc/component.wat
+++ b/crates/wit-component/tests/components/realloc-task-hook-link-no-cabi-realloc/component.wat
@@ -202,15 +202,11 @@
       local.get 0
       local.get 1
       call $greet
-      i32.const 1
-      call $"#func4 __wasm_task_hook"
     )
     (func $hook-cabi_post_greet (;12;) (type 3) (param i32)
-      i32.const 10
-      call $"#func4 __wasm_task_hook"
       local.get 0
       call $cabi_post_greet
-      i32.const 11
+      i32.const 1
       call $"#func4 __wasm_task_hook"
     )
     (func $hook-cabi_realloc (;13;) (type 0) (param i32 i32 i32 i32) (result i32)

--- a/crates/wit-component/tests/components/realloc-task-hook-link/component.wat
+++ b/crates/wit-component/tests/components/realloc-task-hook-link/component.wat
@@ -211,15 +211,11 @@
       local.get 0
       local.get 1
       call $foo2
-      i32.const 1
-      call $"#func4 __wasm_task_hook"
     )
     (func $hook-cabi_post_foo2 (;14;) (type 1) (param i32)
-      i32.const 10
-      call $"#func4 __wasm_task_hook"
       local.get 0
       call $cabi_post_foo2
-      i32.const 11
+      i32.const 1
       call $"#func4 __wasm_task_hook"
     )
     (func $hook-cabi_realloc (;15;) (type 0) (param i32 i32 i32 i32) (result i32)

--- a/crates/wit-component/tests/components/realloc-task-hook/component.wat
+++ b/crates/wit-component/tests/components/realloc-task-hook/component.wat
@@ -131,15 +131,11 @@
       local.get 0
       local.get 1
       call $takes-and-returns
-      i32.const 1
-      call $__wasm_task_hook
     )
     (func $hook-cabi_post_takes-and-returns (;12;) (type 0) (param i32)
-      i32.const 10
-      call $__wasm_task_hook
       local.get 0
       call $cabi_post_takes-and-returns
-      i32.const 11
+      i32.const 1
       call $__wasm_task_hook
     )
     (func $hook-no-realloc (;13;) (type 4)

--- a/crates/wit-component/tests/components/wasm-init-task/component.wat
+++ b/crates/wit-component/tests/components/wasm-init-task/component.wat
@@ -163,14 +163,10 @@
       i32.const 0
       call $__wasm_task_hook
       call $sync
-      i32.const 1
-      call $__wasm_task_hook
     )
     (func $hook-cabi_post_sync (;18;) (type 1)
-      i32.const 10
-      call $__wasm_task_hook
       call $cabi_post_sync
-      i32.const 11
+      i32.const 1
       call $__wasm_task_hook
     )
     (func $"hook-[async-lift-stackful]async-stackful-argret" (;19;) (type 4) (param i32 i32)


### PR DESCRIPTION
This commit updates the invocation of `__wasm_task_hook` in `wit-component` for generated components, first intended to be used with wasip3. Previously hooks were added for all known locations, including post-return, but this turned out to be incompatible with how the stack is managed in `wit-dylib`. The preexisting hooks are also a minor source of overhead where a sync task with post return gets 4 hook points, 2 of which are basically unnecessary. The change in this commit is to avoid post-return-specific hooks entirely and instead move the "sync task finished" hook to the end of the post-return function if one is specified. This makes things slightly more efficient (fewer hook points), and is additionally compatible with what wit-dylib does.