### PR TITLE
Return an error instead of panicking on fixed-length-list size overflow

### DIFF
--- a/crates/wit-dylib/src/lib.rs
+++ b/crates/wit-dylib/src/lib.rs
@@ -1491,7 +1491,7 @@ world w {{
             )
             .unwrap();
         let world = resolve.select_world(&[package], None).unwrap();
-        let adapter = super::create(&resolve, world, None);
+        let adapter = super::create(&resolve, world, None).unwrap();
         for payload in Parser::new(0).parse_all(&adapter) {
             match payload.unwrap() {
                 Payload::CodeSectionEntry(body) => {

--- a/crates/wit-dylib/src/lib.rs
+++ b/crates/wit-dylib/src/lib.rs
@@ -51,24 +51,28 @@ pub enum StackPointer {
     TaskContext,
 }
 
-pub fn create(resolve: &Resolve, world_id: WorldId, opts: Option<&mut DylibOpts>) -> Vec<u8> {
-    create_with_metadata(resolve, world_id, opts).0
+pub fn create(
+    resolve: &Resolve,
+    world_id: WorldId,
+    opts: Option<&mut DylibOpts>,
+) -> anyhow::Result<Vec<u8>> {
+    Ok(create_with_metadata(resolve, world_id, opts)?.0)
 }
 
 pub fn create_with_metadata(
     resolve: &Resolve,
     world_id: WorldId,
     mut opts: Option<&mut DylibOpts>,
-) -> (Vec<u8>, Metadata) {
+) -> anyhow::Result<(Vec<u8>, Metadata)> {
     let mut adapter = Adapter::default();
     if let Some(opts) = &mut opts {
         adapter.opts = opts.clone();
     }
-    let result = adapter.encode(resolve, world_id);
+    let result = adapter.encode(resolve, world_id)?;
     if let Some(opts) = &mut opts {
         **opts = adapter.opts;
     }
-    (result, adapter.metadata)
+    Ok((result, adapter.metadata))
 }
 
 #[derive(Default)]
@@ -154,8 +158,8 @@ struct PayloadData {
 }
 
 impl Adapter {
-    pub fn encode(&mut self, resolve: &Resolve, world_id: WorldId) -> Vec<u8> {
-        self.sizes.fill(resolve);
+    pub fn encode(&mut self, resolve: &Resolve, world_id: WorldId) -> anyhow::Result<Vec<u8>> {
+        self.sizes.fill(resolve)?;
 
         // First define all imports that will go into the wasm module since
         // they're required to be first in their index spaces anyway. This will
@@ -194,7 +198,7 @@ impl Adapter {
         let ty = self.define_ty([], []);
         self.define_func("__wasm_call_ctors", ty, ctor, true);
 
-        self.finish(&metadata)
+        Ok(self.finish(&metadata))
     }
 
     fn mangling(

--- a/crates/wit-dylib/test-programs/artifacts/src/lib.rs
+++ b/crates/wit-dylib/test-programs/artifacts/src/lib.rs
@@ -42,7 +42,7 @@ fn create_component(
     resolve: &Resolve,
     wasm: (&Path, WorldId),
 ) -> Result<(Vec<u8>, PathBuf)> {
-    let mut adapter = wit_dylib::create(resolve, wasm.1, None);
+    let mut adapter = wit_dylib::create(resolve, wasm.1, None)?;
     let name = &resolve.worlds[wasm.1].name;
 
     wit_component::embed_component_metadata(

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -252,27 +252,32 @@ pub struct SizeAlign {
 }
 
 impl SizeAlign {
-    pub fn fill(&mut self, resolve: &Resolve) {
+    pub fn fill(&mut self, resolve: &Resolve) -> anyhow::Result<()> {
         self.map = Vec::new();
         for (_, ty) in resolve.types.iter() {
-            let pair = self.calculate(ty);
+            let pair = self.calculate(ty)?;
             self.map.push(pair);
         }
+        Ok(())
     }
 
-    fn calculate(&self, ty: &TypeDef) -> ElementInfo {
-        match &ty.kind {
+    fn calculate(&self, ty: &TypeDef) -> anyhow::Result<ElementInfo> {
+        Ok(match &ty.kind {
             TypeDefKind::Type(t) => ElementInfo::new(self.size(t), self.align(t)),
             TypeDefKind::FixedLengthList(t, size) => {
                 let field_align = self.align(t);
                 let field_size = self.size(t);
-                ElementInfo::new(
-                    ArchitectureSize::new(
-                        field_size.bytes.checked_mul(*size as usize).unwrap(),
-                        field_size.pointers.checked_mul(*size as usize).unwrap(),
-                    ),
-                    field_align,
-                )
+                let bytes = field_size.bytes.checked_mul(*size as usize).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "size of fixed-length list of {size} elements overflows the target architecture's address space"
+                    )
+                })?;
+                let pointers = field_size.pointers.checked_mul(*size as usize).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "size of fixed-length list of {size} elements overflows the target architecture's address space"
+                    )
+                })?;
+                ElementInfo::new(ArchitectureSize::new(bytes, pointers), field_align)
             }
             TypeDefKind::List(_) => {
                 ElementInfo::new(ArchitectureSize::new(0, 2), Alignment::Pointer)
@@ -308,7 +313,7 @@ impl SizeAlign {
                 Alignment::Bytes(NonZeroUsize::new(usize::MAX).unwrap()),
             ),
             TypeDefKind::Unknown => unreachable!(),
-        }
+        })
     }
 
     pub fn size(&self, ty: &Type) -> ArchitectureSize {
@@ -457,6 +462,7 @@ pub fn align_to_arch(val: ArchitectureSize, align: Alignment) -> ArchitectureSiz
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::string::ToString;
     use alloc::vec;
 
     #[test]
@@ -558,15 +564,17 @@ mod test {
     fn resource_size() {
         // keep it identical to the old behavior
         let obj = SizeAlign::default();
-        let elem = obj.calculate(&TypeDef {
-            name: None,
-            kind: TypeDefKind::Resource,
-            owner: crate::TypeOwner::None,
-            docs: Default::default(),
-            stability: Default::default(),
-            span: Default::default(),
-            external_id: Default::default(),
-        });
+        let elem = obj
+            .calculate(&TypeDef {
+                name: None,
+                kind: TypeDefKind::Resource,
+                owner: crate::TypeOwner::None,
+                docs: Default::default(),
+                stability: Default::default(),
+                span: Default::default(),
+                external_id: Default::default(),
+            })
+            .unwrap();
         assert_eq!(elem.size, ArchitectureSize::new(usize::MAX, 0));
         assert_eq!(
             elem.align,
@@ -589,22 +597,72 @@ mod test {
             span: Default::default(),
             external_id: Default::default(),
         });
-        obj.fill(&resolve);
+        obj.fill(&resolve).unwrap();
         let my_result = crate::Result_ {
             ok: Some(Type::String),
             err: Some(Type::Id(id)),
         };
-        let elem = obj.calculate(&TypeDef {
+        let elem = obj
+            .calculate(&TypeDef {
+                name: None,
+                kind: TypeDefKind::Result(my_result),
+                owner: crate::TypeOwner::None,
+                docs: Default::default(),
+                stability: Default::default(),
+                span: Default::default(),
+                external_id: Default::default(),
+            })
+            .unwrap();
+        assert_eq!(elem.size, ArchitectureSize::new(8, 2));
+        assert_eq!(elem.align, Alignment::Pointer);
+    }
+
+    #[test]
+    fn fixed_length_list_size_overflow_returns_error_instead_of_panicking() {
+        // Regression test: a fixed-length list whose element-size * length
+        // overflows `usize` used to panic via `.unwrap()` on a `None` from
+        // `checked_mul`. It must now return an `Err` instead.
+        let mut obj = SizeAlign::default();
+        let mut resolve = Resolve::default();
+
+        // `type a = list<u64, 4294967295>;`
+        let a = resolve.types.alloc(TypeDef {
             name: None,
-            kind: TypeDefKind::Result(my_result),
+            kind: TypeDefKind::FixedLengthList(Type::U64, u32::MAX),
             owner: crate::TypeOwner::None,
             docs: Default::default(),
             stability: Default::default(),
             span: Default::default(),
             external_id: Default::default(),
         });
-        assert_eq!(elem.size, ArchitectureSize::new(8, 2));
-        assert_eq!(elem.align, Alignment::Pointer);
+        // `type b = list<a, 4294967295>;` -- `a`'s size (8 * u32::MAX) times
+        // `u32::MAX` again overflows `usize` on both 32- and 64-bit targets.
+        resolve.types.alloc(TypeDef {
+            name: None,
+            kind: TypeDefKind::FixedLengthList(Type::Id(a), u32::MAX),
+            owner: crate::TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+            span: Default::default(),
+            external_id: Default::default(),
+        });
+
+        let err = obj.fill(&resolve).unwrap_err();
+        assert!(err.to_string().contains("overflows"));
+
+        // A benign, non-overflowing fixed-length list still computes fine.
+        let mut obj = SizeAlign::default();
+        let mut resolve = Resolve::default();
+        resolve.types.alloc(TypeDef {
+            name: None,
+            kind: TypeDefKind::FixedLengthList(Type::U64, 2),
+            owner: crate::TypeOwner::None,
+            docs: Default::default(),
+            stability: Default::default(),
+            span: Default::default(),
+            external_id: Default::default(),
+        });
+        obj.fill(&resolve).unwrap();
     }
     #[test]
     fn result_ptr_64bit() {
@@ -625,15 +683,17 @@ mod test {
                 },
             ],
         };
-        let elem = obj.calculate(&TypeDef {
-            name: None,
-            kind: TypeDefKind::Record(my_record),
-            owner: crate::TypeOwner::None,
-            docs: Default::default(),
-            stability: Default::default(),
-            span: Default::default(),
-            external_id: Default::default(),
-        });
+        let elem = obj
+            .calculate(&TypeDef {
+                name: None,
+                kind: TypeDefKind::Record(my_record),
+                owner: crate::TypeOwner::None,
+                docs: Default::default(),
+                stability: Default::default(),
+                span: Default::default(),
+                external_id: Default::default(),
+            })
+            .unwrap();
         assert_eq!(elem.size, ArchitectureSize::new(8, 2));
         assert_eq!(elem.align, Alignment::Bytes(NonZeroUsize::new(8).unwrap()));
     }

--- a/fuzz/src/wit64.rs
+++ b/fuzz/src/wit64.rs
@@ -26,7 +26,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     sa64.fill(r1);
 
     let mut alt = wit_parser_new::SizeAlign::default();
-    alt.fill(r2);
+    alt.fill(r2).unwrap();
 
     for ((t1, _), (t2, _)) in r1.types.iter().zip(r2.types.iter()) {
         let t1 = &wit_parser_old::Type::Id(t1);

--- a/src/bin/wasm-tools/wit_dylib.rs
+++ b/src/bin/wasm-tools/wit_dylib.rs
@@ -56,7 +56,7 @@ impl Opts {
         let (resolve, pkg_id) = self.resolve.load()?;
         let world = resolve.select_world(&[pkg_id], self.world.as_deref())?;
 
-        let mut wasm = wit_dylib::create(&resolve, world, Some(&mut self.dylib_opts));
+        let mut wasm = wit_dylib::create(&resolve, world, Some(&mut self.dylib_opts))?;
         self.dylib_opts.async_.ensure_all_used()?;
 
         embed_component_metadata(


### PR DESCRIPTION
`SizeAlign::fill` (and its internal `calculate` helper) computed the size of a `FixedLengthList` as `element_size * length` via `checked_mul(..).unwrap()`, which panics when the multiplication overflows `usize`. Since `list<T, N>` places no upper bound on `N` in the WIT text format (unlike the component binary format, which bounds it to `MAX_WASM_FIXED_LENGTH_LIST_ELEMENTS`), a WIT document with two nested fixed-length lists of a non-trivial element type is enough to overflow the multiplication and abort the process, in a release build too.

This changes `SizeAlign::fill`/`calculate` to return `anyhow::Result` and propagates that outward through `wit-dylib`'s `Adapter::encode`, `create`, and `create_with_metadata`, and their two call sites (the `wasm-tools wit-dylib` CLI subcommand and the wit-dylib test-programs harness). A oversized fixed-length list now surfaces as a normal error instead of aborting:

    $ wasm-tools wit-dylib poc.wit
    error: size of fixed-length list of 4294967295 elements overflows
    the target architecture's address space

Adds a regression test covering both the overflow case (now returns `Err`) and a benign nested fixed-length list (still computes correctly).

Fixes #2637