### PR TITLE
Support multiple supertypes in everything but validation

### DIFF
--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -9,7 +9,7 @@ pub struct SubType {
     pub is_final: bool,
     /// The list of supertype indexes. As of GC MVP, there can be at most one
     /// supertype.
-    pub supertype_idx: Option<u32>,
+    pub supertype_idxs: Vec<u32>,
     /// The composite type of the subtype.
     pub composite_type: CompositeType,
 }
@@ -666,7 +666,7 @@ impl<'a> CoreTypeEncoder<'a> {
         // We only need to emit a prefix byte before the actual composite type
         // when either the `sub` type is not final or it has a declared super
         // type (see notes on `push_prefix_if_component_core_type`).
-        if ty.supertype_idx.is_some() || !ty.is_final {
+        if !ty.supertype_idxs.is_empty() || !ty.is_final {
             if ty.is_final {
                 self.bytes.push(0x4f);
             } else {
@@ -675,7 +675,7 @@ impl<'a> CoreTypeEncoder<'a> {
                 }
                 self.bytes.push(0x50);
             }
-            ty.supertype_idx.encode(self.bytes);
+            ty.supertype_idxs.encode(self.bytes);
         }
         if ty.composite_type.shared {
             self.bytes.push(0x65);

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -730,7 +730,7 @@ mod tests {
         let mut types = TypeSection::new();
         types.ty().subtype(&SubType {
             is_final: true,
-            supertype_idx: None,
+            supertype_idxs: Vec::new(),
             composite_type: CompositeType {
                 inner: CompositeInnerType::Func(FuncType::new([], [])),
                 shared: false,

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -1149,10 +1149,11 @@ pub mod utils {
     ) -> Result<crate::SubType, Error<T::Error>> {
         Ok(crate::SubType {
             is_final: sub_ty.is_final,
-            supertype_idx: sub_ty
-                .supertype_idx
+            supertype_idxs: sub_ty
+                .supertype_idxs
+                .iter()
                 .map(|i| reencoder.type_index_unpacked(i.unpack()))
-                .transpose()?,
+                .collect::<Result<Vec<_>, _>>()?,
             composite_type: reencoder.composite_type(sub_ty.composite_type)?,
         })
     }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -2708,7 +2708,7 @@ impl Module {
                             "Subtype {subtype:?} from `exports` Wasm is not final"
                         );
                         assert!(
-                            subtype.supertype_idx.is_none(),
+                            subtype.supertype_idxs.is_empty(),
                             "Subtype {subtype:?} from `exports` Wasm has non-empty supertype"
                         );
                         let func_type = Rc::new(FuncType {
@@ -3995,12 +3995,14 @@ impl TryFrom<wasmparser::SubType> for SubType {
     type Error = ();
 
     fn try_from(value: wasmparser::SubType) -> Result<Self, Self::Error> {
+        let supertype = match &value.supertype_idxs[..] {
+            [_, _, ..] => return Err(()),
+            [a] => Some(a.as_module_index().ok_or(())?),
+            [] => None,
+        };
         Ok(SubType {
             is_final: value.is_final,
-            supertype: value
-                .supertype_idx
-                .map(|idx| idx.as_module_index().ok_or(()))
-                .transpose()?,
+            supertype,
             composite_type: value.composite_type.try_into()?,
             // We cannot determine the depth of current subtype here, set it to 1
             // temporarily and fix it later.

--- a/crates/wasm-smith/src/core/encode.rs
+++ b/crates/wasm-smith/src/core/encode.rs
@@ -38,14 +38,14 @@ impl Module {
                 let ty = &self.types[group.start];
                 section.ty().subtype(&wasm_encoder::SubType {
                     is_final: ty.is_final,
-                    supertype_idx: ty.supertype,
+                    supertype_idxs: ty.supertype.into_iter().collect(),
                     composite_type: (&ty.composite_type).into(),
                 });
             } else {
                 section.ty().rec(self.types[group.clone()].iter().map(|ty| {
                     wasm_encoder::SubType {
                         is_final: ty.is_final,
-                        supertype_idx: ty.supertype,
+                        supertype_idxs: ty.supertype.into_iter().collect(),
                         composite_type: (&ty.composite_type).into(),
                     }
                 }));

--- a/crates/wasm-smith/tests/exports.rs
+++ b/crates/wasm-smith/tests/exports.rs
@@ -136,7 +136,7 @@ fn get_exports(features: WasmFeatures, module: &[u8]) -> Vec<(String, ExportType
                     EntityType::Func(core_id) => {
                         let sub_type = types.get(core_id).expect("Failed to lookup core id");
                         assert!(sub_type.is_final);
-                        assert!(sub_type.supertype_idx.is_none());
+                        assert!(sub_type.supertype_idxs.is_empty());
                         let CompositeType {
                             inner: wasmparser::CompositeInnerType::Func(func_type),
                             ..
@@ -159,7 +159,7 @@ fn get_exports(features: WasmFeatures, module: &[u8]) -> Vec<(String, ExportType
                     EntityType::Tag(core_id) => {
                         let sub_type = types.get(core_id).expect("Failed to lookup core id");
                         assert!(sub_type.is_final);
-                        assert!(sub_type.supertype_idx.is_none());
+                        assert!(sub_type.supertype_idxs.is_empty());
                         let CompositeType {
                             inner: wasmparser::CompositeInnerType::Func(func_type),
                             ..

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -20,7 +20,7 @@
 //
 // See https://webassembly.github.io/spec/js-api/#limits for details.
 pub const MAX_WASM_TYPES: usize = 1_000_000;
-pub const MAX_WASM_SUPERTYPES: usize = 1;
+pub const MAX_WASM_SUPERTYPES: usize = 5;
 pub const MAX_WASM_FUNCTIONS: usize = 1_000_000;
 pub const MAX_WASM_IMPORTS: usize = 1_000_000;
 pub const MAX_WASM_EXPORTS: usize = 1_000_000;

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -450,21 +450,21 @@ pub struct SubType {
     /// Is the subtype final.
     pub is_final: bool,
     /// The list of supertype indexes. As of GC MVP, there can be at most one supertype.
-    pub supertype_idx: Option<PackedIndex>,
+    pub supertype_idxs: Vec<PackedIndex>,
     /// The composite type of the subtype.
     pub composite_type: CompositeType,
 }
 
 impl fmt::Display for SubType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_final && self.supertype_idx.is_none() {
+        if self.is_final && self.supertype_idxs.is_empty() {
             fmt::Display::fmt(&self.composite_type, f)
         } else {
             write!(f, "(sub ")?;
             if self.is_final {
                 write!(f, "final ")?;
             }
-            if let Some(idx) = self.supertype_idx {
+            for idx in self.supertype_idxs.iter() {
                 write!(f, "{idx} ")?;
             }
             fmt::Display::fmt(&self.composite_type, f)?;
@@ -485,7 +485,7 @@ impl SubType {
     pub fn func(signature: FuncType, shared: bool) -> Self {
         Self {
             is_final: true,
-            supertype_idx: None,
+            supertype_idxs: Vec::new(),
             composite_type: CompositeType {
                 inner: CompositeInnerType::Func(signature),
                 shared,
@@ -522,7 +522,7 @@ impl SubType {
         &mut self,
         f: &mut dyn FnMut(&mut PackedIndex) -> Result<()>,
     ) -> Result<()> {
-        if let Some(idx) = &mut self.supertype_idx {
+        for idx in self.supertype_idxs.iter_mut() {
             f(idx)?;
         }
         if let Some(idx) = &mut self.composite_type.descriptor_idx {
@@ -2069,7 +2069,7 @@ impl<'a> TypeSectionReader<'a> {
                 (Some(ty), None) => ty,
                 _ => bail!(offset, "gc proposal not supported"),
             };
-            if !ty.is_final || ty.supertype_idx.is_some() {
+            if !ty.is_final || !ty.supertype_idxs.is_empty() {
                 bail!(offset, "gc proposal not supported");
             }
             match ty.composite_type.inner {
@@ -2162,18 +2162,14 @@ impl<'a> FromReader<'a> for RecGroup {
 
 impl<'a> FromReader<'a> for SubType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let pos = reader.original_position();
         // NB: See `FromReader<'a> for ValType` for a table of how this
         // interacts with other value encodings.
         Ok(match reader.read_u8()? {
             opcode @ (0x4f | 0x50) => {
                 let idx_iter = reader.read_iter(MAX_WASM_SUPERTYPES, "supertype idxs")?;
                 let idxs = idx_iter.collect::<Result<Vec<u32>>>()?;
-                if idxs.len() > 1 {
-                    return Err(Error::new("multiple supertypes not supported", pos));
-                }
-                let supertype_idx = idxs
-                    .first()
+                let supertype_idxs = idxs
+                    .iter()
                     .copied()
                     .map(|idx| {
                         PackedIndex::from_module_index(idx).ok_or_else(|| {
@@ -2183,16 +2179,16 @@ impl<'a> FromReader<'a> for SubType {
                             )
                         })
                     })
-                    .transpose()?;
+                    .collect::<Result<Vec<_>>>()?;
                 SubType {
                     is_final: opcode == 0x4f,
-                    supertype_idx,
+                    supertype_idxs,
                     composite_type: read_composite_type(reader.read_u8()?, reader)?,
                 }
             }
             opcode => SubType {
                 is_final: true,
-                supertype_idx: None,
+                supertype_idxs: Vec::new(),
                 composite_type: read_composite_type(opcode, reader)?,
             },
         })

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -131,7 +131,7 @@ pub(crate) trait InternRecGroup {
         offset: u64,
     ) -> Result<()> {
         let ty = &types[id];
-        if !ty.is_final || ty.supertype_idx.is_some() {
+        if !ty.is_final || !ty.supertype_idxs.is_empty() {
             require_feature::gc(
                 *self.features(),
                 "gc proposal must be enabled to use subtypes",
@@ -141,27 +141,29 @@ pub(crate) trait InternRecGroup {
 
         self.check_composite_type(&ty.composite_type, &types, offset)?;
 
-        let depth = if let Some(supertype_index) = ty.supertype_idx {
-            debug_assert!(supertype_index.is_canonical());
-            let sup_id = self.at_packed_index(types, rec_group, supertype_index, offset)?;
-            if types[sup_id].is_final {
-                bail!(offset, "sub type cannot have a final super type");
+        let depth = match &ty.supertype_idxs[..] {
+            [] => 0,
+            [supertype_index] => {
+                debug_assert!(supertype_index.is_canonical());
+                let sup_id = self.at_packed_index(types, rec_group, *supertype_index, offset)?;
+                if types[sup_id].is_final {
+                    bail!(offset, "sub type cannot have a final super type");
+                }
+                if !types.matches(id, sup_id) {
+                    bail!(offset, "sub type must match super type");
+                }
+                let depth = types.get_subtyping_depth(sup_id) + 1;
+                if usize::from(depth) > crate::limits::MAX_WASM_SUBTYPING_DEPTH {
+                    bail!(
+                        offset,
+                        "sub type hierarchy too deep: found depth {}, cannot exceed depth {}",
+                        depth,
+                        crate::limits::MAX_WASM_SUBTYPING_DEPTH,
+                    );
+                }
+                depth
             }
-            if !types.matches(id, sup_id) {
-                bail!(offset, "sub type must match super type");
-            }
-            let depth = types.get_subtyping_depth(sup_id) + 1;
-            if usize::from(depth) > crate::limits::MAX_WASM_SUBTYPING_DEPTH {
-                bail!(
-                    offset,
-                    "sub type hierarchy too deep: found depth {}, cannot exceed depth {}",
-                    depth,
-                    crate::limits::MAX_WASM_SUBTYPING_DEPTH,
-                );
-            }
-            depth
-        } else {
-            0
+            [_, _, ..] => bail!(offset, "multiple supertypes"),
         };
         types.set_subtyping_depth(id, depth);
 
@@ -212,13 +214,14 @@ pub(crate) trait InternRecGroup {
             None
         };
 
-        if let Some(supertype_index) = types[id].supertype_idx {
+        debug_assert!(types[id].supertype_idxs.len() <= 1);
+        if let Some(supertype_index) = types[id].supertype_idxs.get(0).copied() {
             debug_assert!(supertype_index.is_canonical());
             let sup_id = map_canonical(supertype_index)?;
             if let Some(descriptor_idx) = descriptor_idx {
                 if types[sup_id].composite_type.descriptor_idx.is_some()
-                    && (types[descriptor_idx].supertype_idx.is_none()
-                        || (map_canonical(types[descriptor_idx].supertype_idx.unwrap())?
+                    && (types[descriptor_idx].supertype_idxs.is_empty()
+                        || (map_canonical(types[descriptor_idx].supertype_idxs[0])?
                             != map_canonical(
                                 types[sup_id].composite_type.descriptor_idx.unwrap(),
                             )?))
@@ -240,8 +243,8 @@ pub(crate) trait InternRecGroup {
             ) {
                 (Some(a), Some(b)) => {
                     let a_id = self.at_packed_index(types, rec_group, a, offset)?;
-                    if types[a_id].supertype_idx.is_none()
-                        || (map_canonical(types[a_id].supertype_idx.unwrap())? != map_canonical(b)?)
+                    if types[a_id].supertype_idxs.is_empty()
+                        || (map_canonical(types[a_id].supertype_idxs[0])? != map_canonical(b)?)
                     {
                         bail!(offset, "supertype of descriptor does not match");
                     }
@@ -457,7 +460,7 @@ impl<'a> TypeCanonicalizer<'a> {
             let rec_group_local_index = u32::try_from(rec_group_local_index).unwrap();
             let type_index = self.rec_group_start + rec_group_local_index;
 
-            if let Some(sup) = ty.supertype_idx.as_mut() {
+            for sup in ty.supertype_idxs.iter_mut() {
                 if sup.as_module_index().map_or(false, |i| i >= type_index) {
                     bail!(self.offset, "supertypes must be defined before subtypes");
                 }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -360,7 +360,7 @@ mod tests {
     impl Default for EmptyResources {
         fn default() -> Self {
             EmptyResources(crate::SubType {
-                supertype_idx: None,
+                supertype_idxs: Vec::new(),
                 is_final: true,
                 composite_type: crate::CompositeType {
                     inner: crate::CompositeInnerType::Func(crate::FuncType::new([], [])),

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -931,8 +931,9 @@ impl TypeList {
             debug_assert_eq!(self.core_types.len(), self.core_type_to_supertype.len());
             debug_assert_eq!(self.core_types.len(), self.core_type_to_rec_group.len());
 
+            debug_assert!(ty.supertype_idxs.len() <= 2);
             self.core_type_to_supertype
-                .push(ty.supertype_idx.and_then(|idx| match idx.unpack() {
+                .push(ty.supertype_idxs.get(0).and_then(|idx| match idx.unpack() {
                     UnpackedIndex::RecGroup(offset) => {
                         Some(CoreTypeId::from_index(start.index + offset))
                     }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -919,7 +919,7 @@ impl Printer<'_, '_> {
     }
 
     fn print_sub(&mut self, state: &State, ty: &SubType, ty_idx: u32) -> Result<u32> {
-        let r = if !ty.is_final || !ty.supertype_idx.is_none() {
+        let r = if !ty.is_final || !ty.supertype_idxs.is_empty() {
             self.start_group("sub")?;
             self.print_sub_type(state, ty)?;
             let r = self.print_composite(state, &ty.composite_type, ty_idx)?;
@@ -1099,7 +1099,7 @@ impl Printer<'_, '_> {
         if ty.is_final {
             self.result.write_str("final ")?;
         }
-        if let Some(idx) = ty.supertype_idx {
+        for idx in ty.supertype_idxs.iter() {
             self.print_idx(&state.core.type_names, idx.as_module_index().unwrap())?;
             self.result.write_str(" ")?;
         }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -407,7 +407,7 @@ impl TypeDef<'_> {
         wasm_encoder::SubType {
             composite_type,
             is_final: self.final_type.unwrap_or(true),
-            supertype_idx: self.parent.map(|i| i.unwrap_u32()),
+            supertype_idxs: self.parents.iter().map(|i| i.unwrap_u32()).collect(),
         }
     }
 }

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -843,7 +843,7 @@ pub(crate) trait ResolveCoreType<'a> {
     }
 
     fn resolve_type_def(&mut self, ty: &mut TypeDef<'a>) -> Result<(), Error> {
-        if let Some(parent) = &mut ty.parent {
+        for parent in ty.parents.iter_mut() {
             self.resolve_type_name(parent)?;
         }
         if let Some(descriptor) = &mut ty.descriptor {

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -265,7 +265,7 @@ impl<'a> TypeKey<'a> for FuncKey<'a> {
                 results: self.1.clone(),
             }),
             shared,
-            parent: None,
+            parents: Vec::new(),
             descriptor: None,
             describes: None,
             final_type: None,

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -957,7 +957,7 @@ pub struct TypeDef<'a> {
     /// Whether the type is shared or not.
     pub shared: bool,
     /// The declared parent type of this definition.
-    pub parent: Option<Index<'a>>,
+    pub parents: Vec<Index<'a>>,
     /// The descriptor type.
     pub descriptor: Option<Index<'a>>,
     /// The descriptor for type.
@@ -1023,7 +1023,7 @@ impl<'a> Parse<'a> for TypeDef<'a> {
                 },
             )
         };
-        let (parent, (shared, descriptor, describes, kind), final_type) =
+        let (parents, (shared, descriptor, describes, kind), final_type) =
             if parser.peek::<kw::sub>()? {
                 parser.parse::<kw::sub>()?;
 
@@ -1034,21 +1034,20 @@ impl<'a> Parse<'a> for TypeDef<'a> {
                     Some(false)
                 };
 
-                let parent = if parser.peek::<Index<'a>>()? {
-                    parser.parse()?
-                } else {
-                    None
-                };
+                let mut parents = Vec::new();
+                while parser.peek::<Index<'a>>()? {
+                    parents.push(parser.parse()?);
+                }
                 let pair = parser.parens(parse_shared_and_kind)?;
-                (parent, pair, final_type)
+                (parents, pair, final_type)
             } else {
-                (None, parse_shared_and_kind(parser)?, None)
+                (Vec::new(), parse_shared_and_kind(parser)?, None)
             };
 
         Ok(TypeDef {
             kind,
             shared,
-            parent,
+            parents,
             descriptor,
             describes,
             final_type,

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -1522,7 +1522,7 @@ impl CoreTypeInterner {
             return Ok(*ret);
         }
         let ty = &types[id];
-        if !ty.is_final || ty.supertype_idx.is_some() || ty.composite_type.shared {
+        if !ty.is_final || !ty.supertype_idxs.is_empty() || ty.composite_type.shared {
             bail!("unsupported core type to translate")
         }
         let f = match &ty.composite_type.inner {

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -111,7 +111,7 @@ impl<'a> Dump<'a> {
                         if explicit {
                             me.print(offset)?;
                         }
-                        write!(me.state, "[type {}] {ty:?}", inc(&mut i.core_types))?;
+                        write!(me.state, "[type {}] {ty}", inc(&mut i.core_types))?;
                     }
                     me.print(end)
                 })?,

--- a/tests/cli/dump-branch-hints.wat.stdout
+++ b/tests/cli/dump-branch-hints.wat.stdout
@@ -3,7 +3,7 @@
   0x8 | 01 04       | type section
   0xa | 01          | 1 count
 --- rec group 0 (implicit) ---
-  0xb | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 00 00    | [type 0] (func)
   0xe | 03 02       | func section
  0x10 | 01          | 1 count
  0x11 | 00          | [func 0] type 0

--- a/tests/cli/dump-elem-segments.wat.stdout
+++ b/tests/cli/dump-elem-segments.wat.stdout
@@ -3,7 +3,7 @@
   0x8 | 01 04       | type section
   0xa | 01          | 1 count
 --- rec group 0 (implicit) ---
-  0xb | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 00 00    | [type 0] (func)
   0xe | 03 02       | func section
  0x10 | 01          | 1 count
  0x11 | 00          | [func 0] type 0

--- a/tests/cli/dump-llvm-object.wat.stdout
+++ b/tests/cli/dump-llvm-object.wat.stdout
@@ -3,21 +3,21 @@
    0x8 | 01 22       | type section
    0xa | 06          | 6 count
 --- rec group 0 (implicit) ---
-   0xb | 60 01 7f 00 | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0xb | 60 01 7f 00 | [type 0] (func (param i32))
 --- rec group 1 (implicit) ---
-   0xf | 60 04 7f 7f | [type 1] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32, I32, I32], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0xf | 60 04 7f 7f | [type 1] (func (param i32 i32 i32 i32) (result i32))
        | 7f 7f 01 7f
 --- rec group 2 (implicit) ---
-  0x17 | 60 05 7f 7f | [type 2] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32, I32, I32, I32], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0x17 | 60 05 7f 7f | [type 2] (func (param i32 i32 i32 i32 i32) (result i32))
        | 7f 7f 7f 01
        | 7f         
 --- rec group 3 (implicit) ---
-  0x20 | 60 01 7f 01 | [type 3] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0x20 | 60 01 7f 01 | [type 3] (func (param i32) (result i32))
        | 7f         
 --- rec group 4 (implicit) ---
-  0x25 | 60 00 01 7f | [type 4] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0x25 | 60 00 01 7f | [type 4] (func (result i32))
 --- rec group 5 (implicit) ---
-  0x29 | 60 00 00    | [type 5] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0x29 | 60 00 00    | [type 5] (func)
   0x2c | 02 8b 01    | import section
   0x2f | 04          | 4 count
   0x30 | 03 65 6e 76 | import [memory 0] Import { module: "env", name: "__linear_memory", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) }

--- a/tests/cli/dump/alias.wat.stdout
+++ b/tests/cli/dump/alias.wat.stdout
@@ -31,7 +31,7 @@
    0x57 | 01 04       | type section
    0x59 | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x5a | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x5a | 60 00 00    | [type 0] (func)
    0x5d | 03 02       | func section
    0x5f | 01          | 1 count
    0x60 | 00          | [func 0] type 0

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -124,7 +124,7 @@
    0x151 | 01 04       | type section
    0x153 | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x154 | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x154 | 60 00 00    | [type 0] (func)
    0x157 | 03 02       | func section
    0x159 | 01          | 1 count
    0x15a | 00          | [func 0] type 0
@@ -161,7 +161,7 @@
    0x19b | 01 04       | type section
    0x19d | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x19e | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x19e | 60 00 00    | [type 0] (func)
    0x1a1 | 02 19       | import section
    0x1a3 | 04          | 4 count
    0x1a4 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }

--- a/tests/cli/dump/blockty.wat.stdout
+++ b/tests/cli/dump/blockty.wat.stdout
@@ -3,16 +3,16 @@
   0x8 | 01 17       | type section
   0xa | 05          | 5 count
 --- rec group 0 (implicit) ---
-  0xb | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 00 00    | [type 0] (func)
 --- rec group 1 (implicit) ---
-  0xe | 60 00 01 7f | [type 1] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xe | 60 00 01 7f | [type 1] (func (result i32))
 --- rec group 2 (implicit) ---
- 0x12 | 60 01 7f 00 | [type 2] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x12 | 60 01 7f 00 | [type 2] (func (param i32))
 --- rec group 3 (implicit) ---
- 0x16 | 60 01 7f 01 | [type 3] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x16 | 60 01 7f 01 | [type 3] (func (param i32) (result i32))
       | 7f         
 --- rec group 4 (implicit) ---
- 0x1b | 60 01 7f 02 | [type 4] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [I32, I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x1b | 60 01 7f 02 | [type 4] (func (param i32) (result i32 i32))
       | 7f 7f      
  0x21 | 03 02       | func section
  0x23 | 01          | 1 count

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -26,7 +26,7 @@
     0x54 | 01 09       | type section
     0x56 | 01          | 1 count
 --- rec group 0 (implicit) ---
-    0x57 | 60 04 7f 7f | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32, I32, I32], results: [I32] }), shared: false, descriptor_idx: None, describes_idx: None } }
+    0x57 | 60 04 7f 7f | [type 0] (func (param i32 i32 i32 i32) (result i32))
          | 7f 7f 01 7f
     0x5f | 03 02       | func section
     0x61 | 01          | 1 count
@@ -63,10 +63,10 @@
     0xa0 | 01 09       | type section
     0xa2 | 02          | 2 count
 --- rec group 0 (implicit) ---
-    0xa3 | 60 02 7f 7f | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+    0xa3 | 60 02 7f 7f | [type 0] (func (param i32 i32))
          | 00         
 --- rec group 1 (implicit) ---
-    0xa8 | 60 00 00    | [type 1] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+    0xa8 | 60 00 00    | [type 1] (func)
     0xab | 02 12       | import section
     0xad | 01          | 1 count
     0xae | 09 77 61 73 | import [func 0] Import { module: "wasi-file", name: "read", ty: Func(0) }
@@ -107,10 +107,10 @@
    0x101 | 01 0c       | type section
    0x103 | 02          | 2 count
 --- rec group 0 (implicit) ---
-   0x104 | 60 02 7f 7f | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x104 | 60 02 7f 7f | [type 0] (func (param i32 i32))
          | 00         
 --- rec group 1 (implicit) ---
-   0x109 | 60 03 7f 7f | [type 1] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32, I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x109 | 60 03 7f 7f | [type 1] (func (param i32 i32 i32))
          | 7f 00      
    0x10f | 02 12       | import section
    0x111 | 01          | 1 count

--- a/tests/cli/dump/component-expand-bundle.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle.wat.stdout
@@ -6,7 +6,7 @@
    0x12 | 01 04       | type section
    0x14 | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x15 | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x15 | 60 00 00    | [type 0] (func)
    0x18 | 03 02       | func section
    0x1a | 01          | 1 count
    0x1b | 00          | [func 0] type 0
@@ -30,7 +30,7 @@
    0x3d | 01 04       | type section
    0x3f | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x40 | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x40 | 60 00 00    | [type 0] (func)
    0x43 | 02 06       | import section
    0x45 | 01          | 1 count
    0x46 | 00 01 61 00 | import [func 0] Import { module: "", name: "a", ty: Func(0) }

--- a/tests/cli/dump/import-modules.wat.stdout
+++ b/tests/cli/dump/import-modules.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 0d       | core type section
   0xa | 01          | 1 count
-  0xb | 50 02 01 60 | [core type 0] Module([Type(RecGroup { inner: Implicit((14, SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } })) }), Import(Import { module: "", name: "f", ty: Func(0) })])
+  0xb | 50 02 01 60 | [core type 0] Module([Type(RecGroup { inner: Implicit((14, SubType { is_final: true, supertype_idxs: [], composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } })) }), Import(Import { module: "", name: "f", ty: Func(0) })])
       | 00 00 00 00
       | 01 66 00 00
  0x17 | 0a 07       | component import section
@@ -15,7 +15,7 @@
    0x2a | 01 04       | type section
    0x2c | 01          | 1 count
 --- rec group 0 (implicit) ---
-   0x2d | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+   0x2d | 60 00 00    | [type 0] (func)
    0x30 | 03 02       | func section
    0x32 | 01          | 1 count
    0x33 | 00          | [func 0] type 0

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(RecGroup { inner: Implicit((14, SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } })) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(RecGroup { inner: Implicit((14, SubType { is_final: true, supertype_idxs: [], composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } })) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/names.wat.stdout
+++ b/tests/cli/dump/names.wat.stdout
@@ -3,7 +3,7 @@
   0x8 | 01 05       | type section
   0xa | 01          | 1 count
 --- rec group 0 (implicit) ---
-  0xb | 60 01 7f 00 | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 01 7f 00 | [type 0] (func (param i32))
   0xf | 03 02       | func section
  0x11 | 01          | 1 count
  0x12 | 00          | [func 0] type 0

--- a/tests/cli/dump/rec-group.wat.stdout
+++ b/tests/cli/dump/rec-group.wat.stdout
@@ -4,25 +4,25 @@
   0xa | 04          | 4 count
 --- rec group 0 (explicit) ---
   0xb | 4e 01       | 
-  0xd | 60 02 7f 7f | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32, I32], results: [F64] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xd | 60 02 7f 7f | [type 0] (func (param i32 i32) (result f64))
       | 01 7c      
 --- rec group 1 (explicit) ---
  0x13 | 4e 03       | 
- 0x15 | 50 00 5f 01 | [type 1] SubType { is_final: false, supertype_idx: None, composite_type: CompositeType { inner: Struct(StructType { fields: [FieldType { element_type: Val(I32), mutable: false }] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x15 | 50 00 5f 01 | [type 1] (sub (struct i32))
       | 7f 00      
- 0x1b | 50 00 5f 01 | [type 2] SubType { is_final: false, supertype_idx: None, composite_type: CompositeType { inner: Struct(StructType { fields: [FieldType { element_type: Val(I32), mutable: true }] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x1b | 50 00 5f 01 | [type 2] (sub (struct (mut i32)))
       | 7f 01      
- 0x21 | 50 00 5f 08 | [type 3] SubType { is_final: false, supertype_idx: None, composite_type: CompositeType { inner: Struct(StructType { fields: [FieldType { element_type: Val(I32), mutable: true }, FieldType { element_type: Val(I64), mutable: true }, FieldType { element_type: Val(F32), mutable: true }, FieldType { element_type: Val(F64), mutable: true }, FieldType { element_type: Val(V128), mutable: true }, FieldType { element_type: Val(Ref(funcref)), mutable: true }, FieldType { element_type: Val(Ref(externref)), mutable: true }, FieldType { element_type: Val(Ref((ref null (module 2)))), mutable: true }] }), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x21 | 50 00 5f 08 | [type 3] (sub (struct (mut i32) (mut i64) (mut f32) (mut f64) (mut v128) (mut funcref) (mut externref) (mut (ref null (module 2)))))
       | 7f 01 7e 01
       | 7d 01 7c 01
       | 7b 01 70 01
       | 6f 01 63 02
       | 01         
 --- rec group 2 (implicit) ---
- 0x36 | 50 00 5e 7f | [type 4] SubType { is_final: false, supertype_idx: None, composite_type: CompositeType { inner: Array(ArrayType(FieldType { element_type: Val(I32), mutable: false })), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x36 | 50 00 5e 7f | [type 4] (sub (array i32))
       | 00         
 --- rec group 3 (implicit) ---
- 0x3b | 50 01 04 5e | [type 5] SubType { is_final: false, supertype_idx: Some(CoreTypeIndex { kind: "module", index: 4 }), composite_type: CompositeType { inner: Array(ArrayType(FieldType { element_type: Val(I32), mutable: false })), shared: false, descriptor_idx: None, describes_idx: None } }
+ 0x3b | 50 01 04 5e | [type 5] (sub (module 4) (array i32))
       | 7f 00      
  0x41 | 00 0e       | custom section
  0x43 | 04 6e 61 6d | name: "name"

--- a/tests/cli/dump/select.wat.stdout
+++ b/tests/cli/dump/select.wat.stdout
@@ -3,7 +3,7 @@
   0x8 | 01 04       | type section
   0xa | 01          | 1 count
 --- rec group 0 (implicit) ---
-  0xb | 60 00 00    | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 00 00    | [type 0] (func)
   0xe | 03 02       | func section
  0x10 | 01          | 1 count
  0x11 | 00          | [func 0] type 0

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -3,9 +3,9 @@
   0x8 | 01 08       | type section
   0xa | 02          | 2 count
 --- rec group 0 (implicit) ---
-  0xb | 60 01 7f 00 | [type 0] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [I32], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xb | 60 01 7f 00 | [type 0] (func (param i32))
 --- rec group 1 (implicit) ---
-  0xf | 60 00 00    | [type 1] SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false, descriptor_idx: None, describes_idx: None } }
+  0xf | 60 00 00    | [type 1] (func)
  0x12 | 02 07       | import section
  0x14 | 01          | 1 count
  0x15 | 01 6d 01 6e | import [func 0] Import { module: "m", name: "n", ty: Func(0) }

--- a/tests/cli/gc/gc-subtypes.wast
+++ b/tests/cli/gc/gc-subtypes.wast
@@ -120,3 +120,11 @@
   ;; different field, same name
   (type (sub $struct_with_named_field (struct (field (mut i32)) (field $field (mut i64)))))
 )
+
+(assert_invalid
+  (module
+    (type $parent1 (sub (struct)))
+    (type $parent2 (sub (struct)))
+    (type $child (sub $parent1 $parent2 (struct))))
+  "multiple supertypes"
+)

--- a/tests/snapshots/cli/gc/gc-subtypes.wast.json
+++ b/tests/snapshots/cli/gc/gc-subtypes.wast.json
@@ -6,6 +6,13 @@
       "line": 5,
       "filename": "gc-subtypes.0.wasm",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 125,
+      "filename": "gc-subtypes.1.wasm",
+      "module_type": "binary",
+      "text": "multiple supertypes"
     }
   ]
 }


### PR DESCRIPTION
Upstream a new spec test has been added that a type with multiple supetypes is considered invalid. This is distinct from malformed meaning that the binary doesn't even parse, but by being invalid that means that the binary parses but is dynamically considered invalid. This test requires handling multiple supertypes in all locations throughout the tooling here, for example `wast`, `wasm-encoder`, and `wasmparser`. Notably `wasmparser` now has a `Vec<u32>` for supertype indices, and lengths > 1 are rejected during validation.

While here this is changing all of the `dump` test outputs anyway so this switches to printing types in a more human-readable format.