### PR TITLE
Try to improve performance of `deinline_import_export`

### DIFF
--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -4,7 +4,9 @@ use crate::token::{Id, Index, Span};
 use std::mem;
 
 pub fn run(fields: &mut Vec<ModuleField>) {
-    for mut item in mem::take(fields) {
+    let fields_to_expand = mem::take(fields);
+    fields.reserve(fields_to_expand.len());
+    for mut item in fields_to_expand {
         match &mut item {
             ModuleField::Func(f) => {
                 for name in f.exports.names.drain(..) {


### PR DESCRIPTION
This commit is an attempt to improve the performance of this loop which I've seen time out on OSS-Fuzz when parsing large files. Previously this would `mem::take` the list of fields to parse to `push` back into the list, but now after this commit there's a `reserve` after the `take` to pre-allocate space for all the fields that are going to be pushed.