### PR TITLE
wasm-wave: Clean up syntax docs

### DIFF
--- a/crates/wasm-wave/README.md
+++ b/crates/wasm-wave/README.md
@@ -52,8 +52,8 @@ Kebab-case labels are used for record fields, variant cases, enum cases, and fla
 
 - Labels consist of one or more hyphen-separated words.
   - `one`, `two-words`
-- Words consist of one ASCII letter followed by any number of ASCII alphanumeric characters.
-  - `q`, `abc123`
+- The first word must start with an ASCII letter, followed by any number of ASCII alphanumeric characters. Subsequent words (after a hyphen) may also start with a digit, and must consist of one or more ASCII alphanumeric characters.
+  - `q`, `abc123`, `item-2`
 - Each word can contain lowercase or uppercase characters but not both; each word in a label can use a different (single) case.
   - `HTTP3`, `method-GET`
 - Any label may be prefixed with `%`; this is not part of the label itself but allows for representing labels that would otherwise be parsed as keywords.

--- a/crates/wasm-wave/wave_ebnf.md
+++ b/crates/wasm-wave/wave_ebnf.md
@@ -11,6 +11,7 @@ whitespace around the value, equivalent to the `value-ws` rule.
 value ::= number
         | char
         | string
+        | multiline-string
         | variant-case
         | tuple
         | list
@@ -18,7 +19,7 @@ value ::= number
         | record
 
 value-ws ::= ws value ws
-ws ::= ([ \t\n\r]* comment?)*
+ws ::= ([ \t\n\r] | comment)*
 comment ::= '//' [^\n]*
 
 number ::= number_finite
@@ -31,7 +32,7 @@ integer ::= unsigned-integer
 unsigned-integer ::= '0'
                    | [1-9] [0-9]*
 number-fraction ::= '.' [0-9]+
-number-exponent ::= [eE] [+-]? unsigned-integer
+number-exponent ::= [eE] [+-]? [0-9]+
 
 char ::= ['] char-char [']
 char-char ::= common-char | '"'
@@ -59,26 +60,27 @@ list ::= '[' ws ']'
        | '[' values-seq ','? ws ']'
 
 values-seq ::= value-ws
-             | values ',' values-ws
+             | values-seq ',' value-ws
 
 flags ::= '{' ws '}'
         | '{' flags-seq ','? ws '}'
 flags-seq ::= ws label ws
-            | flags-seq ',' label
+            | flags-seq ',' ws label ws
 
 record ::= '{' ws ':' ws '}'
          | '{' record-fields ','? ws '}'
 record-fields ::= ws record-field ws
-                | record-fields ',' record-field
+                | record-fields ',' ws record-field ws
 record-field ::= label ws ':' ws value
 
-label ::= '%'? inner-label
-inner-label ::= word
-              | inner-label '-' word
-word ::= [a-z][a-z0-9]*
-       | [A-Z][A-Z0-9]*
+label ::= '%'? first-word ('-' word)*
+first-word ::= [a-z][a-z0-9]*
+             | [A-Z][A-Z0-9]*
+word ::= [a-z0-9]+
+       | [A-Z0-9]+
 ```
 
 * "`Unicode scalar value`" is defined by Unicode
-* `escape-unicode` must identify a valid Unicode scalar value.
+* `escape-unicode` must identify a valid Unicode scalar value, using 1 to 6 hexadecimal digits.
 * `multiline-string-line` must not contain `"""`
+* See [README.md#multiline-strings](./README.md#multiline-strings) for the indentation and decoding rules that constrain `multiline-string`.


### PR DESCRIPTION
* Allow numeric segments in labels (from #2372)

* Make whitespace matching more consistent

* Allow leading zero in number exponent (1e05)

* Constrain unicode escape hex length

* Reference README prose for multiline string format