### PR TITLE
Enable the `cm-implements` and `cm-map` features by default

### DIFF
--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -339,7 +339,7 @@ define_wasm_features! {
         ///
         /// Corresponds to the 🗺️ character in
         /// <https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md>.
-        pub cm_map: CM_MAP(1 << 38) = false;
+        pub cm_map: CM_MAP(1 << 38) = true;
 
         /// Support for 64-bit contexts in the component model proposal.
         ///
@@ -351,7 +351,7 @@ define_wasm_features! {
         ///
         /// Corresponds to the 🏷️ character in
         /// <https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md>.
-        pub cm_implements: CM_IMPLEMENTS(1 << 40) = false;
+        pub cm_implements: CM_IMPLEMENTS(1 << 40) = true;
 
         /// Support for the `(versionsuffix "...")` directive in the component model
         ///

--- a/tests/cli/missing-features/component-model/map.wast
+++ b/tests/cli/missing-features/component-model/map.wast
@@ -1,4 +1,4 @@
-;; RUN: wast % --assert default --snapshot tests/snapshots
+;; RUN: wast % --assert default --snapshot tests/snapshots -f=-cm-map
 
 (assert_invalid
   (component


### PR DESCRIPTION
These features have been voted on by the WASI subgroup for inclusion in a future WASI release and are thus effectively stable in the component model, so this commit sets the features to being enabled-by-default.