### PR TITLE
Start requiring "strict" indices in the text format

### DIFF
--- a/crates/wast/src/component/item_ref.rs
+++ b/crates/wast/src/component/item_ref.rs
@@ -19,7 +19,7 @@ use crate::token::Index;
 /// default will be flipped to strict in the future, and eventually support
 /// for the legacy syntax will be removed.
 pub(crate) fn allow_legacy_indices() -> bool {
-    const DEFAULT: bool = true;
+    const DEFAULT: bool = false;
     static ALLOW: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
         match std::env::var("WAST_STRICT_COMPONENT_INDICES").as_deref() {
             Ok("0") => true,


### PR DESCRIPTION
This commit is a continuation of #2562 in the plan to phase out the historical form of specifying indices in the text format of the component model. The `wast` crate still supports the old version but requires an env var opt-in now of `WAST_STRICT_COMPONENT_INDICES=0`.