### PR TITLE
perf: optimize `OperatorsReader::skip_const_expr`

### DIFF
--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -578,16 +578,18 @@ impl<'a> OperatorsReader<'a> {
     pub(crate) fn skip_const_expr(&mut self) -> Result<()> {
         // TODO add skip_operator() method and/or validate ConstExpr operators.
         loop {
-            if let Operator::End = self.read()? {
-                if self.current_frame().is_some() {
-                    bail!(
-                        self.original_position(),
-                        "control frames remain at end of expression"
-                    );
-                }
-                return Ok(());
+            let is_end = self.visit_operator(&mut IsEndOperatorVisitor)?;
+            if is_end {
+                break;
             }
         }
+        if self.current_frame().is_some() {
+            bail!(
+                self.original_position(),
+                "control frames remain at end of expression"
+            );
+        }
+        Ok(())
     }
 
     /// Function that must be called after the last opcode has been processed.
@@ -1094,6 +1096,44 @@ impl<'a, T: VisitOperator<'a>> VisitOperator<'a> for SingleFrameAdapter<'_, T> {
     }
 
     crate::for_each_visit_operator!(define_passthrough_visit_operator);
+}
+
+/// Implements [`VisitOperator`] with [`bool`] output: `true` it's an [`Operator::End`]
+struct IsEndOperatorVisitor;
+
+macro_rules! define_visit_is_end_operator {
+    ($(@$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident ($($ann:tt)*))*) => {
+        $(
+            #[allow(unused)]
+            fn $visit(&mut self $($(,$arg: $argty)*)?) -> bool {
+                define_visit_is_end_operator!(@visit self $visit $($($arg,)*)?)
+            }
+        )*
+    };
+
+    (@visit $self:ident visit_end $($rest:tt)*) => {
+	    true
+    };
+
+    (@visit $self:ident $visit:ident $($rest:tt)*) => {
+	    false
+    };
+}
+
+impl<'a> VisitOperator<'a> for IsEndOperatorVisitor {
+    type Output = bool;
+
+    #[cfg(feature = "simd")]
+    fn simd_visitor(&mut self) -> Option<&mut dyn VisitSimdOperator<'a, Output = Self::Output>> {
+        Some(self)
+    }
+
+    crate::for_each_visit_operator!(define_visit_is_end_operator);
+}
+
+#[cfg(feature = "simd")]
+impl<'a> VisitSimdOperator<'a> for IsEndOperatorVisitor {
+    crate::for_each_visit_simd_operator!(define_visit_is_end_operator);
 }
 
 impl<'a> BinaryReader<'a> {


### PR DESCRIPTION
This optimizes just `OperatorsReader::skip_const_expr` from:
- #2638

bench `parse/tests` change: -2%

<details>

<summary>[Spoiler] cargo bench </summary>

ran 4 times (`main` and my branch)

```
parse/tests             time:   [7.5023 ms 7.5062 ms 7.5105 ms]
                        change: [−2.2118% −2.0553% −1.9033%] (p = 0.00 < 0.05)
                        Performance has improved.
parse/tests             time:   [7.4871 ms 7.4903 ms 7.4937 ms]
                        change: [−2.5212% −2.4240% −2.3359%] (p = 0.00 < 0.05)
                        Performance has improved.
parse/tests             time:   [7.4769 ms 7.4807 ms 7.4849 ms]
                        change: [−2.4526% −2.3487% −2.2449%] (p = 0.00 < 0.05)
                        Performance has improved.                
parse/tests             time:   [7.4658 ms 7.4712 ms 7.4768 ms]
                        change: [−2.0683% −1.9672% −1.8664%] (p = 0.00 < 0.05)
                        Performance has improved.


                        
validate/tests          time:   [43.889 ms 43.930 ms 43.977 ms]
                        change: [+0.9219% +1.0458% +1.1819%] (p = 0.00 < 0.05)
                        Change within noise threshold.
validate/tests          time:   [43.413 ms 43.440 ms 43.467 ms]
                        change: [−0.5937% −0.4812% −0.3684%] (p = 0.00 < 0.05)
                        Change within noise threshold.
validate/tests          time:   [43.516 ms 43.570 ms 43.634 ms]
                        change: [−0.0868% +0.0767% +0.2552%] (p = 0.36 > 0.05)
                        No change in performance detected.
validate/tests          time:   [43.715 ms 43.747 ms 43.782 ms]
                        change: [−0.0765% +0.0745% +0.2170%] (p = 0.32 > 0.05)
                        No change in performance detected.
```

</details>